### PR TITLE
修复内置 AI 上游不稳定错误提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,19 @@ AI_DEFAULT_ENABLED=false
 
 只配置 `AI_API_KEY` 不会自动显示服务端 AI；必须同时设置 `AI_BUILTIN_ENABLED=true`。如果想提供公益内置 AI，但默认仍让用户复制提示词，可设置 `AI_BUILTIN_ENABLED=true`、`AI_DEFAULT_ENABLED=false`。用户仍可通过齿轮自行填写自己的接口。
 
+AI 代理会对上游临时错误自动重试 2 次。只重试网络异常、408、429 和 5xx；鉴权失败、模型名错误等确定性问题不会重试。常见错误码：
+
+| 错误码 | 含义 |
+| --- | --- |
+| `AI_UPSTREAM_UNSTABLE`       | 上游 AI 服务返回 5xx，通常是服务临时不稳定 |
+| `AI_UPSTREAM_RATE_LIMIT`     | 上游限流或额度受限                         |
+| `AI_UPSTREAM_TIMEOUT`        | 上游响应超时                               |
+| `AI_UPSTREAM_AUTH_ERROR`     | API Key 无效、过期或额度账号异常           |
+| `AI_UPSTREAM_CONFIG_ERROR`   | 接口地址或模型名称可能不被上游支持         |
+| `AI_UPSTREAM_NETWORK_ERROR`  | 服务器无法连接上游 AI 服务                 |
+| `AI_UPSTREAM_EMPTY_RESPONSE` | 上游返回成功状态但没有可读取内容           |
+| `AI_UPSTREAM_STREAM_ERROR`   | 上游流式响应中途断开                       |
+
 `.dev.vars.example` 提供了本地和 Cloudflare 可参考的变量模板。公开站点启用服务端 AI 会产生调用成本，也可能受上游模型稳定性影响，建议先确认额度、限流和可用性。
 
 </details>

--- a/src/lib/ai/proxy.ts
+++ b/src/lib/ai/proxy.ts
@@ -10,6 +10,7 @@ const DEFAULT_BASE_URL = 'https://api.deepseek.com/v1';
 const DEFAULT_MODEL = 'deepseek-chat';
 const MAX_PROMPT_LENGTH = 50_000;
 const MAX_MESSAGES = 30;
+const UPSTREAM_RETRY_DELAYS_MS = [500, 1500];
 
 const SSE_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -35,6 +36,8 @@ type AiProviderConfig = {
   baseUrl?: unknown;
   model?: unknown;
 };
+type UpstreamFetchResult =
+  { ok: true; response: Response; attempts: number } | { ok: false; error: Response };
 
 const SYSTEM_PROMPT_SINGLE =
   '你是一位精通中国传统命理学、占卜术数的分析师。' +
@@ -115,7 +118,7 @@ export async function handleAiAnalyze(request: Request, env?: AiEnv): Promise<Re
   const systemPrompt = isMultiTurn ? SYSTEM_PROMPT_CHAT : SYSTEM_PROMPT_SINGLE;
 
   const endpoint = `${provider.baseUrl}/chat/completions`;
-  const upstream = await fetch(endpoint, {
+  const upstreamResult = await fetchUpstreamWithRetry(endpoint, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${provider.apiKey}`,
@@ -135,14 +138,21 @@ export async function handleAiAnalyze(request: Request, env?: AiEnv): Promise<Re
       ],
     }),
   });
+  if (!upstreamResult.ok) {
+    return upstreamResult.error;
+  }
 
-  if (!upstream.ok || !upstream.body) {
+  const { response: upstream, attempts } = upstreamResult;
+  if (!upstream.ok) {
     const errText = await upstream.text().catch(() => '');
-    return aiJsonError(
-      upstream.status,
-      'AI_UPSTREAM_ERROR',
-      `AI 服务返回错误（${upstream.status}）。${errText.slice(0, 200)}`,
-    );
+    return buildUpstreamErrorResponse(upstream.status, errText, attempts);
+  }
+
+  if (!upstream.body) {
+    return aiJsonError(502, 'AI_UPSTREAM_EMPTY_RESPONSE', 'AI 服务没有返回可读取的内容。', {
+      attempts,
+      retryable: true,
+    });
   }
 
   // 将 upstream SSE 流转换为前端可读的 SSE 流
@@ -188,8 +198,15 @@ export async function handleAiAnalyze(request: Request, env?: AiEnv): Promise<Re
         }
       }
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : '流式读取异常';
-      const payload = JSON.stringify({ error: errMsg });
+      const payload = JSON.stringify({
+        error: {
+          code: 'AI_UPSTREAM_STREAM_ERROR',
+          message: 'AI 服务响应中断，请稍后重试，或在设置里改用自己的接口。',
+          attempts,
+          retryable: true,
+          detail: err instanceof Error ? err.message : undefined,
+        },
+      });
       await writer.write(encoder.encode(`data: ${payload}\n\n`));
     } finally {
       await writer.close();
@@ -215,21 +232,21 @@ export async function handleAiModels(request: Request, env?: AiEnv): Promise<Res
     return provider.error;
   }
 
-  const upstream = await fetch(`${provider.baseUrl}/models`, {
+  const upstreamResult = await fetchUpstreamWithRetry(`${provider.baseUrl}/models`, {
     method: 'GET',
     headers: {
       Authorization: `Bearer ${provider.apiKey}`,
       'Content-Type': 'application/json',
     },
   });
+  if (!upstreamResult.ok) {
+    return upstreamResult.error;
+  }
 
+  const { response: upstream, attempts } = upstreamResult;
   if (!upstream.ok) {
     const errText = await upstream.text().catch(() => '');
-    return aiJsonError(
-      upstream.status,
-      'AI_UPSTREAM_ERROR',
-      `获取模型失败（${upstream.status}）。${errText.slice(0, 200)}`,
-    );
+    return buildUpstreamErrorResponse(upstream.status, errText, attempts, '获取模型失败：');
   }
 
   const data = await upstream.json().catch(() => null);
@@ -316,11 +333,203 @@ function isBuiltinAiEnabled(env?: AiEnv): boolean {
   return enabled === 'true';
 }
 
-function aiJsonError(status: number, code: string, message: string): Response {
+async function fetchUpstreamWithRetry(
+  url: string,
+  init: RequestInit,
+): Promise<UpstreamFetchResult> {
+  const maxAttempts = UPSTREAM_RETRY_DELAYS_MS.length + 1;
+
+  for (let attemptIndex = 0; attemptIndex < maxAttempts; attemptIndex += 1) {
+    try {
+      const response = await fetch(url, init);
+      if (isRetryableUpstreamStatus(response.status) && attemptIndex < maxAttempts - 1) {
+        await response.text().catch(() => '');
+        await sleep(getRetryDelayMs(response, attemptIndex));
+        continue;
+      }
+
+      return { ok: true, response, attempts: attemptIndex + 1 };
+    } catch (error) {
+      if (attemptIndex < maxAttempts - 1) {
+        await sleep(UPSTREAM_RETRY_DELAYS_MS[attemptIndex]);
+        continue;
+      }
+
+      const attempts = attemptIndex + 1;
+      return {
+        ok: false,
+        error: aiJsonError(
+          502,
+          'AI_UPSTREAM_NETWORK_ERROR',
+          `无法连接 AI 服务${formatRetrySummary(attempts)}。请稍后再试，或在设置里改用自己的接口。`,
+          {
+            attempts,
+            retryable: true,
+            detail: error instanceof Error ? error.message : undefined,
+          },
+        ),
+      };
+    }
+  }
+
+  return {
+    ok: false,
+    error: aiJsonError(502, 'AI_UPSTREAM_NETWORK_ERROR', '无法连接 AI 服务。', {
+      attempts: maxAttempts,
+      retryable: true,
+    }),
+  };
+}
+
+function isRetryableUpstreamStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function getRetryDelayMs(response: Response, attemptIndex: number): number {
+  const retryAfter = parseRetryAfterMs(response.headers.get('Retry-After'));
+  return retryAfter ?? UPSTREAM_RETRY_DELAYS_MS[attemptIndex];
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, 3000);
+  }
+
+  const retryAt = Date.parse(value);
+  if (Number.isFinite(retryAt)) {
+    return Math.min(Math.max(retryAt - Date.now(), 0), 3000);
+  }
+
+  return undefined;
+}
+
+function sleep(delayMs: number): Promise<void> {
+  if (delayMs <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function buildUpstreamErrorResponse(
+  status: number,
+  rawBody: string,
+  attempts: number,
+  prefix = '',
+): Response {
+  const upstreamError = parseUpstreamError(rawBody);
+  const retrySummary = formatRetrySummary(attempts);
+  const retryable = isRetryableUpstreamStatus(status);
+  const detail = upstreamError.message
+    ? `上游提示：${upstreamError.message}${upstreamError.code ? `（${upstreamError.code}）` : ''}`
+    : undefined;
+  const commonDetails = {
+    upstreamStatus: status,
+    upstreamCode: upstreamError.code,
+    attempts,
+    retryable,
+    detail,
+  };
+
+  if (status === 401 || status === 403) {
+    return aiJsonError(
+      status,
+      'AI_UPSTREAM_AUTH_ERROR',
+      `${prefix}AI 服务鉴权失败，请检查 API Key 是否有效、额度是否正常。`,
+      commonDetails,
+    );
+  }
+
+  if (status === 400 || status === 404) {
+    return aiJsonError(
+      status,
+      'AI_UPSTREAM_CONFIG_ERROR',
+      `${prefix}AI 服务配置可能有误，请检查接口地址和模型名称是否支持当前请求。`,
+      commonDetails,
+    );
+  }
+
+  if (status === 408) {
+    return aiJsonError(
+      status,
+      'AI_UPSTREAM_TIMEOUT',
+      `${prefix}AI 服务响应超时${retrySummary}。请稍后再试。`,
+      commonDetails,
+    );
+  }
+
+  if (status === 429) {
+    return aiJsonError(
+      status,
+      'AI_UPSTREAM_RATE_LIMIT',
+      `${prefix}AI 服务请求过多或额度受限${retrySummary}。请稍后再试，或改用自己的接口。`,
+      commonDetails,
+    );
+  }
+
+  if (status >= 500) {
+    return aiJsonError(
+      status,
+      'AI_UPSTREAM_UNSTABLE',
+      `${prefix}AI 服务暂时不稳定${retrySummary}。请稍后再试，或在设置里改用自己的接口。`,
+      commonDetails,
+    );
+  }
+
+  return aiJsonError(
+    status,
+    'AI_UPSTREAM_ERROR',
+    `${prefix}AI 服务返回异常（上游状态 ${status}）。`,
+    commonDetails,
+  );
+}
+
+function formatRetrySummary(attempts: number): string {
+  return attempts > 1 ? `，已自动重试 ${attempts - 1} 次仍未成功` : '';
+}
+
+function parseUpstreamError(rawBody: string): { message?: string; code?: string } {
+  const trimmed = rawBody.trim();
+  if (!trimmed) return {};
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    const error = parsed?.error;
+    const message =
+      typeof error?.message === 'string'
+        ? error.message
+        : typeof parsed?.message === 'string'
+          ? parsed.message
+          : '';
+    const code =
+      typeof error?.code === 'string'
+        ? error.code
+        : typeof parsed?.code === 'string'
+          ? parsed.code
+          : '';
+    return {
+      message: sanitizeUpstreamText(message),
+      code: sanitizeUpstreamText(code),
+    };
+  } catch {
+    return { message: sanitizeUpstreamText(trimmed) };
+  }
+}
+
+function sanitizeUpstreamText(value: string): string | undefined {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized ? normalized.slice(0, 180) : undefined;
+}
+
+function aiJsonError(
+  status: number,
+  code: string,
+  message: string,
+  details: Record<string, unknown> = {},
+): Response {
   return new Response(
     JSON.stringify({
       ok: false,
-      error: { code, message },
+      error: { code, message, ...details },
     }),
     {
       status,

--- a/src/lib/ai/stream-client.ts
+++ b/src/lib/ai/stream-client.ts
@@ -21,6 +21,10 @@ export interface StreamOptions extends StreamCallbacks {
 
 export type ChatMessage = { role: 'user' | 'assistant'; content: string };
 
+type AiErrorPayload = {
+  error?: string | { code?: unknown; message?: unknown };
+};
+
 /**
  * 发送多轮对话消息到 AI 解析端点，流式接收回复。
  *
@@ -59,9 +63,7 @@ export async function fetchAiModels(aiConfig: AiRequestConfig): Promise<string[]
     let message = `获取模型失败（${response.status}）`;
     try {
       const data = await response.json();
-      if (data?.error?.message) {
-        message = data.error.message;
-      }
+      message = formatAiErrorMessage(data, message);
     } catch {
       // 忽略 JSON 解析失败
     }
@@ -83,9 +85,7 @@ async function consumeSseStream(response: Response, { onChunk, onDone, onError }
     let message = `请求失败（${response.status}）`;
     try {
       const data = await response.json();
-      if (data?.error?.message) {
-        message = data.error.message;
-      }
+      message = formatAiErrorMessage(data, message);
     } catch {
       // 忽略 JSON 解析失败
     }
@@ -126,7 +126,7 @@ async function consumeSseStream(response: Response, { onChunk, onDone, onError }
       try {
         const parsed = JSON.parse(data);
         if (parsed.error) {
-          onError(parsed.error);
+          onError(formatAiErrorMessage(parsed, 'AI 返回错误。'));
           return;
         }
         if (typeof parsed.content === 'string' && parsed.content) {
@@ -139,4 +139,16 @@ async function consumeSseStream(response: Response, { onChunk, onDone, onError }
   }
 
   onDone();
+}
+
+function formatAiErrorMessage(data: unknown, fallback: string): string {
+  if (!data || typeof data !== 'object') return fallback;
+  const payload = data as AiErrorPayload;
+  const error = payload.error;
+  if (typeof error === 'string') return error || fallback;
+  if (!error || typeof error !== 'object') return fallback;
+
+  const message = typeof error.message === 'string' && error.message ? error.message : fallback;
+  const code = typeof error.code === 'string' && error.code ? error.code : '';
+  return code ? `${message}（错误码：${code}）` : message;
 }

--- a/tests/ai-config.test.ts
+++ b/tests/ai-config.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { handleAiModels } from '../src/lib/ai/proxy';
+import { handleAiAnalyze, handleAiModels } from '../src/lib/ai/proxy';
 import {
   getDefaultAiSettings,
   getServerBuiltinAiLabel,
@@ -92,4 +92,164 @@ test('未开启内置 AI 时拒绝服务端 AI 调用', async () => {
   const body = await response.json();
   assert.equal(response.status, 403);
   assert.equal(body.error.code, 'AI_SERVER_NOT_ENABLED');
+});
+
+test('AI 解析遇到上游临时错误时会自动重试', async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async () => {
+    calls += 1;
+    if (calls < 3) {
+      return new Response(
+        JSON.stringify({
+          error: {
+            message: 'server error',
+            code: 'bad_response_status_code',
+          },
+        }),
+        {
+          status: 500,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'Retry-After': '0',
+          },
+        },
+      );
+    }
+
+    return new Response('data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n', {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+    });
+  }) as typeof fetch;
+
+  const response = await handleAiAnalyze(
+    new Request('https://example.com/api/v1/ai/analyze', {
+      method: 'POST',
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: '测试' }],
+        aiConfig: { mode: 'builtin' },
+      }),
+    }),
+    {
+      AI_API_KEY: 'test-key',
+      AI_BASE_URL: 'https://example.com/v1',
+      AI_MODEL: 'free/cc',
+      AI_BUILTIN_ENABLED: 'true',
+      AI_DEFAULT_ENABLED: 'false',
+    },
+  );
+
+  const text = await response.text();
+  assert.equal(calls, 3);
+  assert.equal(response.status, 200);
+  assert.match(text, /"content":"ok"/);
+});
+
+test('AI 解析连续遇到上游错误时返回明确错误码', async (t) => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async () => {
+    calls += 1;
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: 'server error',
+          code: 'bad_response_status_code',
+        },
+      }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'Retry-After': '0',
+        },
+      },
+    );
+  }) as typeof fetch;
+
+  const response = await handleAiAnalyze(
+    new Request('https://example.com/api/v1/ai/analyze', {
+      method: 'POST',
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: '测试' }],
+        aiConfig: { mode: 'builtin' },
+      }),
+    }),
+    {
+      AI_API_KEY: 'test-key',
+      AI_BASE_URL: 'https://example.com/v1',
+      AI_MODEL: 'free/cc',
+      AI_BUILTIN_ENABLED: 'true',
+      AI_DEFAULT_ENABLED: 'false',
+    },
+  );
+
+  const body = await response.json();
+  assert.equal(calls, 3);
+  assert.equal(response.status, 500);
+  assert.equal(body.error.code, 'AI_UPSTREAM_UNSTABLE');
+  assert.equal(body.error.upstreamCode, 'bad_response_status_code');
+  assert.equal(body.error.attempts, 3);
+  assert.match(body.error.message, /已自动重试 2 次仍未成功/);
+});
+
+test('AI 流式响应中断时返回明确错误码', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const encoder = new TextEncoder();
+  let pulls = 0;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(
+      new ReadableStream({
+        pull(controller) {
+          pulls += 1;
+          if (pulls === 1) {
+            controller.enqueue(
+              encoder.encode('data: {"choices":[{"delta":{"content":"开头"}}]}\n\n'),
+            );
+            return;
+          }
+          throw new Error('upstream stream aborted');
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream; charset=utf-8' },
+      },
+    )) as typeof fetch;
+
+  const response = await handleAiAnalyze(
+    new Request('https://example.com/api/v1/ai/analyze', {
+      method: 'POST',
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: '测试' }],
+        aiConfig: { mode: 'builtin' },
+      }),
+    }),
+    {
+      AI_API_KEY: 'test-key',
+      AI_BASE_URL: 'https://example.com/v1',
+      AI_MODEL: 'free/cc',
+      AI_BUILTIN_ENABLED: 'true',
+      AI_DEFAULT_ENABLED: 'false',
+    },
+  );
+
+  const text = await response.text();
+  assert.equal(response.status, 200);
+  assert.match(text, /"content":"开头"/);
+  assert.match(text, /"code":"AI_UPSTREAM_STREAM_ERROR"/);
+  assert.match(text, /"detail":"upstream stream aborted"/);
 });


### PR DESCRIPTION
## 修改内容
- 内置 AI 代理对网络异常、408、429、5xx 自动重试 2 次，最多请求 3 次。
- 为上游不稳定、限流、超时、鉴权失败、配置错误、网络异常、空响应、流式中断等情况增加明确错误码。
- 前端展示 AI 错误时附带错误码，用户能区分是上游不稳定、限流、配置问题还是网络问题。
- 补充自动重试、连续失败和流式中断的测试，并更新 README 说明。

## 验证
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ai-config.test.ts
- pnpm exec prettier --check src/lib/ai/proxy.ts src/lib/ai/stream-client.ts tests/ai-config.test.ts
- pnpm lint
- pnpm exec tsc --noEmit -p tsconfig.app.json
- pnpm test
- pnpm build
- wrangler pages functions build

## 备注
- pnpm run format:check 仍会提示 6 个既有测试文件格式不符合 Prettier，本次没有修改这些文件；本次改动的 TypeScript 文件已单独通过 Prettier 检查。
- 未提交任何密钥、本地配置或构建产物。