### PR TITLE
修正紫微明珠出海空宫识别

### DIFF
--- a/packages/core/src/ziwei/iztro/pattern-detection.ts
+++ b/packages/core/src/ziwei/iztro/pattern-detection.ts
@@ -249,8 +249,7 @@ const PATTERN_RULES: PatternRule[] = [
       // 明禄暗禄：传统指禄存或生年化禄在命宫（明）和对宫（暗）对应，
       // 不含运限化禄——本命格局不应随大限/流年变化
       const mingHasLu =
-        hasStar(ming, '禄存') ||
-        getAllStars(ming).some((star) => star.birth_mutagen === '禄');
+        hasStar(ming, '禄存') || getAllStars(ming).some((star) => star.birth_mutagen === '禄');
       const oppositeHasLu =
         hasStar(opposite, '禄存') ||
         getAllStars(opposite).some((star) => star.birth_mutagen === '禄');
@@ -364,7 +363,8 @@ const PATTERN_RULES: PatternRule[] = [
     id: 'cai-yin-jia-yin',
     name: '财荫夹印',
     kind: 'auspicious',
-    description: '天相（印）坐命宫或财帛宫，被天府（财星）与天梁（荫星）邻宫夹拱，主因财得官、富贵绵延。',
+    description:
+      '天相（印）坐命宫或财帛宫，被天府（财星）与天梁（荫星）邻宫夹拱，主因财得官、富贵绵延。',
     priority: 88,
     detect(context) {
       const ming = getPalaceByName(context, '命宫');
@@ -396,10 +396,9 @@ const PATTERN_RULES: PatternRule[] = [
       const qian = getPalaceByName(context, '迁移');
       if (!ming || !qian) return null;
       if (!palaceInBranch(ming, ['未'])) return null;
-      const mStars = getAllStars(ming);
       const hasSunMoonSurrounded =
         surroundedHasOneOf(context, ming, ['太阳']) && surroundedHasOneOf(context, ming, ['太阴']);
-      if (mStars.length === 0 && hasSunMoonSurrounded) {
+      if (ming.empty_state && hasSunMoonSurrounded) {
         return { palaces: [ming], stars: ['太阳', '太阴'] };
       }
       return null;
@@ -607,7 +606,10 @@ const PATTERN_RULES: PatternRule[] = [
       // 判断是否有吉星解网：紫微、天府坐罗网可解，天同、天梁亦能缓解
       const jieWangStars = ['紫微', '天府', '天同', '天梁', '太阳', '贪狼'];
       const hasJieWang = jieWangStars.some((n) => hasStar(ming, n));
-      return { palaces: [ming], stars: hasJieWang ? jieWangStars.filter((n) => hasStar(ming, n)) : [] };
+      return {
+        palaces: [ming],
+        stars: hasJieWang ? jieWangStars.filter((n) => hasStar(ming, n)) : [],
+      };
     },
   },
 

--- a/tests/ziwei-pattern-detection.test.ts
+++ b/tests/ziwei-pattern-detection.test.ts
@@ -23,7 +23,9 @@ function createPalaces(mingBranch: string, mingStars: StarFact[]): PalaceFact[] 
   return branches.map((branch, index) => {
     const isMing = index === mingIndex;
     const oppositeIndex = (index + 6) % 12;
-    const surroundedIndexes = Array.from(new Set([index, oppositeIndex, (index + 4) % 12, (index + 8) % 12]));
+    const surroundedIndexes = Array.from(
+      new Set([index, oppositeIndex, (index + 4) % 12, (index + 8) % 12]),
+    );
 
     return {
       index,
@@ -56,13 +58,19 @@ test('紫微格局：按实际地支判断月朗天门和日照雷门，不依�
   assert.ok(yueLang.some((item) => item.name === '月朗天门'));
 
   const wrongYueLang = detectPatterns({ palaces: createPalaces('丑', [star('太阴')]) });
-  assert.equal(wrongYueLang.some((item) => item.name === '月朗天门'), false);
+  assert.equal(
+    wrongYueLang.some((item) => item.name === '月朗天门'),
+    false,
+  );
 
   const riZhao = detectPatterns({ palaces: createPalaces('卯', [star('太阳')]) });
   assert.ok(riZhao.some((item) => item.name === '日照雷门'));
 
   const wrongRiZhao = detectPatterns({ palaces: createPalaces('巳', [star('太阳')]) });
-  assert.equal(wrongRiZhao.some((item) => item.name === '日照雷门'), false);
+  assert.equal(
+    wrongRiZhao.some((item) => item.name === '日照雷门'),
+    false,
+  );
 });
 
 test('紫微格局：天罗地网和日月反背按辰戌地支判断', () => {
@@ -102,4 +110,13 @@ test('紫微格局：子午寅申亥未等地支规则不受 iztro 索引起点�
   mingZhu[1].major_stars.push(star('太阳'));
   mingZhu[9].major_stars.push(star('太阴'));
   assert.ok(detectPatterns({ palaces: mingZhu }).some((item) => item.name === '明珠出海'));
+
+  const mingZhuWithMinorStar = createPalaces('未', []);
+  mingZhuWithMinorStar[11].name = '迁移';
+  mingZhuWithMinorStar[5].minor_stars.push(star('文昌'));
+  mingZhuWithMinorStar[1].major_stars.push(star('太阳'));
+  mingZhuWithMinorStar[9].major_stars.push(star('太阴'));
+  assert.ok(
+    detectPatterns({ palaces: mingZhuWithMinorStar }).some((item) => item.name === '明珠出海'),
+  );
 });


### PR DESCRIPTION
## 修改内容
- 修正紫微格局“明珠出海”的空宫判断：按命宫无主星识别，不再因为命宫存在文昌等辅星或杂曜而漏判。
- 新增回归测试，覆盖未宫空宫但带辅星、三方见太阳太阴时仍应识别“明珠出海”。

## 验证结果
- 已通过：pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ziwei-pattern-detection.test.ts
- 已通过：pnpm exec prettier --check packages/core/src/ziwei/iztro/pattern-detection.ts tests/ziwei-pattern-detection.test.ts
- 已通过：pnpm test
- 已通过：pnpm build
- 已通过：pnpm test:e2e
- 已通过：git diff --check

## 风险说明
- 影响范围仅限紫微格局识别。此前被漏掉的命盘会开始显示“明珠出海”，这是本次修复的预期变化。
