### PR TITLE
修复紫微年限弹窗大限/流年/流月无法选中

### DIFF
--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -1063,29 +1063,38 @@ function ZiweiScopeModal(props: {
     if (!yearOptions.length) {
       return;
     }
+    if (yearOptions.some((item) => item.dateStr === draftYearDateStr)) {
+      return;
+    }
 
-    const matchedDateStr = findZiweiYearOptionDate(yearOptions, draftDayDateStr || draftYearDateStr);
+    const matchedDateStr = findZiweiYearOptionDate(yearOptions, draftYearDateStr);
     if (matchedDateStr && matchedDateStr !== draftYearDateStr) {
       setDraftYearDateStr(matchedDateStr);
     }
-  }, [draftDayDateStr, draftYearDateStr, yearOptions]);
+  }, [draftYearDateStr, yearOptions]);
 
   useEffect(() => {
     if (!monthOptions.length) {
       return;
     }
+    if (monthOptions.some((item) => item.dateStr === draftMonthDateStr)) {
+      return;
+    }
 
     const matchedDateStr = findZiweiMonthOptionDate(
       monthOptions,
-      draftDayDateStr || draftMonthDateStr || draftYearDateStr,
+      draftMonthDateStr || draftYearDateStr,
     );
     if (matchedDateStr && matchedDateStr !== draftMonthDateStr) {
       setDraftMonthDateStr(matchedDateStr);
     }
-  }, [draftDayDateStr, draftMonthDateStr, draftYearDateStr, monthOptions]);
+  }, [draftMonthDateStr, draftYearDateStr, monthOptions]);
 
   useEffect(() => {
     if (!dayOptions.length) {
+      return;
+    }
+    if (dayOptions.some((item) => item.dateStr === draftDayDateStr)) {
       return;
     }
 
@@ -2353,7 +2362,7 @@ export function ResultPage() {
     isUnknownTimeIndex(inputState.partnerTimeIndex);
   const hasUnknownBirthTime = primaryHasUnknownTime || partnerHasUnknownTime;
   const shouldLoadZiweiPromptPayload =
-    mountedTabs.prompt && promptState.promptSource === 'ziwei' && !mountedTabs.ziwei;
+    mountedTabs.prompt && promptState.promptSource === 'ziwei';
   const primaryThreePillarsState = useMemo(() => {
     if (!primaryHasUnknownTime) {
       return {


### PR DESCRIPTION
Body
  ## 问题
  ZiweiScopeModal（提示词来源选「紫微」时打开的「选择年限」弹窗）里大限 / 流年 /
  流月点击后会被立即重置，仅有流日能选中。

  ## 根因
  三个同步副作用每次 draft 状态变都会用 **旧的** yearOptions / monthOptions / dayOptions 做匹配，并且优先用
  `draftDayDateStr` 作为匹配键。点击流年时 `draftDayDateStr` 被设为新年的日期，但 `dayOptions` 还是旧月份的，于是按
  `day=15` 匹配回旧月份的 dateStr，再级联反推回旧月份、旧年份，把用户的选择覆写。流日不影响上游字段，所以唯独流日生效。

  ## 修复
  三个同步副作用前置 `xxOptions.some(item => item.dateStr === draftXxDateStr)` 守卫，已是合法值则直接
  return；同步键里去掉 `draftDayDateStr` 的优先项，避免下游污染上游。worker 返回新选项后再让相应副作用一次性把不一致的
  draft 拉回正确值。

  ## Test plan
  - [x] 提示词来源选「紫微」→ 打开「选择年限」
  - [x] 依次点 大限 / 流年 / 流月 / 流日，每一行都能正确高亮停留
  - [x] 切大限后年/月/日自动落到新大限范围内
  - [x] 「确定」写回 promptState 的 ziweiScope / ziweiScopeDate 与所选项一致