### PR TITLE
补强公开 API 排盘提示词反查

### DIFF
--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -496,8 +496,10 @@ test('公开 API 八字提示词接口应一次返回排盘和提示词', async 
   assert.equal(response.status, 200);
   assert.equal(body.ok, true);
   assert.equal(body.data.result.gender, 'male');
-  assert.match(body.data.prompt, /【排盘信息】/);
-  assert.match(body.data.prompt, /我适合创业还是上班/);
+  const prompt = body.data.prompt;
+  assert.match(prompt, /【排盘信息】/);
+  assert.match(prompt, /我适合创业还是上班/);
+  assertPromptIsPortableTaskText(prompt);
 });
 
 test('公开 API 八字空问题应返回 400，保持 question 必填契约', async () => {
@@ -773,8 +775,10 @@ test('公开 API 紫微提示词接口应一次返回排盘和提示词', async 
   assert.equal(body.ok, true);
   assert.deepEqual(body.data.result.scopeNames, ['origin']);
   assert.equal(body.data.result.payloadByScope.origin.evidence_pool.length, 0);
-  assert.match(body.data.prompt, /【问题】/);
-  assert.match(body.data.prompt, /我的感情关系要注意什么/);
+  const prompt = body.data.prompt;
+  assert.match(prompt, /【问题】/);
+  assert.match(prompt, /我的感情关系要注意什么/);
+  assertPromptIsPortableTaskText(prompt);
 });
 
 test('公开 API 紫微提示词接口只生成所需范围，避免线上函数超时', async () => {
@@ -802,8 +806,10 @@ test('公开 API 紫微提示词接口只生成所需范围，避免线上函数
   assert.equal(body.data.result.payloadByScope.yearly.evidence_pool.length, 0);
   assert.equal(body.data.result.payloadByScope.yearly.patterns.length, 0);
   assert.equal(body.data.result.payloadByScope.decadal, undefined);
-  assert.match(body.data.prompt, /分析范围：流年/);
-  assert.match(body.data.prompt, /【任务】/);
+  const prompt = body.data.prompt;
+  assert.match(prompt, /分析范围：流年/);
+  assert.match(prompt, /【任务】/);
+  assertPromptIsPortableTaskText(prompt);
 });
 
 test('公开 API 紫微空问题应返回 400，保持 question 必填契约', async () => {


### PR DESCRIPTION
## 修改内容
- 公开 API 八字提示词接口复用可复制任务书断言。
- 公开 API 紫微本命和流年提示词接口复用同一反查，确认真实返回 prompt 不含占位符、工程提示词和 Markdown 加粗残留。

## 验证结果
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/public-api.test.ts
- pnpm lint
- git diff --check

## 风险说明
- 只修改测试断言，不改变接口实现和用户可见返回。