### PR TITLE
精简提示词证据重复测试

### DIFF
--- a/tests/prompt-evidence.test.ts
+++ b/tests/prompt-evidence.test.ts
@@ -1,7 +1,5 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 
 import {
   formatPromptEvidenceBundle,
@@ -42,46 +40,4 @@ test('证据资料包同权重时按证据等级稳定排序', () => {
 
 test('证据资料包为空时可返回保守占位', () => {
   assert.deepEqual(formatPromptEvidenceBundle({ items: [], emptyText: '- 暂无' }), ['- 暂无']);
-});
-
-test('六爻用神评分已接入统一证据类型再格式化为现有文案', () => {
-  const source = readFileSync(resolve('src/lib/divination/engine/formatters.ts'), 'utf8');
-
-  assert.match(source, /PromptEvidenceItem/);
-  assert.match(source, /createLiuyaoUsefulGodScoreEvidenceItems/);
-  assert.match(source, /formatLiuyaoUsefulGodScoreEvidence/);
-  assert.match(source, /source: '六爻用神评分'/);
-});
-
-test('八字年限触发摘要已通过统一证据类型生成', () => {
-  const source = readFileSync(resolve('packages/core/src/bazi/fortuneSelection/index.ts'), 'utf8');
-
-  assert.match(source, /formatPromptEvidenceBundle/);
-  assert.match(source, /PromptEvidenceItem\[\]/);
-  assert.match(source, /function buildFortuneEvidenceLines/);
-  assert.match(source, /title: '用户已选择年限运限'/);
-  assert.match(source, /title: '断事层级限制'/);
-});
-
-test('紫微运限命中摘要已通过统一证据类型生成', () => {
-  const source = readFileSync(resolve('src/lib/ziwei-prompts/builders.ts'), 'utf8');
-
-  assert.match(source, /formatPromptEvidenceBundle/);
-  assert.match(source, /PromptEvidenceItem\[\]/);
-  assert.match(source, /export function buildScopeHitSummary/);
-  assert.match(source, /title: '所选运限落宫'/);
-  assert.match(source, /title: '当前运限四化飞入'/);
-  assert.match(source, /title: '本命与运限边界'/);
-});
-
-test('择日禁忌筛查和取舍证据已接入统一证据类型', () => {
-  const source = readFileSync(resolve('src/lib/divination/engine/formatters.ts'), 'utf8');
-
-  assert.match(source, /normalizePromptEvidenceItems/);
-  assert.match(source, /function createAlmanacTabooEvidenceItems/);
-  assert.match(source, /function createAlmanacSelectionEvidenceItems/);
-  assert.match(source, /source: '择日禁忌筛查'/);
-  assert.match(source, /source: '择日取舍证据'/);
-  assert.match(source, /selectionEvidenceItems/);
-  assert.match(source, /tabooEvidenceItems/);
 });


### PR DESCRIPTION
## 修改内容

- 删除 prompt-evidence.test.ts 中读取源码检查函数名和字符串的重复测试。
- 保留证据格式化工具本身的行为测试。
- 相关真实输出覆盖仍由六爻、择日、紫微和年限选择测试验证，不改变产品逻辑。

## 逆向检查

- 用项目入口生成塔罗、灵签、雷诺曼、择日、星盘、六爻、梅花、小六壬、大六壬真实提示词样本。
- 反向检查结构、证据线索、空值和工程文案泄露，未发现需要改产品逻辑的问题。

## 验证结果

- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/prompt-evidence.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/divination-prompt-structure.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ziwei-prompt-snapshot.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/fortune-selection.test.ts
- 真实提示词样本反向检查脚本
- pnpm test
- pnpm lint
- pnpm exec prettier --check tests/prompt-evidence.test.ts
- git diff --check
- pnpm build
- pnpm test:e2e

## 风险

- 低风险。只删除重复的源码字符串测试，不改变运行逻辑；真实行为测试仍保留。