### PR TITLE
调整内置 AI 默认启用逻辑

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -2,8 +2,9 @@
 # 复制此文件为 .dev.vars 后填入真实值
 # Cloudflare Pages 部署时在 Dashboard → Settings → Environment variables 中配置同样的变量
 #
-# 注意：仅配置 AI_API_KEY 不会自动打开前端 AI。
-# 需要显式设置 AI_DEFAULT_ENABLED=true，才默认显示并启用服务端 AI。
+# 注意：仅配置 AI_API_KEY 不会自动显示前端内置 AI。
+# 需要显式设置 AI_BUILTIN_ENABLED=true，才显示并允许使用服务端 AI。
+# AI_DEFAULT_ENABLED 只控制页面是否默认进入 AI 解读；公益服务不稳定时建议保持 false。
 
 # API Key（填写你的 AI 服务商密钥）
 # 支持任何 OpenAI 兼容接口，如 DeepSeek、千问、豆包、Groq、OpenAI 等
@@ -18,5 +19,8 @@ AI_MODEL=deepseek-chat
 # 前端显示的服务端 AI 名称（可选）
 # AI_PROVIDER_NAME=DeepSeek
 
-# 页面是否默认打开 AI 开关，并允许使用服务端 AI（可选，默认 false）
-# AI_DEFAULT_ENABLED=true
+# 是否显示并允许使用内置 AI（可选，默认 false）
+# AI_BUILTIN_ENABLED=true
+
+# 页面是否默认打开 AI 解读（可选，默认 false）
+# AI_DEFAULT_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ docker run --rm -p 3000:3000 \
   -e AI_BASE_URL=https://api.deepseek.com/v1 \
   -e AI_MODEL=deepseek-chat \
   -e AI_PROVIDER_NAME=DeepSeek \
-  -e AI_DEFAULT_ENABLED=true \
+  -e AI_BUILTIN_ENABLED=true \
+  -e AI_DEFAULT_ENABLED=false \
   mingyu
 ```
 
@@ -396,7 +397,8 @@ AI_API_KEY=sk-xxx
 AI_BASE_URL=https://api.deepseek.com/v1
 AI_MODEL=deepseek-chat
 AI_PROVIDER_NAME=DeepSeek
-AI_DEFAULT_ENABLED=true
+AI_BUILTIN_ENABLED=true
+AI_DEFAULT_ENABLED=false
 ```
 
 默认端口是 `3000`。如需修改容器内端口，可设置 `PORT`；如需修改宿主机端口，调整 compose 或 `docker run` 的 `-p` 左侧端口。
@@ -419,9 +421,10 @@ AI_DEFAULT_ENABLED=true
 | `AI_BASE_URL` | OpenAI 兼容接口地址，例如 `https://api.deepseek.com/v1` |
 | `AI_MODEL` | 默认模型名称 |
 | `AI_PROVIDER_NAME` | 前端显示的服务商名称，可自行命名 |
-| `AI_DEFAULT_ENABLED` | 设为 `true` 时，才默认显示并启用服务端 AI |
+| `AI_BUILTIN_ENABLED` | 设为 `true` 时，前端显示并允许使用服务端 AI |
+| `AI_DEFAULT_ENABLED` | 设为 `true` 时，页面默认进入 AI 解读；设为 `false` 时默认仍是提示词模式 |
 
-只配置 `AI_API_KEY` 不会自动打开服务端 AI；必须同时设置 `AI_DEFAULT_ENABLED=true`。如果不启用，前端不会提示服务端 AI，用户仍可通过齿轮自行填写自己的接口。
+只配置 `AI_API_KEY` 不会自动显示服务端 AI；必须同时设置 `AI_BUILTIN_ENABLED=true`。如果想提供公益内置 AI，但默认仍让用户复制提示词，可设置 `AI_BUILTIN_ENABLED=true`、`AI_DEFAULT_ENABLED=false`。用户仍可通过齿轮自行填写自己的接口。
 
 `.dev.vars.example` 提供了本地和 Cloudflare 可参考的变量模板。公开站点启用服务端 AI 会产生调用成本，也可能受上游模型稳定性影响，建议先确认额度、限流和可用性。
 

--- a/server/docker-server.ts
+++ b/server/docker-server.ts
@@ -45,9 +45,13 @@ function sendText(
 }
 
 function getRuntimeConfigScript() {
-  const aiDefaultEnabled = process.env.AI_DEFAULT_ENABLED === 'true' && Boolean(process.env.AI_API_KEY);
+  const hasAiApiKey = Boolean(process.env.AI_API_KEY);
+  const aiBuiltinFlag = process.env.AI_BUILTIN_ENABLED ?? process.env.AI_DEFAULT_ENABLED;
+  const aiBuiltinEnabled = aiBuiltinFlag === 'true' && hasAiApiKey;
+  const aiDefaultEnabled = aiBuiltinEnabled && process.env.AI_DEFAULT_ENABLED === 'true';
   const aiProviderName = process.env.AI_PROVIDER_NAME || '';
   const payload = JSON.stringify({
+    aiBuiltinEnabled,
     aiDefaultEnabled,
     aiProviderName,
   });
@@ -65,7 +69,9 @@ async function readRequestBody(request: IncomingMessage) {
 
 async function handleApiRequest(request: IncomingMessage, response: ServerResponse, url: URL) {
   const body =
-    request.method === 'GET' || request.method === 'HEAD' ? undefined : await readRequestBody(request);
+    request.method === 'GET' || request.method === 'HEAD'
+      ? undefined
+      : await readRequestBody(request);
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(request.headers)) {

--- a/src/lib/ai/proxy.ts
+++ b/src/lib/ai/proxy.ts
@@ -24,6 +24,7 @@ export type AiEnv = {
   AI_API_KEY?: string;
   AI_BASE_URL?: string;
   AI_MODEL?: string;
+  AI_BUILTIN_ENABLED?: string;
   AI_DEFAULT_ENABLED?: string;
 };
 
@@ -287,7 +288,7 @@ function resolveAiProvider(
     return { apiKey, baseUrl, model };
   }
 
-  if (env?.AI_DEFAULT_ENABLED !== 'true') {
+  if (!isBuiltinAiEnabled(env)) {
     return {
       error: aiJsonError(
         403,
@@ -308,6 +309,11 @@ function resolveAiProvider(
   }
 
   return { apiKey, baseUrl, model };
+}
+
+function isBuiltinAiEnabled(env?: AiEnv): boolean {
+  const enabled = env?.AI_BUILTIN_ENABLED ?? env?.AI_DEFAULT_ENABLED;
+  return enabled === 'true';
 }
 
 function aiJsonError(status: number, code: string, message: string): Response {

--- a/src/lib/ai/settings.ts
+++ b/src/lib/ai/settings.ts
@@ -26,6 +26,7 @@ export const AI_SETTINGS_STORAGE_KEY = 'mingyu:ai-settings:v1';
 export const AI_SETTINGS_EVENT = 'mingyu-ai-settings-change';
 
 type RuntimeAiConfig = {
+  aiBuiltinEnabled?: boolean;
   aiDefaultEnabled?: boolean;
   aiProviderName?: string;
 };
@@ -72,8 +73,15 @@ export function isServerBuiltinAiEnabled(): boolean {
   const runtimeConfig = (
     globalThis as typeof globalThis & { __MINGYU_RUNTIME_CONFIG__?: RuntimeAiConfig }
   ).__MINGYU_RUNTIME_CONFIG__;
+  if (typeof runtimeConfig?.aiBuiltinEnabled === 'boolean') {
+    return runtimeConfig.aiBuiltinEnabled;
+  }
   if (typeof runtimeConfig?.aiDefaultEnabled === 'boolean') {
+    // 兼容旧版本：原先 AI_DEFAULT_ENABLED 同时表示显示内置 AI 和默认启用。
     return runtimeConfig.aiDefaultEnabled;
+  }
+  if (import.meta.env.VITE_AI_BUILTIN_ENABLED) {
+    return import.meta.env.VITE_AI_BUILTIN_ENABLED === 'true';
   }
   return import.meta.env.VITE_AI_DEFAULT_ENABLED === 'true';
 }
@@ -89,7 +97,15 @@ export function getServerBuiltinAiLabel(): string {
 }
 
 export function isServerDefaultAiEnabled(): boolean {
-  return isServerBuiltinAiEnabled();
+  const runtimeConfig = (
+    globalThis as typeof globalThis & { __MINGYU_RUNTIME_CONFIG__?: RuntimeAiConfig }
+  ).__MINGYU_RUNTIME_CONFIG__;
+  const defaultEnabled =
+    typeof runtimeConfig?.aiDefaultEnabled === 'boolean'
+      ? runtimeConfig.aiDefaultEnabled
+      : import.meta.env.VITE_AI_DEFAULT_ENABLED === 'true';
+
+  return isServerBuiltinAiEnabled() && defaultEnabled;
 }
 
 export function getDefaultAiSettings(): AiSettings {

--- a/tests/ai-config.test.ts
+++ b/tests/ai-config.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { handleAiModels } from '../src/lib/ai/proxy';
+import {
+  getDefaultAiSettings,
+  getServerBuiltinAiLabel,
+  isServerBuiltinAiEnabled,
+  isServerDefaultAiEnabled,
+} from '../src/lib/ai/settings';
+
+type RuntimeConfigGlobal = typeof globalThis & {
+  __MINGYU_RUNTIME_CONFIG__?: {
+    aiBuiltinEnabled?: boolean;
+    aiDefaultEnabled?: boolean;
+    aiProviderName?: string;
+  };
+};
+
+test('内置 AI 可显示但默认仍保持提示词模式', (t) => {
+  const target = globalThis as RuntimeConfigGlobal;
+  const originalConfig = target.__MINGYU_RUNTIME_CONFIG__;
+  t.after(() => {
+    target.__MINGYU_RUNTIME_CONFIG__ = originalConfig;
+  });
+
+  target.__MINGYU_RUNTIME_CONFIG__ = {
+    aiBuiltinEnabled: true,
+    aiDefaultEnabled: false,
+    aiProviderName: '内置（不稳定）',
+  };
+
+  assert.equal(isServerBuiltinAiEnabled(), true);
+  assert.equal(isServerDefaultAiEnabled(), false);
+  assert.equal(getServerBuiltinAiLabel(), '内置（不稳定）');
+  assert.deepEqual(
+    {
+      enabled: getDefaultAiSettings().enabled,
+      mode: getDefaultAiSettings().mode,
+    },
+    {
+      enabled: false,
+      mode: 'builtin',
+    },
+  );
+});
+
+test('主动选择内置 AI 时不受默认关闭影响', async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    assert.equal(String(url), 'https://example.com/v1/models');
+    return new Response(JSON.stringify({ data: [{ id: 'free/cc' }] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+  }) as typeof fetch;
+
+  const response = await handleAiModels(
+    new Request('https://example.com/api/v1/ai/models', {
+      method: 'POST',
+      body: JSON.stringify({ aiConfig: { mode: 'builtin' } }),
+    }),
+    {
+      AI_API_KEY: 'test-key',
+      AI_BASE_URL: 'https://example.com/v1',
+      AI_MODEL: 'free/cc',
+      AI_BUILTIN_ENABLED: 'true',
+      AI_DEFAULT_ENABLED: 'false',
+    },
+  );
+
+  const body = await response.json();
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, { ok: true, models: ['free/cc'] });
+});
+
+test('未开启内置 AI 时拒绝服务端 AI 调用', async () => {
+  const response = await handleAiModels(
+    new Request('https://example.com/api/v1/ai/models', {
+      method: 'POST',
+      body: JSON.stringify({ aiConfig: { mode: 'builtin' } }),
+    }),
+    {
+      AI_API_KEY: 'test-key',
+      AI_DEFAULT_ENABLED: 'false',
+    },
+  );
+
+  const body = await response.json();
+  assert.equal(response.status, 403);
+  assert.equal(body.error.code, 'AI_SERVER_NOT_ENABLED');
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,17 +87,25 @@ function aiProxyDevPlugin(): Plugin {
 }
 
 // ── AI 功能开关 ──────────────────────────────────────
-// 不再因为配置了 AI_API_KEY 自动开启前端 AI。
-// AI_DEFAULT_ENABLED=true 且配置了 AI_API_KEY 时，页面默认打开 AI，并允许使用服务端 AI。
+// AI_BUILTIN_ENABLED=true 且配置了 AI_API_KEY 时，页面显示内置 AI 选项。
+// AI_DEFAULT_ENABLED=true 只表示默认打开 AI 解读；默认关闭时仍保留提示词模式。
 const devAiVars = parseDevVars(path.resolve(__dirname, '.dev.vars'));
-const isAiDefaultEnabled =
-  (process.env.AI_DEFAULT_ENABLED ?? devAiVars.AI_DEFAULT_ENABLED) === 'true' &&
-  !!(devAiVars.AI_API_KEY || process.env.AI_API_KEY);
-const aiProviderName = process.env.AI_PROVIDER_NAME ?? devAiVars.AI_PROVIDER_NAME ?? '';
+function readAiEnv(name: string) {
+  return process.env[name] ?? devAiVars[name];
+}
+
+const hasAiApiKey = Boolean(readAiEnv('AI_API_KEY'));
+const aiBuiltinFlag = readAiEnv('AI_BUILTIN_ENABLED') ?? readAiEnv('AI_DEFAULT_ENABLED');
+const isAiBuiltinEnabled = aiBuiltinFlag === 'true' && hasAiApiKey;
+const isAiDefaultEnabled = isAiBuiltinEnabled && readAiEnv('AI_DEFAULT_ENABLED') === 'true';
+const aiProviderName = readAiEnv('AI_PROVIDER_NAME') ?? '';
 
 export default defineConfig({
   define: {
     'import.meta.env.VITE_AI_ENABLED': JSON.stringify(isAiDefaultEnabled ? 'true' : 'false'),
+    'import.meta.env.VITE_AI_BUILTIN_ENABLED': JSON.stringify(
+      isAiBuiltinEnabled ? 'true' : 'false',
+    ),
     'import.meta.env.VITE_AI_DEFAULT_ENABLED': JSON.stringify(
       isAiDefaultEnabled ? 'true' : 'false',
     ),


### PR DESCRIPTION
## 修改内容
- 拆分内置 AI 的“可用开关”和“默认启用开关”。
- 新增 `AI_BUILTIN_ENABLED`：控制是否显示并允许使用内置 AI。
- 保留 `AI_DEFAULT_ENABLED`：只控制页面是否默认进入 AI 解读。
- 更新 Docker、Cloudflare 变量示例和 README。
- 增加测试覆盖“内置 AI 可选但默认提示词模式”的场景。

## 验证结果
- `pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ai-config.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm exec prettier --check src/lib/ai/settings.ts src/lib/ai/proxy.ts vite.config.ts server/docker-server.ts tests/ai-config.test.ts`
- `pnpm build`
- `wrangler pages functions build`
- `pnpm exec tsc --noEmit -p tsconfig.app.json`

## 风险
- 需要部署环境设置 `AI_BUILTIN_ENABLED=true` 才会显示内置 AI。
- `AI_DEFAULT_ENABLED=false` 时用户默认仍看到提示词模式，只有主动开启 AI 后才会调用内置服务。