### PR TITLE
修正六爻月卦身起法

### DIFF
--- a/packages/core/src/divination/algorithms/liuyao.ts
+++ b/packages/core/src/divination/algorithms/liuyao.ts
@@ -37,7 +37,6 @@ import {
   LIUCHONG_MAP,
 } from './_shared';
 
-
 /**
  * 五行入墓支（《卜筮正宗》卷三《墓库章》、《增删卜易·入墓》定例）：
  * 金墓在丑、木墓在未、火墓在戌、水土墓在辰。
@@ -601,28 +600,29 @@ export function generateLiuyao(customDate?: Date) {
     }
   }
 
-  // 卦身（按六爻传统，世爻所在位置对应卦身地支）：
-  // 阳世：世爻为阳，从子上顺行——初爻子、二爻寅、三爻辰、四爻午、五爻申、六爻戌
-  // 阴世：世爻为阴，从午上逆行——初爻午、二爻辰、三爻寅、四爻子、五爻戌、六爻申
+  // 月卦身（按六爻传统“阳世从子月起，阴世从午月生，从初数至世方真”）：
+  // 阳世：初爻子、二爻丑、三爻寅、四爻卯、五爻辰、六爻巳
+  // 阴世：初爻午、二爻未、三爻申、四爻酉、五爻戌、六爻亥
   const SHI_YANG_TO_GUA_SHEN: Record<number, string> = {
     1: '子',
-    2: '寅',
-    3: '辰',
-    4: '午',
-    5: '申',
-    6: '戌',
+    2: '丑',
+    3: '寅',
+    4: '卯',
+    5: '辰',
+    6: '巳',
   };
   const SHI_YIN_TO_GUA_SHEN: Record<number, string> = {
     1: '午',
-    2: '辰',
-    3: '寅',
-    4: '子',
+    2: '未',
+    3: '申',
+    4: '酉',
     5: '戌',
-    6: '申',
+    6: '亥',
   };
   // 世爻的阴阳决定卦身取阳表还是阴表
   const shiYaoIsYang = mainYaos[shiYing.shi - 1] === '阳';
-  const guaShenBranch = (shiYaoIsYang ? SHI_YANG_TO_GUA_SHEN : SHI_YIN_TO_GUA_SHEN)[shiYing.shi] || '';
+  const guaShenBranch =
+    (shiYaoIsYang ? SHI_YANG_TO_GUA_SHEN : SHI_YIN_TO_GUA_SHEN)[shiYing.shi] || '';
   const guaShenYao = yaosInfo.find((i) => i.dizhi === guaShenBranch);
   const guaShen = guaShenYao
     ? {

--- a/tests/liuyao-strength-change.test.ts
+++ b/tests/liuyao-strength-change.test.ts
@@ -83,3 +83,19 @@ test('六爻：三合局应区分日辰与月建的实际参与', () => {
   assert.deepEqual(data.sanheWithMonth?.members, ['申', '子', '辰']);
   assert.match(data.sanheWithMonth?.description || '', /月建子引动三合水局/);
 });
+
+test('六爻：月卦身应按阳世起子、阴世起午逐爻顺数', () => {
+  const yangShi = generateLiuyao(new Date('2025-01-01T16:00:00+08:00'));
+  assert.equal(yangShi.originalName, '风水涣');
+  assert.equal(yangShi.worldAndResponse.indexOf('世') + 1, 5);
+  assert.equal(yangShi.yaosDetail[4].yaoType, '阳');
+  assert.equal(yangShi.guaShen?.branch, '辰');
+  assert.equal(yangShi.guaShen?.position, 2);
+
+  const yinShi = generateLiuyao(new Date('2025-01-01T01:00:00+08:00'));
+  assert.equal(yinShi.originalName, '巽为风');
+  assert.equal(yinShi.worldAndResponse.indexOf('世') + 1, 6);
+  assert.equal(yinShi.yaosDetail[5].yaoType, '阴');
+  assert.equal(yinShi.guaShen?.branch, '亥');
+  assert.equal(yinShi.guaShen?.position, 2);
+});


### PR DESCRIPTION
## 修改内容
- 修正六爻月卦身地支推法：按传统“阳世从子月起，阴世从午月生，从初数至世方真”逐爻顺数。
- 避免把纳甲隔支序列误用为卦身地支序列，导致卦身落支错误或本应有卦身却输出为空。
- 新增阳世、阴世两个稳定样本测试，覆盖卦身地支与实际纳甲爻位定位。

## 验证结果
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/liuyao-strength-change.test.ts tests/liuyao-najia-data.test.ts
- pnpm exec prettier --check packages/core/src/divination/algorithms/liuyao.ts tests/liuyao-strength-change.test.ts
- git diff --check
- pnpm test
- pnpm build
- pnpm test:e2e

## 风险说明
- 改动范围仅限六爻月卦身字段和对应测试。
- 会改变此前卦身落支错误或漏出的六爻排盘结果；纳甲、六亲、世应、动变等逻辑未改。
