### PR TITLE
改用真实提示词检查当前时间格式

### DIFF
--- a/tests/prompt-time-format.test.ts
+++ b/tests/prompt-time-format.test.ts
@@ -1,8 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import {
+  DEFAULT_REVERSE_BIRTH_TIME_FORM_DATA,
+  buildReverseBirthTimePrompt,
+  buildThreePillarsProfile,
+} from '../src/lib/birth-time-reverse';
 import { formatPromptCurrentTime } from '../src/lib/prompt-time';
+
+function assertCurrentTimeSectionHasGanzhiCalendar(prompt: string) {
+  const currentTimeSection = prompt.match(/^【当前时间】\n([\s\S]*?)(?=\n【)/m)?.[1] ?? '';
+
+  assert.match(currentTimeSection, /^公历：\d{4}年\d{1,2}月\d{1,2}日 \d{1,2}时\d{1,2}分/m);
+  assert.match(currentTimeSection, /^农历：.+[子丑寅卯辰巳午未申酉戌亥]时$/m);
+  assert.match(currentTimeSection, /^干支历：.+年 .+月 .+日 .+时$/m);
+  assert.match(currentTimeSection, /^当前节气：.+/m);
+}
 
 test('提示词当前时间应同时给出公历、农历、干支历与节气', () => {
   const date = new Date(2025, 0, 2, 3, 4);
@@ -17,15 +29,19 @@ test('提示词当前时间应同时给出公历、农历、干支历与节气',
   );
 });
 
-test('八字、紫微和反推时辰提示词应复用统一时间格式 helper', () => {
-  const source = [
-    readFileSync(resolve('src/utils/ai/aiPrompts.ts'), 'utf8'),
-    readFileSync(resolve('src/lib/birth-time-reverse/prompts.ts'), 'utf8'),
-    readFileSync(resolve('src/lib/full-chart-engine/ziwei.ts'), 'utf8'),
-    readFileSync(resolve('src/pages/ResultPage/ResultPage.helpers.ts'), 'utf8'),
-  ].join('\n');
+test('反推时辰提示词会输出统一的当前时间证据', () => {
+  const reverseProfile = buildThreePillarsProfile({
+    gender: 'male',
+    dateType: 'solar',
+    year: '1994',
+    month: '10',
+    day: '23',
+    isLeapMonth: false,
+  });
+  const reversePrompt = buildReverseBirthTimePrompt({
+    profile: reverseProfile,
+    formData: DEFAULT_REVERSE_BIRTH_TIME_FORM_DATA,
+  });
 
-  assert.match(source, /formatPromptCurrentTime/);
-  assert.match(readFileSync(resolve('src/lib/prompt-time.ts'), 'utf8'), /干支历：/);
-  assert.doesNotMatch(source, /toLocaleString\('zh-CN'\)/);
+  assertCurrentTimeSectionHasGanzhiCalendar(reversePrompt);
 });

--- a/tests/ziwei-prompt-snapshot.test.ts
+++ b/tests/ziwei-prompt-snapshot.test.ts
@@ -16,6 +16,15 @@ function assertNoEngineeringPromptText(prompt: string) {
   assert.doesNotMatch(prompt, /当前已写入|当前未写入|未写入/);
 }
 
+function assertCurrentTimeSectionHasGanzhiCalendar(prompt: string) {
+  const currentTimeSection = prompt.match(/^【当前时间】\n([\s\S]*?)(?=\n【)/m)?.[1] ?? '';
+
+  assert.match(currentTimeSection, /^公历：\d{4}年\d{1,2}月\d{1,2}日 \d{1,2}时\d{1,2}分/m);
+  assert.match(currentTimeSection, /^农历：.+[子丑寅卯辰巳午未申酉戌亥]时$/m);
+  assert.match(currentTimeSection, /^干支历：.+年 .+月 .+日 .+时$/m);
+  assert.match(currentTimeSection, /^当前节气：.+/m);
+}
+
 function createPalace(index: number, name: string, stars: string[] = []): PalaceFact {
   return {
     index,
@@ -338,6 +347,7 @@ test('紫微完整提示词应补充完整运限任务书', () => {
   assert.match(prompt, /【解读目标】/);
   assert.match(prompt, /【本命资料】/);
   assert.match(prompt, /【分析对象】/);
+  assertCurrentTimeSectionHasGanzhiCalendar(prompt);
   assert.match(prompt, /【运限重点】/);
   assert.match(prompt, /【主证】所选运限落宫/);
   assert.doesNotMatch(prompt, /【运限资料】/);


### PR DESCRIPTION
## 修改内容

- 将 \prompt-time-format.test.ts\ 中读取源码检查 helper 复用的测试，改为生成反推时辰真实提示词并检查【当前时间】输出。
- 在紫微提示词快照测试中补充真实紫微提示词的【当前时间】证据检查。
- 测试目标从内部函数名转为用户最终看到的公历、农历、干支历和节气内容。

## 逆向检查

- 反向检查反推时辰和紫微真实提示词，确认【当前时间】不是只显示普通本地时间，而是包含公历、农历、干支历和当前节气。
- 未改产品逻辑。

## 验证结果

- \pnpm exec tsx --tsconfig tsconfig.app.json --test tests/prompt-time-format.test.ts\
- \pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ziwei-prompt-snapshot.test.ts\
- \pnpm exec prettier --check tests/prompt-time-format.test.ts tests/ziwei-prompt-snapshot.test.ts\
- \pnpm test\
- \pnpm lint\
- \git diff --check\
- \pnpm build\
- \pnpm test:e2e\

## 风险

- 低风险。只调整测试，不改变提示词生成逻辑。