### PR TITLE
修正占法共享地支关系判断

### DIFF
--- a/packages/core/src/divination/algorithms/_shared/wuxing.ts
+++ b/packages/core/src/divination/algorithms/_shared/wuxing.ts
@@ -104,8 +104,9 @@ export const BRANCH_SANHE: Record<string, { group: string; partners: string[] }>
  * 如有申子而无辰，为水局半合，合而不全
  */
 export function isHalfSanhe(branches: string[]): string | null {
+  const uniqueBranches = Array.from(new Set(branches));
   for (const [group, members] of Object.entries(SANHE_GROUPS)) {
-    const present = branches.filter((b) => members.includes(b));
+    const present = uniqueBranches.filter((b) => members.includes(b));
     if (present.length === 2) {
       return group;
     }
@@ -356,7 +357,12 @@ export function isLiuhai(a: string, b: string): boolean {
 
 /** 检查两个地支是否为三刑关系 */
 export function isSanxing(a: string, b: string): boolean {
-  return SANXING_MAP[a] === b;
+  if (!a || !b) return false;
+  if ((a === '子' && b === '卯') || (a === '卯' && b === '子')) return true;
+  if (['寅', '巳', '申'].includes(a) && ['寅', '巳', '申'].includes(b) && a !== b) return true;
+  if (['丑', '戌', '未'].includes(a) && ['丑', '戌', '未'].includes(b) && a !== b) return true;
+  if (['辰', '午', '酉', '亥'].includes(a) && a === b) return true;
+  return false;
 }
 
 /** 检查数组中是否构成完整的三合局 */

--- a/tests/traditional-relations.test.ts
+++ b/tests/traditional-relations.test.ts
@@ -9,6 +9,8 @@ import { MONTH_COMMANDER as appMonthCommander } from '../src/utils/bazi/baziMapp
 import { TIAN_GAN_CHONG as appDivinationChong } from '../packages/core/src/divination/algorithms/_shared/wuxing';
 import {
   TIAN_GAN_CHONG as coreDivinationChong,
+  isHalfSanhe,
+  isSanxing,
   getWuxingChangSheng,
 } from '../packages/core/src/divination/algorithms/_shared/wuxing';
 import { analyzeLifeStageProfile } from '../packages/core/src/bazi/lifeStageAnalysis';
@@ -166,6 +168,23 @@ test('八字关系结构应识别寅午火局生地半合', () => {
         item.values.join('') === '寅午',
     ),
   );
+});
+
+test('占法共享半合判断不应把重复地支当作两个成员', () => {
+  assert.equal(isHalfSanhe(['申', '子']), '水局');
+  assert.equal(isHalfSanhe(['申', '申']), null);
+  assert.equal(isHalfSanhe(['寅', '寅', '午']), '火局');
+});
+
+test('占法共享三刑关系应按同组三刑互见判断，不因传入顺序漏判', () => {
+  assert.equal(isSanxing('寅', '申'), true);
+  assert.equal(isSanxing('申', '寅'), true);
+  assert.equal(isSanxing('未', '戌'), true);
+  assert.equal(isSanxing('戌', '未'), true);
+  assert.equal(isSanxing('子', '卯'), true);
+  assert.equal(isSanxing('辰', '辰'), true);
+  assert.equal(isSanxing('寅', '寅'), false);
+  assert.equal(isSanxing('子', '午'), false);
 });
 
 test('八字墓库分析应按日主天干十二长生取墓位', () => {


### PR DESCRIPTION
## 修改内容
- 修正共享半合判断：先对地支去重，避免重复地支被误判为三合缺一的半合。
- 修正共享三刑关系判断：用于关系检测时按同组三刑互见处理，避免寅申、未戌等因传入顺序漏判；保留有方向的 SANXING_MAP 供大六壬伏吟取刑等场景使用。
- 补充传统关系回归测试，覆盖重复地支、三刑顺序、自刑和非三刑组合。

## 验证结果
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/traditional-relations.test.ts：通过
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/liuyao-strength-change.test.ts tests/liuyao-najia-data.test.ts：通过
- pnpm test：通过，744 项
- pnpm build：通过
- pnpm test:e2e：通过，20 项
- pnpm exec prettier --check packages/core/src/divination/algorithms/_shared/wuxing.ts tests/traditional-relations.test.ts：通过

## 说明
- 未读取或参考旧审核目录。
- 未提交 tmp/ 临时目录。
- 全仓库 pnpm format:check 仍会因既有测试文件格式问题失败，涉及 tests/bazi-useful-god.test.ts、tests/chunking.test.ts、tests/divination-engine.test.ts、tests/public-api.test.ts、tests/ziwei-pattern-detection.test.ts；本次修改文件格式检查已通过。