### PR TITLE
修正奇门五不遇时判断

### DIFF
--- a/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
@@ -30,6 +30,18 @@ import { STEM_TOMB_MAP } from './_constants';
 
 const { dizhi, diPanPalaces, palaceStars, palaceDoorMap, jieQiJuShuMap } = qimen;
 const tenStems = tiangan;
+const wuBuYuHourStemByDayStem: Record<string, string> = {
+  甲: '庚',
+  乙: '辛',
+  丙: '壬',
+  丁: '癸',
+  戊: '甲',
+  己: '乙',
+  庚: '丙',
+  辛: '丁',
+  壬: '戊',
+  癸: '己',
+};
 
 // ============================================================================
 // 内部辅助方法
@@ -220,9 +232,13 @@ export function getQimenJuShu(timeInfo: {
  *   时干克日干，名为五不遇，主事多不顺，好事被阻，凶时。
  *
  * @param hourGanZhi 时辰干支字符串（如 "甲子"、"乙丑"）
+ * @param dayGanZhi  日干支字符串（用于判断五不遇时）
  * @returns 包含各项特殊条件的检查结果
  */
-export function checkSpecialHourConditions(hourGanZhi: string): {
+export function checkSpecialHourConditions(
+  hourGanZhi: string,
+  dayGanZhi?: string,
+): {
   isLiuJiaHour: boolean;
   isLiuGuiHour: boolean;
   isShiGanRuMu: boolean;
@@ -269,23 +285,11 @@ export function checkSpecialHourConditions(hourGanZhi: string): {
 
   // ── 4. 五不遇时 ──
   // 《遁甲演义》："五不遇时者，时干克日干也。"
-  // 传统固定列：甲申、乙酉、丙子、丁亥、戊寅、己卯、庚午、辛巳、壬辰、癸未
-  // 此时辰时干克日干，主事多不顺
-  const wuBuYuShiHours = [
-    '甲申',
-    '乙酉',
-    '丙子',
-    '丁亥',
-    '戊寅',
-    '己卯',
-    '庚午',
-    '辛巳',
-    '壬辰',
-    '癸未',
-  ];
-  if (wuBuYuShiHours.includes(hourGanZhi)) {
+  // 五不遇必须同时比较日干与时干，不能只凭时辰干支固定列表判断。
+  const dayGan = dayGanZhi?.charAt(0);
+  if (dayGan && wuBuYuHourStemByDayStem[dayGan] === hourGan) {
     result.isWuBuYuShi = true;
-    result.description += '五不遇时（时干克日干），事多不顺，不宜举事；';
+    result.description += `五不遇时（日干${dayGan}遇时干${hourGan}克日干），事多不顺，不宜举事；`;
   }
 
   return result;
@@ -312,6 +316,7 @@ export function checkSpecialHourConditions(hourGanZhi: string): {
  *   3. 该宫之星 = 值符，该宫之门 = 值使
  *
  * @param hourGanZhi 时辰干支（如 "甲子"、"乙丑"）
+ * @param dayGanZhi  日干支（用于特殊时辰中的五不遇时判断）
  * @returns { zhiFu, zhiShi, zhiFuPalace, specialConditions }
  *    zhiFu            - 值符星名
  *    zhiShi           - 值使门名
@@ -320,7 +325,10 @@ export function checkSpecialHourConditions(hourGanZhi: string): {
  *
  * @throws 当时辰干支无法识别时
  */
-export function getZhiFuZhiShi(hourGanZhi: string): {
+export function getZhiFuZhiShi(
+  hourGanZhi: string,
+  dayGanZhi?: string,
+): {
   zhiFu: string;
   zhiShi: string;
   zhiFuPalace: number;
@@ -348,7 +356,7 @@ export function getZhiFuZhiShi(hourGanZhi: string): {
   const zhiShi = palaceDoorMap[xunShouPalace as keyof typeof palaceDoorMap];
 
   // 检查当前时辰的特殊情况
-  const specialConditions = checkSpecialHourConditions(hourGanZhi);
+  const specialConditions = checkSpecialHourConditions(hourGanZhi, dayGanZhi);
 
   return { zhiFu, zhiShi, zhiFuPalace: xunShouPalace, specialConditions };
 }

--- a/packages/core/src/divination/algorithms/qimen/index.ts
+++ b/packages/core/src/divination/algorithms/qimen/index.ts
@@ -28,7 +28,12 @@ import type { QimenMethod } from './helpers/layout';
 import { getDivinationTime } from '../../../calendar/timeManager';
 import { getVoidBranches } from '../../../calendar/lunar';
 import { diPanPalaces, STEM_TOMB_MAP } from './helpers/_constants';
-import { getQimenJuShu, getZhiFuZhiShi, getZhiFuZhiShiByGanZhi, getDunJiaStem } from './helpers/jushu';
+import {
+  getQimenJuShu,
+  getZhiFuZhiShi,
+  getZhiFuZhiShiByGanZhi,
+  getDunJiaStem,
+} from './helpers/jushu';
 import { getMonthQimenJuShu, getYearQimenJuShu } from './helpers/jushu-extended';
 import { arrangeJiuGongGe, resolveZhiShiLandingPalace } from './helpers/layout';
 import { getQimenPatternTags, buildPatternDetails, buildPalaceInsights } from './helpers/patterns';
@@ -390,10 +395,14 @@ function getActiveGanZhi(
   scope: QimenScope,
 ): string {
   switch (scope) {
-    case 'year':  return ganzhi.year;
-    case 'month': return ganzhi.month;
-    case 'day':   return ganzhi.day;
-    default:      return ganzhi.hour;
+    case 'year':
+      return ganzhi.year;
+    case 'month':
+      return ganzhi.month;
+    case 'day':
+      return ganzhi.day;
+    default:
+      return ganzhi.hour;
   }
 }
 
@@ -445,7 +454,7 @@ function getZhiFuShiForScope(
   switch (scope) {
     case 'hour': {
       // 时家奇门：支持特殊时辰检查
-      const result = getZhiFuZhiShi(activeGanZhi);
+      const result = getZhiFuZhiShi(activeGanZhi, ganzhi.day);
       return {
         zhiFu: result.zhiFu,
         zhiShi: result.zhiShi,

--- a/tests/divination-engine.test.ts
+++ b/tests/divination-engine.test.ts
@@ -5,6 +5,7 @@ import { buildTimeInfoText } from '../src/lib/divination/engine/formatters';
 import type { QimenJiuGongGe } from '../packages/core/src/types/divination';
 import { STEM_TOMB_MAP } from '../packages/core/src/divination/algorithms/qimen/helpers/_constants';
 import { getStemRelations } from '../packages/core/src/divination/algorithms/qimen/helpers/classic-patterns';
+import { checkSpecialHourConditions } from '../packages/core/src/divination/algorithms/qimen/helpers/jushu';
 import { generateLiuyao } from 'mingyu-core/divination/liuyao';
 import { generateXiaoliuren } from 'mingyu-core/divination/xiaoliuren';
 import { generateQimen, resolveZhiShiLandingPalace } from 'mingyu-core/divination/qimen';
@@ -167,6 +168,22 @@ test('奇门算法会补出时旬空亡与马星落宫', () => {
   assert.ok(data.horseStar?.sourceBranch);
 });
 
+test('奇门五不遇时应按日干克应判断，不只看时辰干支', () => {
+  assert.equal(checkSpecialHourConditions('庚午', '甲戌').isWuBuYuShi, true);
+  assert.equal(checkSpecialHourConditions('戊寅', '庚午').isWuBuYuShi, false);
+  assert.equal(checkSpecialHourConditions('戊寅').isWuBuYuShi, false);
+
+  const falsePositiveCase = generateQimen(new Date('2025-01-01T04:00:00+08:00'));
+  assert.equal(falsePositiveCase.ganzhi.day, '庚午');
+  assert.equal(falsePositiveCase.ganzhi.hour, '戊寅');
+  assert.equal(falsePositiveCase.specialConditions?.isWuBuYuShi, false);
+
+  const trueCase = generateQimen(new Date('2025-01-05T12:00:00+08:00'));
+  assert.equal(trueCase.ganzhi.day, '甲戌');
+  assert.equal(trueCase.ganzhi.hour, '庚午');
+  assert.equal(trueCase.specialConditions?.isWuBuYuShi, true);
+});
+
 test('奇门算法会输出节令背景与复合格局结构', () => {
   const data = generateQimen(new Date('2025-01-01T08:00:00+08:00'));
 
@@ -228,7 +245,8 @@ test('奇门天地盘干入墓关系与统一天干入墓表一致', () => {
 
     assert.ok(
       relations.some(
-        (relation) => relation.heaven === stem && relation.type === '入墓' && relation.palace === tomb.palace,
+        (relation) =>
+          relation.heaven === stem && relation.type === '入墓' && relation.palace === tomb.palace,
       ),
       `${stem}应在${tomb.palace}宫/${tomb.branch}支入墓`,
     );


### PR DESCRIPTION
## 修改内容
- 将奇门五不遇时判断改为按日干与时干关系判断，不再只凭时辰干支固定列表。
- 时家奇门排盘入口传入日干支，避免误报或漏报特殊时辰。
- 补充底层函数与 generateQimen 入口测试，覆盖旧逻辑误报和真实命中的样例。

## 验证结果
- pnpm --filter mingyu-core build：通过
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/divination-engine.test.ts：通过
- pnpm test：通过，745 项
- pnpm build：通过
- pnpm test:e2e：通过，20 项
- 本次修改文件 Prettier 检查：通过

## 已知情况
- pnpm format:check 仍有 4 个既有无关文件格式问题：tests/bazi-useful-god.test.ts、tests/chunking.test.ts、tests/public-api.test.ts、tests/ziwei-pattern-detection.test.ts。