### PR TITLE
修正奇门庚格应期日干判断

### DIFF
--- a/packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts
@@ -72,7 +72,7 @@ export interface YingQiEstimate {
  *   hasVoid: true,
  *   zhiFuLandingPalace: 1,
  *   zhiShiLandingPalace: 8,
- *   hourGanZhi: '甲子',
+ *   dayGanZhi: '甲子',
  *   classicPatterns: [{ name: '青龙返首', score: 8 }],
  *   voidBranches: ['寅', '卯'],
  * });
@@ -98,7 +98,9 @@ export function estimateYingQi(
     zhiFuLandingPalace?: number;
     /** 值使落宫 */
     zhiShiLandingPalace?: number;
-    /** 时干支（如 "甲子"） */
+    /** 日干支（如 "甲子"），用于庚格定应期的阳日/阴日判断 */
+    dayGanZhi?: string;
+    /** 旧字段兼容：历史上误传时干支，新调用请使用 dayGanZhi */
     hourGanZhi?: string;
     /** 经典格局列表 */
     classicPatterns?: Array<{ name: string; score: number }>;
@@ -174,7 +176,7 @@ export function estimateYingQi(
   //   阴日（乙丁己辛癸）看庚上 → 天盘庚所在宫
   //   地支逢冲为应 → 庚所在宫的地支逢其六冲之日/月为应期
 
-  const ganZhi = options?.hourGanZhi || '';
+  const ganZhi = options?.dayGanZhi || options?.hourGanZhi || '';
   if (ganZhi) {
     const dayStem = ganZhi.charAt(0);
     const isYangDay = YANG_STEMS.includes(dayStem);

--- a/packages/core/src/divination/algorithms/qimen/index.ts
+++ b/packages/core/src/divination/algorithms/qimen/index.ts
@@ -336,7 +336,7 @@ export function generateQimen(
     hasVoid,
     zhiFuLandingPalace,
     zhiShiLandingPalace,
-    hourGanZhi: activeGanZhi,
+    dayGanZhi: ganzhi.day,
     classicPatterns: classicPatternsRaw,
     voidBranches,
   });

--- a/tests/divination-engine.test.ts
+++ b/tests/divination-engine.test.ts
@@ -6,6 +6,7 @@ import type { QimenJiuGongGe } from '../packages/core/src/types/divination';
 import { STEM_TOMB_MAP } from '../packages/core/src/divination/algorithms/qimen/helpers/_constants';
 import { getStemRelations } from '../packages/core/src/divination/algorithms/qimen/helpers/classic-patterns';
 import { checkSpecialHourConditions } from '../packages/core/src/divination/algorithms/qimen/helpers/jushu';
+import { estimateYingQi } from '../packages/core/src/divination/algorithms/qimen/helpers/ying-qi';
 import { generateLiuyao } from 'mingyu-core/divination/liuyao';
 import { generateXiaoliuren } from 'mingyu-core/divination/xiaoliuren';
 import { generateQimen, resolveZhiShiLandingPalace } from 'mingyu-core/divination/qimen';
@@ -182,6 +183,32 @@ test('奇门五不遇时应按日干克应判断，不只看时辰干支', () =>
   assert.equal(trueCase.ganzhi.day, '甲戌');
   assert.equal(trueCase.ganzhi.hour, '庚午');
   assert.equal(trueCase.specialConditions?.isWuBuYuShi, true);
+});
+
+test('奇门庚格应期应按日干阴阳判断，不应误用时干', () => {
+  const result = estimateYingQi(
+    [
+      {
+        gong: 1,
+        tianPan: { stem: '庚', star: '' },
+        diPan: { stem: '甲' },
+      },
+      {
+        gong: 2,
+        tianPan: { stem: '乙', star: '' },
+        diPan: { stem: '庚' },
+      },
+    ],
+    2,
+    {
+      dayGanZhi: '甲子',
+      hourGanZhi: '乙丑',
+    },
+  );
+
+  const sourcesText = result.sources.join('\n');
+  assert.match(sourcesText, /阳日（甲日）见庚在地盘2宫/);
+  assert.doesNotMatch(sourcesText, /阴日（乙日）见庚在天盘1宫/);
 });
 
 test('奇门算法会输出节令背景与复合格局结构', () => {


### PR DESCRIPTION
## 修改内容
- 奇门庚格定应期新增 dayGanZhi 入参，按日干阴阳判断阳日看庚下、阴日看庚上。
- 生成奇门盘时改为传入真实日干支，避免时家盘误用时干支判断庚格。
- 增加回归测试，覆盖日干为阳、时干为阴时仍按日干走地盘庚的情况。

## 验证结果
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/divination-engine.test.ts
- pnpm exec prettier --check packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts packages/core/src/divination/algorithms/qimen/index.ts tests/divination-engine.test.ts
- git diff --check
- pnpm build
- pnpm test
- pnpm test:e2e

## 风险说明
- 变更范围限于奇门应期估算的庚格判断；保留 hourGanZhi 旧字段兼容，外部直接调用旧参数不会报错。