### PR TITLE
隐藏内置 AI 模式的自定义接口配置

### DIFF
--- a/src/components/AiSettingsModal.tsx
+++ b/src/components/AiSettingsModal.tsx
@@ -67,7 +67,7 @@ export function AiSettingsModal({ settings, onApply, onClose }: AiSettingsModalP
             <h2>AI 设置</h2>
             <p>
               {builtinEnabled
-                ? `打开后可使用${builtinLabel}，也可以填写自己的 OpenAI 兼容接口。`
+                ? `打开后可使用${builtinLabel}；需要自己的接口时切换到“自行配置”。`
                 : '填写 OpenAI 兼容接口后可使用 AI 解读。'}
             </p>
           </div>
@@ -112,92 +112,91 @@ export function AiSettingsModal({ settings, onApply, onClose }: AiSettingsModalP
             ) : null}
           </section>
 
-          <section className="ai-settings-section">
-            <label className="field-card">
-              <div className="field-header">
-                <span>服务商</span>
-              </div>
-              <select
-                value={draft.providerId}
-                onChange={(event) => applyProvider(event.target.value)}
-                disabled={draft.mode === 'builtin'}
-              >
-                {AI_PROVIDER_PRESETS.map((preset) => (
-                  <option value={preset.id} key={preset.id}>
-                    {preset.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+          {draft.mode === 'custom' ? (
+            <section className="ai-settings-section">
+              <label className="field-card">
+                <div className="field-header">
+                  <span>服务商</span>
+                </div>
+                <select
+                  value={draft.providerId}
+                  onChange={(event) => applyProvider(event.target.value)}
+                >
+                  {AI_PROVIDER_PRESETS.map((preset) => (
+                    <option value={preset.id} key={preset.id}>
+                      {preset.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
 
-            <label className="field-card">
-              <div className="field-header">
-                <span>接口地址</span>
-              </div>
-              <input
-                value={draft.baseUrl}
-                disabled={draft.mode === 'builtin'}
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, baseUrl: event.target.value }))
-                }
-              />
-            </label>
+              <label className="field-card">
+                <div className="field-header">
+                  <span>接口地址</span>
+                </div>
+                <input
+                  value={draft.baseUrl}
+                  onChange={(event) =>
+                    setDraft((current) => ({ ...current, baseUrl: event.target.value }))
+                  }
+                />
+              </label>
 
-            <label className="field-card">
-              <div className="field-header">
-                <span>API Key</span>
-              </div>
-              <input
-                type="password"
-                value={draft.apiKey}
-                disabled={draft.mode === 'builtin'}
-                placeholder="仅自行配置时填写，保存在本机浏览器"
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, apiKey: event.target.value }))
-                }
-              />
-            </label>
+              <label className="field-card">
+                <div className="field-header">
+                  <span>API Key</span>
+                </div>
+                <input
+                  type="password"
+                  value={draft.apiKey}
+                  placeholder="仅自行配置时填写，保存在本机浏览器"
+                  onChange={(event) =>
+                    setDraft((current) => ({ ...current, apiKey: event.target.value }))
+                  }
+                />
+              </label>
 
-            <label className="field-card">
-              <div className="field-header">
-                <span>模型</span>
-              </div>
-              <input
-                value={draft.model}
-                placeholder="点击获取模型后选择，或手动填写"
-                onChange={(event) =>
-                  setDraft((current) => ({ ...current, model: event.target.value }))
-                }
-              />
-            </label>
+              <label className="field-card">
+                <div className="field-header">
+                  <span>模型</span>
+                </div>
+                <input
+                  value={draft.model}
+                  placeholder="点击获取模型后选择，或手动填写"
+                  onChange={(event) =>
+                    setDraft((current) => ({ ...current, model: event.target.value }))
+                  }
+                />
+              </label>
 
-            <div className="ai-settings-model-actions">
-              <button
-                type="button"
-                className="modal-btn modal-btn-secondary"
-                onClick={handleFetchModels}
-                disabled={!canFetchModels}
-              >
-                获取模型
-              </button>
-              {modelStatus ? <span>{modelStatus}</span> : null}
-            </div>
-
-            {models.length ? (
-              <div className="ai-settings-model-list">
-                {models.map((model) => (
-                  <button
-                    type="button"
-                    className={`quick-chip ${draft.model === model ? 'is-active' : ''}`}
-                    onClick={() => setDraft((current) => ({ ...current, model }))}
-                    key={model}
-                  >
-                    {model}
-                  </button>
-                ))}
+              <div className="ai-settings-model-actions">
+                <button
+                  type="button"
+                  className="modal-btn modal-btn-secondary"
+                  onClick={handleFetchModels}
+                  disabled={!canFetchModels}
+                >
+                  获取模型
+                </button>
+                {modelStatus ? <span>{modelStatus}</span> : null}
               </div>
-            ) : null}
-          </section>
+
+              {models.length ? (
+                <div className="ai-settings-model-list">
+                  {models.map((model) => (
+                    <button
+                      type="button"
+                      className={`quick-chip ${draft.model === model ? 'is-active' : ''}`}
+                      onClick={() => setDraft((current) => ({ ...current, model }))}
+                      key={model}
+                    >
+                      {model}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </section>
+          ) : null}
         </div>
 
         <div className="modal-actions">

--- a/tests/ai-settings-modal.test.ts
+++ b/tests/ai-settings-modal.test.ts
@@ -1,0 +1,73 @@
+import test, { type TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AiSettingsModal } from '../src/components/AiSettingsModal';
+import type { AiSettings } from '../src/lib/ai/settings';
+
+type RuntimeConfigGlobal = typeof globalThis & {
+  __MINGYU_RUNTIME_CONFIG__?: {
+    aiBuiltinEnabled?: boolean;
+    aiDefaultEnabled?: boolean;
+    aiProviderName?: string;
+  };
+};
+
+const baseSettings: AiSettings = {
+  enabled: true,
+  mode: 'builtin',
+  providerId: 'deepseek',
+  baseUrl: 'https://api.deepseek.com/v1',
+  apiKey: 'test-key',
+  model: 'test-model',
+};
+
+function withBuiltinAiConfig(t: TestContext) {
+  const target = globalThis as RuntimeConfigGlobal;
+  const originalConfig = target.__MINGYU_RUNTIME_CONFIG__;
+  t.after(() => {
+    target.__MINGYU_RUNTIME_CONFIG__ = originalConfig;
+  });
+
+  target.__MINGYU_RUNTIME_CONFIG__ = {
+    aiBuiltinEnabled: true,
+    aiDefaultEnabled: false,
+    aiProviderName: '内置 AI',
+  };
+}
+
+test('AI 设置选择内置时不渲染自定义 API 配置内容', (t) => {
+  withBuiltinAiConfig(t);
+
+  const html = renderToStaticMarkup(
+    createElement(AiSettingsModal, {
+      settings: baseSettings,
+      onApply: () => {},
+      onClose: () => {},
+    }),
+  );
+
+  assert.match(html, /内置 AI/);
+  assert.match(html, /自行配置/);
+  assert.doesNotMatch(html, /服务商/);
+  assert.doesNotMatch(html, /接口地址/);
+  assert.doesNotMatch(html, /API Key/);
+  assert.doesNotMatch(html, /获取模型/);
+});
+
+test('AI 设置选择自行配置时仍渲染自定义 API 配置内容', (t) => {
+  withBuiltinAiConfig(t);
+
+  const html = renderToStaticMarkup(
+    createElement(AiSettingsModal, {
+      settings: { ...baseSettings, mode: 'custom' },
+      onApply: () => {},
+      onClose: () => {},
+    }),
+  );
+
+  assert.match(html, /服务商/);
+  assert.match(html, /接口地址/);
+  assert.match(html, /API Key/);
+  assert.match(html, /获取模型/);
+});


### PR DESCRIPTION
## 修改内容
- AI 设置选择内置 AI 时，不再显示服务商、接口地址、API Key、模型和获取模型等自定义 API 配置内容。
- 选择自行配置时，自定义 API 配置内容保持正常显示。
- 调整弹窗顶部文案，提示需要自己的接口时切换到自行配置。
- 新增组件渲染测试，覆盖内置模式隐藏、自行配置模式显示。

## 验证结果
- pnpm exec prettier --check src/components/AiSettingsModal.tsx tests/ai-settings-modal.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ai-settings-modal.test.ts tests/ai-config.test.ts
- pnpm test（720 个用例通过）
- pnpm lint
- pnpm exec tsc --noEmit -p tsconfig.app.json
- pnpm build
- wrangler pages functions build

## 风险说明
- 只改 AI 设置弹窗展示逻辑，不改变内置 AI 和自定义 API 的请求参数保存与调用逻辑。