### PR TITLE
加强提示词真实样本质量检查

### DIFF
--- a/scripts/generate-prompt-audit.ts
+++ b/scripts/generate-prompt-audit.ts
@@ -225,6 +225,32 @@ function assertRequiredSampleFields(samples: PromptSample[]) {
   }
 }
 
+function assertSamplePromptsAreClean(samples: PromptSample[]) {
+  const leakedMessages: string[] = [];
+  const forbiddenPatterns = [
+    { label: 'undefined', pattern: /\bundefined\b/i },
+    { label: 'null', pattern: /\bnull\b/i },
+    { label: 'NaN', pattern: /\bNaN\b/ },
+    { label: '[object Object]', pattern: /\[object Object\]/ },
+    { label: 'PromptContext', pattern: /\bPromptContext\b/ },
+    { label: 'report_key', pattern: /\breport_key\b/ },
+    { label: 'selected_topic', pattern: /\bselected_topic\b/ },
+    { label: 'scope_type', pattern: /\bscope_type\b/ },
+  ];
+
+  samples.forEach((sample) => {
+    forbiddenPatterns.forEach(({ label, pattern }) => {
+      if (pattern.test(sample.prompt)) {
+        leakedMessages.push(`${sample.name} 出现异常占位或工程字段：${label}`);
+      }
+    });
+  });
+
+  if (leakedMessages.length > 0) {
+    throw new Error(`提示词真实样本质量检查失败：\n${leakedMessages.join('\n')}`);
+  }
+}
+
 async function buildSamples(): Promise<PromptSample[]> {
   const fixedNow = AUDIT_DATE;
 
@@ -539,6 +565,7 @@ async function buildSamples(): Promise<PromptSample[]> {
 async function main() {
   const samples = await buildSamples();
   assertRequiredSampleFields(samples);
+  assertSamplePromptsAreClean(samples);
   const outputDir = resolve('docs', 'prompt-audit');
   mkdirSync(outputDir, { recursive: true });
 


### PR DESCRIPTION
## 修改内容

- 在真实提示词样本生成脚本中增加统一质量检查。
- 拦截 undefined、null、NaN、[object Object] 等占位异常。
- 拦截 PromptContext、report_key、selected_topic、scope_type 等工程字段泄漏。

## 验证结果

- pnpm prompt:audit
- pnpm exec prettier --check scripts/generate-prompt-audit.ts
- git diff --check
- pnpm build
- pnpm test
- pnpm test:e2e
- pnpm prompt:check

## 风险

- 低风险，只增强真实样本生成时的检查规则；当前真实样本已通过新规则。