### PR TITLE
补强 MCP 提示词输出反查

### DIFF
--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -5,6 +5,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { TIME_MAP } from '../../src/utils/bazi/baziDisplayData';
 import { calculateTrueSolarTime } from '../../src/utils/bazi/trueSolarTime';
 import { getTimeIndexFromClock } from 'mingyu-core/calendar';
+import { assertPromptIsPortableTaskText } from '../prompt-assertions';
 
 const toolCalls: Array<[string, Record<string, unknown>]> = [
   ['divine_liuyao', {}],
@@ -225,11 +226,9 @@ test('MCP 一站式提示词工具应同时返回结果和 prompt', async () => 
 
       assert.equal(result.isError, undefined, `${name} 不应返回错误`);
       assert.ok(result.structuredContent?.result, `${name} 应返回 result`);
-      assert.match(
-        String(result.structuredContent?.prompt),
-        promptPattern,
-        `${name} prompt 格式不正确`,
-      );
+      const prompt = String(result.structuredContent?.prompt);
+      assert.match(prompt, promptPattern, `${name} prompt 格式不正确`);
+      assertPromptIsPortableTaskText(prompt);
 
       const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
       assert.deepEqual(JSON.parse(text), result.structuredContent);


### PR DESCRIPTION
## 修改内容
- MCP 一站式提示词工具测试复用可复制任务书断言，反查真实返回的 prompt 是否适合直接交给 AI 解读。
- 在保留原有 section 匹配的基础上，增加对占位符、工程提示词、Markdown 加粗残留等问题的统一检查。

## 验证结果
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/mcp/structured-output.test.ts
- pnpm exec prettier --check tests/mcp/structured-output.test.ts tests/prompt-assertions.ts
- git diff --check

## 风险说明
- 只修改测试断言，不改变用户可见功能或接口返回。