### PR TITLE
适配折叠屏桌面布局

### DIFF
--- a/src/components/DivinationPanel/index.tsx
+++ b/src/components/DivinationPanel/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/lib/divination/inspiration';
 import { addDivinationHistory, getDivinationHistoryById } from '@/lib/history-records';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
-import { useViewportWidth } from '@/hooks/useViewportWidth';
+import { useViewportSize } from '@/hooks/useViewportWidth';
 import { usePromptCopyShare } from '@/hooks/usePromptCopyShare';
 import {
   QuestionInspirationModal,
@@ -54,7 +54,7 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
   const [activeInspirationTab, setActiveInspirationTab] =
     useState<DivinationInspirationTabId>('ganqing');
   const [inspirationSearch, setInspirationSearch] = useState('');
-  const viewportWidth = useViewportWidth(1280);
+  const viewportSize = useViewportSize({ width: 1280, height: 800 });
   const questionInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { copyState, shareState, handleCopy, handleShare } = usePromptCopyShare(
@@ -169,7 +169,8 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
       .filter((section) => section.items.length > 0);
   }, [activeInspirationTab, draft, inspirationSearch, specialInspiration]);
   const showShareButton = shouldShowPromptShareButton({
-    viewportWidth,
+    viewportWidth: viewportSize.width,
+    viewportHeight: viewportSize.height,
     hasNavigatorShare: typeof navigator !== 'undefined' && typeof navigator.share === 'function',
   });
 

--- a/src/hooks/useViewportWidth.ts
+++ b/src/hooks/useViewportWidth.ts
@@ -1,8 +1,15 @@
 import { useEffect, useState } from 'react';
 
-export function useViewportWidth(defaultWidth: number): number {
-  const [width, setWidth] = useState(() =>
-    typeof window === 'undefined' ? defaultWidth : window.innerWidth,
+export type ViewportSize = {
+  width: number;
+  height: number;
+};
+
+export function useViewportSize(defaultSize: ViewportSize): ViewportSize {
+  const [size, setSize] = useState<ViewportSize>(() =>
+    typeof window === 'undefined'
+      ? defaultSize
+      : { width: window.innerWidth, height: window.innerHeight },
   );
 
   useEffect(() => {
@@ -11,12 +18,16 @@ export function useViewportWidth(defaultWidth: number): number {
     }
 
     function handleResize() {
-      setWidth(window.innerWidth);
+      setSize({ width: window.innerWidth, height: window.innerHeight });
     }
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  return width;
+  return size;
+}
+
+export function useViewportWidth(defaultWidth: number): number {
+  return useViewportSize({ width: defaultWidth, height: 0 }).width;
 }

--- a/src/lib/prompt-page-rules.ts
+++ b/src/lib/prompt-page-rules.ts
@@ -1,8 +1,11 @@
+import { shouldUsePhoneLayout } from './responsive-layout';
+
 export function shouldShowPromptShareButton(options: {
   viewportWidth: number;
+  viewportHeight?: number;
   hasNavigatorShare: boolean;
 }) {
-  return options.viewportWidth < 1024 && options.hasNavigatorShare;
+  return shouldUsePhoneLayout(options) && options.hasNavigatorShare;
 }
 
 export function buildBaziCustomPromptPatch() {

--- a/src/lib/responsive-layout.ts
+++ b/src/lib/responsive-layout.ts
@@ -1,0 +1,23 @@
+export const PHONE_LAYOUT_MAX_WIDTH = 640;
+export const COMPACT_LAYOUT_MAX_WIDTH = 900;
+export const SHORT_VIEWPORT_MAX_HEIGHT = 520;
+
+type ViewportLayoutOptions = {
+  viewportWidth: number;
+  viewportHeight?: number;
+};
+
+export function shouldUsePhoneLayout({
+  viewportWidth,
+  viewportHeight = 0,
+}: ViewportLayoutOptions): boolean {
+  if (viewportWidth <= 0) {
+    return false;
+  }
+
+  if (viewportWidth <= PHONE_LAYOUT_MAX_WIDTH) {
+    return true;
+  }
+
+  return viewportWidth <= COMPACT_LAYOUT_MAX_WIDTH && viewportHeight <= SHORT_VIEWPORT_MAX_HEIGHT;
+}

--- a/src/pages/BirthTimeReversePage.tsx
+++ b/src/pages/BirthTimeReversePage.tsx
@@ -12,13 +12,13 @@ import {
   type ReverseBirthTimeFormData,
 } from '@/lib/birth-time-reverse';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
-import { useViewportWidth } from '@/hooks/useViewportWidth';
+import { useViewportSize } from '@/hooks/useViewportWidth';
 import { usePromptCopyShare } from '@/hooks/usePromptCopyShare';
 
 export function BirthTimeReversePage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const viewportWidth = useViewportWidth(1280);
+  const viewportSize = useViewportSize({ width: 1280, height: 800 });
   const [formData, setFormData] = useState<ReverseBirthTimeFormData>(
     DEFAULT_REVERSE_BIRTH_TIME_FORM_DATA,
   );
@@ -82,7 +82,8 @@ export function BirthTimeReversePage() {
   }
 
   const showShareButton = shouldShowPromptShareButton({
-    viewportWidth,
+    viewportWidth: viewportSize.width,
+    viewportHeight: viewportSize.height,
     hasNavigatorShare: typeof navigator !== 'undefined' && typeof navigator.share === 'function',
   });
 

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -24,9 +24,10 @@ import {
 } from '@/lib/query-state';
 import { buildAstrolabeScopeContext } from '@/lib/astrolabe-scope';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
+import { shouldUsePhoneLayout } from '@/lib/responsive-layout';
 import { PageTopbar } from '@/components/PageTopbar';
 import { QuestionInspirationModal } from '@/components/QuestionInspirationModal';
-import { useViewportWidth } from '@/hooks/useViewportWidth';
+import { useViewportSize } from '@/hooks/useViewportWidth';
 import { buildUnknownTimeBaziPrompt } from '@/lib/birth-time-reverse';
 import { getBaziDefaultQuestion } from '@/lib/prompt-default-questions';
 import { ASTROLABE_SHORTCUT_ACTIONS } from '@/lib/astrolabe-prompts';
@@ -120,11 +121,16 @@ export function ResultPage() {
   const [isZiweiScopeModalOpen, setIsZiweiScopeModalOpen] = useState(false);
   const [isAstrolabeScopeModalOpen, setIsAstrolabeScopeModalOpen] = useState(false);
   const inspiration = useQuestionInspiration();
-  const viewportWidth = useViewportWidth(0);
+  const viewportSize = useViewportSize({ width: 0, height: 0 });
   const [aiSettings] = useAiSettings();
   const isAiEnabled = aiSettings.enabled;
   const aiRequestConfig = useMemo(() => buildAiRequestConfig(aiSettings), [aiSettings]);
-  const isMobileAi = isAiEnabled && viewportWidth > 0 && viewportWidth < 768;
+  const isMobileAi =
+    isAiEnabled &&
+    shouldUsePhoneLayout({
+      viewportWidth: viewportSize.width,
+      viewportHeight: viewportSize.height,
+    });
   const [isAiShortcutPopoverOpen, setIsAiShortcutPopoverOpen] = useState(false);
   const [isAiMobileSettingsOpen, setIsAiMobileSettingsOpen] = useState(true);
   const [promptEngine, setPromptEngine] = useState<PromptEngineModule | null>(null);
@@ -836,7 +842,8 @@ export function ResultPage() {
   const { copyState, shareState, handleCopy, handleShare } =
     usePromptCopyShare(latestActivePromptText);
   const showShareButton = shouldShowPromptShareButton({
-    viewportWidth,
+    viewportWidth: viewportSize.width,
+    viewportHeight: viewportSize.height,
     hasNavigatorShare: typeof navigator !== 'undefined' && typeof navigator.share === 'function',
   });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2648,7 +2648,7 @@ select {
   font-size: 13px;
 }
 
-@media (min-width: 769px) {
+@media (min-width: 641px) and (min-height: 521px), (min-width: 901px) {
   .question-inspiration-modal {
     width: min(760px, calc(100vw - 48px));
     padding: 16px;
@@ -4804,7 +4804,84 @@ div.form-actions.page-submit-actions {
   font-size: 12px;
 }
 
-@media (max-width: 900px) {
+@media (min-width: 641px) and (max-width: 900px) and (min-height: 521px) {
+  .page-shell {
+    padding: 16px 10px 28px;
+  }
+
+  .hero-card {
+    margin-bottom: 18px;
+    padding: 22px;
+    border-radius: 22px;
+  }
+
+  .panel {
+    padding: 16px;
+    border-radius: 20px;
+  }
+
+  .workspace-grid,
+  .workspace-grid-ai,
+  .single-panel-shell,
+  .result-tab-stage {
+    max-width: min(1200px, calc(100vw - 20px));
+  }
+
+  .workspace-grid,
+  .workspace-grid-ai {
+    gap: 12px;
+  }
+
+  .workspace-grid-ai {
+    grid-template-columns: minmax(240px, 300px) minmax(0, 1fr);
+  }
+
+  .workspace-grid-ai > .panel-ai-chat {
+    min-height: 500px;
+    height: min(calc(100dvh - 128px), 760px);
+  }
+
+  .panel-head {
+    gap: 10px;
+    margin-bottom: 14px;
+  }
+
+  .panel-head h2 {
+    font-size: 20px;
+  }
+
+  .field-list,
+  .prompt-compact-grid {
+    gap: 10px;
+  }
+
+  .quick-grid {
+    gap: 7px;
+  }
+
+  .quick-chip {
+    padding: 8px 9px;
+    font-size: 12px;
+  }
+
+  .result-panel {
+    padding: 12px;
+  }
+
+  .result-dual-layout,
+  .bazi-core-layout,
+  .ziwei-layout,
+  .astrolabe-board-layout {
+    gap: 10px;
+  }
+
+  .bazi-core-layout,
+  .ziwei-layout {
+    grid-template-columns: minmax(0, 1.2fr) minmax(240px, 0.8fr);
+  }
+}
+
+@media (max-width: 640px), (max-width: 900px) and (max-height: 520px) {
   * {
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -6701,7 +6778,7 @@ div.form-actions.page-submit-actions {
 }
 
 /* 移动端适配 */
-@media (max-width: 768px) {
+@media (max-width: 640px), (max-width: 900px) and (max-height: 520px) {
   .ai-analysis-content {
     padding: 12px;
     font-size: 13px;
@@ -7090,7 +7167,7 @@ div.form-actions.page-submit-actions {
 }
 
 /* 移动端对话面板适配 */
-@media (max-width: 768px) {
+@media (max-width: 640px), (max-width: 900px) and (max-height: 520px) {
   /* 占卜页移动端：聊天卡片撑满 */
   .divination-ai-card .panel-ai-chat {
     min-height: min(calc(100dvh - 280px), 560px);

--- a/tests/prompt-page-rules.test.ts
+++ b/tests/prompt-page-rules.test.ts
@@ -5,15 +5,43 @@ import {
   buildZiweiCustomPromptPatch,
   shouldShowPromptShareButton,
 } from '../src/lib/prompt-page-rules';
+import { shouldUsePhoneLayout } from '../src/lib/responsive-layout';
 
-test('桌面端不显示提示词分享按钮，移动端且支持分享时显示', () => {
+test('折叠屏展开时使用桌面布局，普通手机和矮横屏使用手机布局', () => {
+  assert.equal(shouldUsePhoneLayout({ viewportWidth: 390, viewportHeight: 844 }), true);
+  assert.equal(shouldUsePhoneLayout({ viewportWidth: 673, viewportHeight: 841 }), false);
+  assert.equal(shouldUsePhoneLayout({ viewportWidth: 720, viewportHeight: 900 }), false);
+  assert.equal(shouldUsePhoneLayout({ viewportWidth: 844, viewportHeight: 390 }), true);
+  assert.equal(shouldUsePhoneLayout({ viewportWidth: 1024, viewportHeight: 500 }), false);
+});
+
+test('桌面端和折叠屏展开不显示提示词分享按钮，手机且支持分享时显示', () => {
   assert.equal(
     shouldShowPromptShareButton({ viewportWidth: 1280, hasNavigatorShare: true }),
     false,
   );
-  assert.equal(shouldShowPromptShareButton({ viewportWidth: 390, hasNavigatorShare: true }), true);
   assert.equal(
-    shouldShowPromptShareButton({ viewportWidth: 390, hasNavigatorShare: false }),
+    shouldShowPromptShareButton({
+      viewportWidth: 673,
+      viewportHeight: 841,
+      hasNavigatorShare: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldShowPromptShareButton({
+      viewportWidth: 390,
+      viewportHeight: 844,
+      hasNavigatorShare: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldShowPromptShareButton({
+      viewportWidth: 390,
+      viewportHeight: 844,
+      hasNavigatorShare: false,
+    }),
     false,
   );
 });


### PR DESCRIPTION
## 修改内容
- 新增统一的视口布局判断规则，折叠屏展开时按桌面布局处理。
- 调整结果页、占卜页、反推时辰页的分享按钮和 AI 面板布局判断。
- 调整 CSS 断点：普通手机和矮横屏仍走手机布局，641-900 宽且高度正常的折叠屏走紧凑桌面布局。
- 补充折叠屏、普通手机、矮横屏的布局判断测试。

## 验证结果
- pnpm exec prettier --check src/lib/responsive-layout.ts src/hooks/useViewportWidth.ts src/lib/prompt-page-rules.ts src/pages/ResultPage/index.tsx src/components/DivinationPanel/index.tsx src/pages/BirthTimeReversePage.tsx tests/prompt-page-rules.test.ts
- pnpm lint
- pnpm test（718 个用例通过）
- pnpm build
- wrangler pages functions build

## 风险说明
- 改动集中在响应式断点和布局判断，不涉及排盘算法、数据结构或后端接口。