### PR TITLE
抽取提示词当前时间测试断言

### DIFF
--- a/tests/prompt-assertions.ts
+++ b/tests/prompt-assertions.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+
+export function assertPromptCurrentTimeHasGanzhiCalendar(prompt: string) {
+  const currentTimeSection = prompt.match(/^【当前时间】\n([\s\S]*?)(?=\n【)/m)?.[1] ?? '';
+
+  assert.match(currentTimeSection, /^公历：\d{4}年\d{1,2}月\d{1,2}日 \d{1,2}时\d{1,2}分/m);
+  assert.match(currentTimeSection, /^农历：.+[子丑寅卯辰巳午未申酉戌亥]时$/m);
+  assert.match(currentTimeSection, /^干支历：.+年 .+月 .+日 .+时$/m);
+  assert.match(currentTimeSection, /^当前节气：.+/m);
+}

--- a/tests/prompt-time-format.test.ts
+++ b/tests/prompt-time-format.test.ts
@@ -6,15 +6,7 @@ import {
   buildThreePillarsProfile,
 } from '../src/lib/birth-time-reverse';
 import { formatPromptCurrentTime } from '../src/lib/prompt-time';
-
-function assertCurrentTimeSectionHasGanzhiCalendar(prompt: string) {
-  const currentTimeSection = prompt.match(/^【当前时间】\n([\s\S]*?)(?=\n【)/m)?.[1] ?? '';
-
-  assert.match(currentTimeSection, /^公历：\d{4}年\d{1,2}月\d{1,2}日 \d{1,2}时\d{1,2}分/m);
-  assert.match(currentTimeSection, /^农历：.+[子丑寅卯辰巳午未申酉戌亥]时$/m);
-  assert.match(currentTimeSection, /^干支历：.+年 .+月 .+日 .+时$/m);
-  assert.match(currentTimeSection, /^当前节气：.+/m);
-}
+import { assertPromptCurrentTimeHasGanzhiCalendar } from './prompt-assertions';
 
 test('提示词当前时间应同时给出公历、农历、干支历与节气', () => {
   const date = new Date(2025, 0, 2, 3, 4);
@@ -43,5 +35,5 @@ test('反推时辰提示词会输出统一的当前时间证据', () => {
     formData: DEFAULT_REVERSE_BIRTH_TIME_FORM_DATA,
   });
 
-  assertCurrentTimeSectionHasGanzhiCalendar(reversePrompt);
+  assertPromptCurrentTimeHasGanzhiCalendar(reversePrompt);
 });

--- a/tests/ziwei-prompt-snapshot.test.ts
+++ b/tests/ziwei-prompt-snapshot.test.ts
@@ -9,20 +9,12 @@ import { buildEvidencePool } from '../src/lib/iztro/build-evidence-pool';
 import { buildEvidenceSummary } from '../src/lib/ziwei-prompts/builders';
 import { buildZiweiReadableSnapshot } from '../src/lib/ziwei-prompts/snapshot';
 import type { PromptContext } from '../src/lib/ziwei-prompts/types';
+import { assertPromptCurrentTimeHasGanzhiCalendar } from './prompt-assertions';
 import type { AnalysisPayloadV1, PalaceFact } from '../src/types/analysis';
 
 function assertNoEngineeringPromptText(prompt: string) {
   assert.doesNotMatch(prompt, /当前项目|本地算法|技术限制|未计算|资料包|提示词规则/);
   assert.doesNotMatch(prompt, /当前已写入|当前未写入|未写入/);
-}
-
-function assertCurrentTimeSectionHasGanzhiCalendar(prompt: string) {
-  const currentTimeSection = prompt.match(/^【当前时间】\n([\s\S]*?)(?=\n【)/m)?.[1] ?? '';
-
-  assert.match(currentTimeSection, /^公历：\d{4}年\d{1,2}月\d{1,2}日 \d{1,2}时\d{1,2}分/m);
-  assert.match(currentTimeSection, /^农历：.+[子丑寅卯辰巳午未申酉戌亥]时$/m);
-  assert.match(currentTimeSection, /^干支历：.+年 .+月 .+日 .+时$/m);
-  assert.match(currentTimeSection, /^当前节气：.+/m);
 }
 
 function createPalace(index: number, name: string, stars: string[] = []): PalaceFact {
@@ -347,7 +339,7 @@ test('紫微完整提示词应补充完整运限任务书', () => {
   assert.match(prompt, /【解读目标】/);
   assert.match(prompt, /【本命资料】/);
   assert.match(prompt, /【分析对象】/);
-  assertCurrentTimeSectionHasGanzhiCalendar(prompt);
+  assertPromptCurrentTimeHasGanzhiCalendar(prompt);
   assert.match(prompt, /【运限重点】/);
   assert.match(prompt, /【主证】所选运限落宫/);
   assert.doesNotMatch(prompt, /【运限资料】/);


### PR DESCRIPTION
## 修改内容

- 新增 \	ests/prompt-assertions.ts\，集中放置【当前时间】公历、农历、干支历和节气的提示词断言。
- 删除 \prompt-time-format.test.ts\ 与 \ziwei-prompt-snapshot.test.ts\ 中重复的当前时间断言函数。
- 保持原有真实提示词行为检查不变。

## 逆向检查

- 继续用反推时辰和紫微真实提示词验证【当前时间】内容，确认仍包含公历、农历、干支历和当前节气。
- 未改产品逻辑。

## 验证结果

- \pnpm exec tsx --tsconfig tsconfig.app.json --test tests/prompt-time-format.test.ts\
- \pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ziwei-prompt-snapshot.test.ts\
- \pnpm exec prettier --check tests/prompt-assertions.ts tests/prompt-time-format.test.ts tests/ziwei-prompt-snapshot.test.ts\
- \pnpm test\
- \pnpm lint\
- \git diff --check\

## 风险

- 低风险。只抽取测试断言，不改变任何提示词生成逻辑。