### PR TITLE
修正八字透干通根扫描范围

### DIFF
--- a/packages/core/src/bazi/stemRootAnalysis.ts
+++ b/packages/core/src/bazi/stemRootAnalysis.ts
@@ -33,8 +33,16 @@ const HIDDEN_STEMS: Record<string, string[]> = {
 };
 
 const STEM_ELEMENT: Record<string, string> = {
-  甲: '木', 乙: '木', 丙: '火', 丁: '火', 戊: '土',
-  己: '土', 庚: '金', 辛: '金', 壬: '水', 癸: '水',
+  甲: '木',
+  乙: '木',
+  丙: '火',
+  丁: '火',
+  戊: '土',
+  己: '土',
+  庚: '金',
+  辛: '金',
+  壬: '水',
+  癸: '水',
 };
 
 function getHiddenRootScore(index: number): number {
@@ -63,18 +71,19 @@ export function analyzeStemRootProfile(
     let hasSameElement = false;
     let rootScore = 0;
 
-    const stems = HIDDEN_STEMS[p.zhi] || [];
-    stems.forEach((stem, index) => {
-      const isSameStem = stem === visibleStem;
-      const isSameElement =
-        STEM_ELEMENT[stem] === visibleElement && stem !== visibleStem;
-      if (isSameStem) {
-        hasSameStem = true;
-        rootScore += getHiddenRootScore(index) * 1.0; // 本根权重 1.0
-      } else if (isSameElement) {
-        hasSameElement = true;
-        rootScore += getHiddenRootScore(index) * 0.6; // 同气根权重 0.6
-      }
+    pillars.forEach((rootPillar) => {
+      const stems = HIDDEN_STEMS[rootPillar.zhi] || [];
+      stems.forEach((stem, index) => {
+        const isSameStem = stem === visibleStem;
+        const isSameElement = STEM_ELEMENT[stem] === visibleElement && stem !== visibleStem;
+        if (isSameStem) {
+          hasSameStem = true;
+          rootScore += getHiddenRootScore(index) * 1.0; // 本根权重 1.0
+        } else if (isSameElement) {
+          hasSameElement = true;
+          rootScore += getHiddenRootScore(index) * 0.6; // 同气根权重 0.6
+        }
+      });
     });
 
     const status: VisibleStemRootItem['status'] = hasSameStem
@@ -91,9 +100,9 @@ export function analyzeStemRootProfile(
       status,
       summary:
         status === '有本根'
-          ? '有本根支撑'
+          ? '四柱地支见本根支撑'
           : status === '有同气根'
-            ? '有同气根支撑'
+            ? '四柱地支见同气根支撑'
             : '无根漂浮',
     });
   });

--- a/tests/traditional-relations.test.ts
+++ b/tests/traditional-relations.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../packages/core/src/divination/algorithms/_shared/wuxing';
 import { analyzeLifeStageProfile } from '../packages/core/src/bazi/lifeStageAnalysis';
 import { analyzeRelationStructure } from '../packages/core/src/bazi/relationStructure';
+import { analyzeStemRootProfile } from '../packages/core/src/bazi/stemRootAnalysis';
 import { analyzeTombStorage } from '../packages/core/src/bazi/tombStorage';
 import { getTenGod, getWuxing } from '../packages/core/src/bazi/baziUtils';
 import { analyzeGanzhiInteractions as analyzeAppQimenGanzhi } from '../packages/core/src/divination/algorithms/qimen/helpers/seasonality';
@@ -168,6 +169,26 @@ test('八字关系结构应识别寅午火局生地半合', () => {
         item.values.join('') === '寅午',
     ),
   );
+});
+
+test('八字透干通根应扫描四柱地支，不应只看本柱坐支', () => {
+  const profile = analyzeStemRootProfile(
+    [
+      { gan: '甲', zhi: '子' },
+      { gan: '丙', zhi: '辰' },
+      { gan: '庚', zhi: '寅' },
+      { gan: '辛', zhi: '午' },
+    ],
+    '甲',
+    getWuxing,
+    getTenGod,
+  );
+
+  const yearStem = profile.items.find((item) => item.pillar === 'year');
+
+  assert.equal(yearStem?.stem, '甲');
+  assert.equal(yearStem?.status, '有本根');
+  assert.ok((yearStem?.rootScore || 0) >= 1.2);
 });
 
 test('占法共享半合判断不应把重复地支当作两个成员', () => {


### PR DESCRIPTION
## 修改内容
- 修正八字透干通根分析：每个透出天干改为扫描四柱全部地支藏干，不再只看本柱坐支。
- 新增回归测试，覆盖甲木透年干、根在日支寅时应判为有本根。

## 验证结果
- pnpm test tests/traditional-relations.test.ts（实际执行全量 tests/*.test.ts，共 749 项通过）
- pnpm build
- pnpm test:e2e
- pnpm exec prettier --check packages/core/src/bazi/stemRootAnalysis.ts tests/traditional-relations.test.ts
- git diff --check

## 风险说明
- 改动仅限八字通根基础分析与对应测试。
- 通根分数会因按四柱全局扫描而更符合传统口径，相关展示可能比之前更准确地显示有根。