### PR TITLE
补充紫微公开提示词证据并瘦身机械测试

### DIFF
--- a/src/lib/public-api/prompt-builders.ts
+++ b/src/lib/public-api/prompt-builders.ts
@@ -1,4 +1,4 @@
-import type { ScopeType } from '../../types/analysis';
+import type { PalaceFact, ScopeType, StarFact } from '../../types/analysis';
 import type { BaziChartResult } from '../../utils/bazi/baziTypes';
 import type { FortuneSelectionContext } from '../../utils/bazi/fortuneSelection';
 import {
@@ -279,6 +279,75 @@ function buildPublicZiweiTaskText(topic: ZiweiPromptTopic) {
   return topicTextMap[topic] ?? topicTextMap.chat!;
 }
 
+const ZIWEI_TOPIC_PALACE_NAMES: Partial<Record<ZiweiPromptTopic, string[]>> = {
+  relationship: ['夫妻宫', '命宫', '福德宫', '迁移宫'],
+  'relationship-push': ['夫妻宫', '命宫', '福德宫', '迁移宫'],
+  'relationship-decision': ['夫妻宫', '命宫', '福德宫', '迁移宫'],
+  'reconciliation-decision': ['夫妻宫', '命宫', '福德宫', '迁移宫', '子女宫'],
+  children: ['子女宫', '夫妻宫', '命宫', '福德宫', '田宅宫'],
+  'career-wealth': ['官禄宫', '财帛宫', '命宫', '迁移宫', '福德宫'],
+  'job-change': ['官禄宫', '迁移宫', '财帛宫', '命宫', '田宅宫', '福德宫'],
+  'startup-partnership': ['官禄宫', '财帛宫', '迁移宫', '命宫', '福德宫', '兄弟宫'],
+  'investment-partnership': ['财帛宫', '官禄宫', '福德宫', '兄弟宫', '迁移宫', '命宫'],
+  recent: ['命宫', '身宫', '官禄宫', '财帛宫', '迁移宫', '福德宫'],
+  family: ['父母宫', '兄弟宫', '田宅宫', '命宫', '福德宫'],
+  'home-move': ['田宅宫', '迁移宫', '财帛宫', '福德宫', '命宫', '父母宫'],
+  'settle-relocate': ['田宅宫', '迁移宫', '官禄宫', '财帛宫', '福德宫', '命宫', '父母宫'],
+  social: ['兄弟宫', '迁移宫', '福德宫', '命宫', '官禄宫', '财帛宫'],
+  emotion: ['福德宫', '命宫', '疾厄宫', '夫妻宫', '迁移宫'],
+  health: ['疾厄宫', '福德宫', '命宫', '身宫', '迁移宫'],
+  study: ['命宫', '福德宫', '官禄宫', '父母宫', '迁移宫'],
+  'study-advance': ['命宫', '福德宫', '官禄宫', '父母宫', '迁移宫'],
+  'exam-landing': ['命宫', '福德宫', '官禄宫', '父母宫', '迁移宫'],
+  growth: ['命宫', '福德宫', '迁移宫', '官禄宫'],
+  talent: ['命宫', '福德宫', '官禄宫', '财帛宫'],
+  life: ['命宫', '身宫', '福德宫', '官禄宫', '财帛宫', '迁移宫'],
+  destiny: ['命宫', '身宫', '福德宫', '官禄宫', '财帛宫', '迁移宫'],
+};
+
+function formatPublicZiweiStar(star: StarFact) {
+  return [star.name, star.brightness ? `(${star.brightness})` : ''].join('');
+}
+
+function formatPublicZiweiPalaceBrief(palace: PalaceFact) {
+  const stars = [...palace.major_stars, ...palace.minor_stars]
+    .map(formatPublicZiweiStar)
+    .filter(Boolean)
+    .slice(0, 8);
+  const tags = palace.summary_tags.length > 0 ? `；标记：${palace.summary_tags.join('、')}` : '';
+  return `- ${palace.name}（${palace.heavenly_stem}${palace.earthly_branch}）：星曜：${stars.length > 0 ? stars.join('、') : '未提供主星资料'}；长生：${palace.changsheng12 || '未提供'}；博士：${palace.boshi12 || '未提供'}${tags}`;
+}
+
+function findPublicZiweiPalaceByName(palaces: PalaceFact[], name: string) {
+  const normalizedName = name.endsWith('宫') ? name.slice(0, -1) : name;
+  return palaces.find((palace) => palace.name === name || palace.name === normalizedName);
+}
+
+function buildPublicZiweiKeyPalaceSection(params: {
+  topic: ZiweiPromptTopic;
+  palaces: PalaceFact[];
+  activePalace?: PalaceFact;
+  bodyPalace?: PalaceFact;
+}) {
+  const palaceNames = [
+    ...(ZIWEI_TOPIC_PALACE_NAMES[params.topic] ?? ['命宫', '身宫', '福德宫', '迁移宫']),
+    params.activePalace?.name,
+    params.bodyPalace?.name,
+  ].filter(Boolean) as string[];
+  const selected = Array.from(
+    new Map(
+      palaceNames
+        .map((name) => findPublicZiweiPalaceByName(params.palaces, name))
+        .filter((palace): palace is PalaceFact => Boolean(palace))
+        .map((palace) => [palace.index, palace]),
+    ).values(),
+  ).slice(0, 7);
+
+  return selected.length > 0
+    ? `【重点宫位】\n${selected.map(formatPublicZiweiPalaceBrief).join('\n')}`
+    : '';
+}
+
 export function buildPublicZiweiPromptForRuntime(params: {
   result: ZiweiRuntime;
   question?: string;
@@ -320,8 +389,16 @@ export function buildPublicZiweiPromptForRuntime(params: {
   const prompt = [
     `【分析背景】\n分析主题：${topicLabel}\n分析范围：${scopeLabel}\n分析对象：${payload.active_scope.label || scopeLabel}\n参考日期：${payload.active_scope.solar_date}\n虚岁：${payload.active_scope.nominal_age}`,
     `【排盘信息】\n出生日期：${payload.basic_info.solar_date}；农历：${payload.basic_info.lunar_date}；时辰：${payload.basic_info.birth_time_label}\n命宫：${lifePalace?.name ?? '命宫'}；星曜：${formatStars(lifePalace)}\n身宫：${bodyPalace?.name ?? '未标出'}；星曜：${formatStars(bodyPalace)}\n当前落宫：${activePalace?.name ?? '本命范围'}\n当前四化：${mutagenText}`,
+    buildPublicZiweiKeyPalaceSection({
+      topic,
+      palaces: payload.palaces,
+      activePalace,
+      bodyPalace,
+    }),
     `【问题】\n${params.question ?? ''}`,
-  ].join('\n\n');
+  ]
+    .filter(Boolean)
+    .join('\n\n');
 
   const schoolGuidance = getZiweiSchoolGuidance(params.school);
   const promptWithSchool = schoolGuidance ? `${schoolGuidance}\n\n${prompt}` : prompt;

--- a/tests/divination-engine.test.ts
+++ b/tests/divination-engine.test.ts
@@ -10,10 +10,9 @@ import { estimateYingQi } from '../packages/core/src/divination/algorithms/qimen
 import { generateLiuyao } from 'mingyu-core/divination/liuyao';
 import { generateXiaoliuren } from 'mingyu-core/divination/xiaoliuren';
 import { generateQimen, resolveZhiShiLandingPalace } from 'mingyu-core/divination/qimen';
-import { assertPromptIsPortableTaskText, assertPromptSectionsInOrder } from './prompt-assertions';
+import { assertPromptIsPortableTaskText } from './prompt-assertions';
 
 type DivinationDraftInput = Parameters<typeof generateDivinationSession>[0];
-type GeneratedSessionMethod = DivinationDraftInput['method'];
 
 function buildDraft(overrides: Partial<DivinationDraftInput>): DivinationDraftInput {
   return {
@@ -75,106 +74,6 @@ function buildQimenPalace(gong: number, heavenStem: string): QimenJiuGongGe {
     shenPan: { god: '' },
   };
 }
-
-function assertGeneratedSessionPrompt(method: GeneratedSessionMethod, prompt: string) {
-  const baseSections = ['【要求】', '【当前时间】', '【补充信息】'];
-  const commonOptions = { requireUnique: true, requireBodyAfterHeading: true };
-
-  if (method === 'liuren') {
-    assertPromptSectionsInOrder(
-      prompt,
-      [
-        ...baseSections,
-        '【排盘信息】',
-        '【分析对象】',
-        '【解读范围】',
-        '【应期判断方法】',
-        '【问题】',
-        '【分析思路】',
-        '【任务】',
-        '【输出要求】',
-      ],
-      commonOptions,
-    );
-  } else if (method === 'almanac') {
-    assertPromptSectionsInOrder(
-      prompt,
-      [...baseSections, '【占卜信息】', '【应期判断方法】', '【任务】', '【输出要求】'],
-      commonOptions,
-    );
-    assert.doesNotMatch(prompt, /^【问题】$/m);
-  } else if (method === 'astrolabe') {
-    assertPromptSectionsInOrder(
-      prompt,
-      [...baseSections, '【占卜信息】', '【问题】', '【分析思路】', '【任务】', '【输出要求】'],
-      commonOptions,
-    );
-    assert.doesNotMatch(prompt, /^【应期判断方法】$/m);
-  } else {
-    assertPromptSectionsInOrder(
-      prompt,
-      [
-        ...baseSections,
-        '【占卜信息】',
-        '【应期判断方法】',
-        '【问题】',
-        '【任务】',
-        ...(method === 'liuyao' ? ['【断卦要点】'] : []),
-        '【输出要求】',
-      ],
-      commonOptions,
-    );
-  }
-
-  assert.match(prompt, /^你是资深.+/);
-  assertPromptIsPortableTaskText(prompt);
-}
-
-test('各占卜方式都可以直接使用当前项目本地算法生成会话', async () => {
-  const methods = [
-    'liuyao',
-    'meihua',
-    'xiaoliuren',
-    'qimen',
-    'liuren',
-    'tarot',
-    'ssgw',
-    'almanac',
-    'lenormand',
-    'astrolabe',
-  ] as const;
-
-  for (const method of methods) {
-    const session = await generateDivinationSession(
-      buildDraft({
-        method,
-        gender: '男',
-        birthYear: '1995',
-        meihuaMethod: 'number',
-        meihuaNumber: '123',
-        almanacEndDate: '2026-06-07',
-        almanacParticipants: [
-          {
-            id: 'p1',
-            name: '本人',
-            gender: '男',
-            year: '1995',
-            month: '5',
-            day: '20',
-            timeIndex: '6',
-            dateType: 'solar',
-          },
-        ],
-        astrolabeGender: '男',
-      }),
-    );
-
-    assert.equal(session.method, method);
-    assert.equal(typeof session.prompt, 'string');
-    assertGeneratedSessionPrompt(method, session.prompt);
-    assert.equal(typeof session.data.timestamp, 'number');
-  }
-});
 
 test('六爻算法会补出伏神结构，供提示词直接引用', () => {
   const data = generateLiuyao(new Date('2025-01-01T08:00:00+08:00'));

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -8,13 +8,7 @@ import { getTimeIndexFromClock } from 'mingyu-core/calendar';
 import { assertPromptIsPortableTaskText } from '../prompt-assertions';
 
 const toolCalls: Array<[string, Record<string, unknown>]> = [
-  ['divine_liuyao', {}],
-  ['divine_meihua', { method: 'number', number: 42 }],
-  ['divine_xiaoliuren', { xiaoliurenMethod: 'number', xiaoliurenNumber: 18 }],
   ['divine_qimen', {}],
-  ['divine_liuren', {}],
-  ['divine_tarot', { spreadType: 'single' }],
-  ['divine_ssgw', {}],
   [
     'divine_almanac',
     {
@@ -35,30 +29,9 @@ const toolCalls: Array<[string, Record<string, unknown>]> = [
       ],
     },
   ],
-  ['divine_lenormand', { spreadType: 'relationship' }],
-  [
-    'divine_astrolabe',
-    {
-      name: '本人',
-      gender: '女',
-      year: 1995,
-      month: 5,
-      day: 20,
-      hour: 12,
-      minute: 30,
-      latitude: 39.9042,
-      longitude: 116.4074,
-      timezone: 8,
-      locationName: '北京',
-    },
-  ],
   [
     'bazi_calculate',
     { gender: 'male', year: 1990, month: 5, day: 15, timeIndex: 1, dateType: 'solar' },
-  ],
-  [
-    'ziwei_calculate',
-    { gender: 'male', dateType: 'solar', year: '1990', month: '5', day: '15', timeIndex: 1 },
   ],
 ];
 
@@ -94,69 +67,24 @@ const promptToolCalls: Array<[string, Record<string, unknown>, RegExp]> = [
   ],
   [
     'liuyao_prompt',
-    {
-      customDate: '2025-01-01T08:00:00+08:00',
-      liuyaoTemplate: 'shiye',
-      question: '今年事业如何？',
-    },
-    /【占卜信息】/,
-  ],
-  ['meihua_prompt', { method: 'number', number: 42, question: '今年事业如何？' }, /【占卜信息】/],
-  [
-    'xiaoliuren_prompt',
-    { xiaoliurenMethod: 'number', xiaoliurenNumber: 18, question: '今年事业如何？' },
-    /【占卜信息】/,
-  ],
-  [
-    'qimen_prompt',
     { customDate: '2025-01-01T08:00:00+08:00', question: '今年事业如何？' },
     /【占卜信息】/,
   ],
-  [
-    'liuren_prompt',
-    {
-      customDate: '2025-01-01T08:00:00+08:00',
-      liurenTemplate: 'shiye',
-      question: '今年事业如何？',
-    },
-    /【排盘信息】/,
-  ],
-  ['tarot_prompt', { spreadType: 'single', question: '今年事业如何？' }, /【占卜信息】/],
-  ['ssgw_prompt', { question: '今年事业如何？' }, /【占卜信息】/],
-  [
-    'almanac_prompt',
-    {
-      topic: 'contract',
-      startDate: '2026-06-01',
-      endDate: '2026-06-03',
-      question: '这几天哪天更适合签约？',
-    },
-    /【占卜信息】/,
-  ],
-  [
-    'lenormand_prompt',
-    { spreadType: 'relationship', question: '这段关系下一步如何？' },
-    /【占卜信息】/,
-  ],
-  [
-    'astrolabe_prompt',
-    {
-      name: '本人',
-      gender: '女',
-      year: 1995,
-      month: 5,
-      day: 20,
-      hour: 12,
-      minute: 30,
-      latitude: 39.9042,
-      longitude: 116.4074,
-      timezone: 8,
-      locationName: '北京',
-      question: '请看我的事业发展。',
-      astrolabeTopic: 'career',
-    },
-    /【占卜信息】/,
-  ],
+];
+
+const promptToolNames = [
+  'bazi_prompt',
+  'ziwei_prompt',
+  'liuyao_prompt',
+  'meihua_prompt',
+  'xiaoliuren_prompt',
+  'qimen_prompt',
+  'liuren_prompt',
+  'tarot_prompt',
+  'ssgw_prompt',
+  'almanac_prompt',
+  'lenormand_prompt',
+  'astrolabe_prompt',
 ];
 
 async function withMcpClient<T>(callback: (client: Client) => Promise<T>) {
@@ -193,7 +121,7 @@ test('MCP 工具列表应声明输出结构', async () => {
       tools.some((tool) => tool.name === 'build_divination_prompt'),
       false,
     );
-    for (const [name] of promptToolCalls) {
+    for (const name of promptToolNames) {
       assert.ok(tools.find((tool) => tool.name === name)?.outputSchema?.properties?.result);
       assert.ok(tools.find((tool) => tool.name === name)?.outputSchema?.properties?.prompt);
     }

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -24,53 +24,6 @@ async function callApi(path: string, init?: RequestInit) {
   };
 }
 
-const divinationPromptCases: Array<[string, Record<string, unknown>]> = [
-  ['liuyao', { customDate: '2025-01-01T08:00:00+08:00' }],
-  ['meihua', { method: 'number', number: 42 }],
-  ['xiaoliuren', { xiaoliurenMethod: 'number', xiaoliurenNumber: 18 }],
-  ['qimen', { customDate: '2025-01-01T08:00:00+08:00' }],
-  ['liuren', { customDate: '2025-01-01T08:00:00+08:00', liurenTemplate: 'shiye' }],
-  ['tarot', { spreadType: 'single' }],
-  ['ssgw', {}],
-  [
-    'almanac',
-    {
-      topic: 'move',
-      startDate: '2026-06-01',
-      endDate: '2026-06-05',
-      participants: [
-        {
-          id: 'self',
-          name: '本人',
-          gender: '男',
-          year: 1990,
-          month: 1,
-          day: 1,
-          timeIndex: 12,
-          dateType: 'solar',
-        },
-      ],
-    },
-  ],
-  ['lenormand', { spreadType: 'relationship' }],
-  [
-    'astrolabe',
-    {
-      name: '本人',
-      gender: '女',
-      year: 1995,
-      month: 5,
-      day: 20,
-      hour: 12,
-      minute: 30,
-      latitude: 39.9042,
-      longitude: 116.4074,
-      timezone: 8,
-      locationName: '北京',
-    },
-  ],
-];
-
 const timeIndexRangeMap: Record<number, string> = {
   0: '00:00~01:00',
   1: '01:00~03:00',
@@ -1437,78 +1390,6 @@ test('公开 API customDate 不应接受非 ISO 或会被 JS 自动进位的无�
   }
 });
 
-test('公开 API 黄历择日、小六壬、雷诺曼和星盘接口应返回结构化结果', async () => {
-  const almanac = await callApi('divination/almanac', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      topic: 'move',
-      startDate: '2026-06-01',
-      endDate: '2026-06-05',
-      participants: [
-        {
-          id: 'self',
-          name: '本人',
-          gender: '男',
-          year: 1990,
-          month: 1,
-          day: 1,
-          timeIndex: 12,
-          dateType: 'solar',
-        },
-      ],
-    }),
-  });
-  assert.equal(almanac.response.status, 200);
-  assert.equal(almanac.body.ok, true);
-  assert.equal(almanac.body.data.topic, 'move');
-  assert.equal(almanac.body.data.days.length, 5);
-  assert.equal(almanac.body.data.participants.length, 1);
-
-  const xiaoliuren = await callApi('divination/xiaoliuren', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ xiaoliurenMethod: 'number', xiaoliurenNumber: 18 }),
-  });
-  assert.equal(xiaoliuren.response.status, 200);
-  assert.equal(xiaoliuren.body.ok, true);
-  assert.equal(xiaoliuren.body.data.method, 'number');
-  assert.equal(xiaoliuren.body.data.sequence.result.name.length > 0, true);
-
-  const lenormand = await callApi('divination/lenormand', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ spreadType: 'relationship' }),
-  });
-  assert.equal(lenormand.response.status, 200);
-  assert.equal(lenormand.body.ok, true);
-  assert.equal(lenormand.body.data.spreadType, 'relationship');
-  assert.ok(lenormand.body.data.cards.length >= 5);
-
-  const astrolabe = await callApi('divination/astrolabe', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      name: '本人',
-      gender: '女',
-      year: 1995,
-      month: 5,
-      day: 20,
-      hour: 12,
-      minute: 30,
-      latitude: 39.9042,
-      longitude: 116.4074,
-      timezone: 8,
-      locationName: '北京',
-    }),
-  });
-  assert.equal(astrolabe.response.status, 200);
-  assert.equal(astrolabe.body.ok, true);
-  assert.ok(astrolabe.body.data.planets.length >= 10);
-  assert.ok(astrolabe.body.data.aspects.length >= 1);
-  assert.match(astrolabe.body.data.birth.location, /北京/);
-});
-
 test('公开 API 数字起卦起课应拒绝超出安全整数范围的数字', async () => {
   const unsafeInteger = Number.MAX_SAFE_INTEGER + 1;
   const cases: Array<[string, Record<string, unknown>, string]> = [
@@ -1570,39 +1451,6 @@ test('公开 API 星盘应支持真太阳时校正', async () => {
     body.data.birth.trueSolarDateTime,
     `${corrected.year}-${String(corrected.month).padStart(2, '0')}-${String(corrected.day).padStart(2, '0')} ${String(corrected.hour).padStart(2, '0')}:${String(corrected.minute).padStart(2, '0')}`,
   );
-});
-
-test('公开 API 各占卜提示词接口应一次返回占卜结果、摘要和提示词', async () => {
-  for (const [method, payload] of divinationPromptCases) {
-    const { response, body } = await callApi(`divination/${method}/prompt`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ...payload,
-        question: '我近期事业应该注意什么？',
-      }),
-    });
-
-    assert.equal(response.status, 200, `${method} prompt 接口应返回 200`);
-    assert.equal(body.ok, true, `${method} prompt 接口应成功`);
-    assert.ok(body.data.result, `${method} prompt 接口应返回 result`);
-    assert.ok(body.data.summary, `${method} prompt 接口应返回 summary`);
-    assert.equal(typeof body.data.summary.title, 'string', `${method} summary 应有标题`);
-    assert.ok(Array.isArray(body.data.summary.tags), `${method} summary 应有标签数组`);
-    assert.ok(Array.isArray(body.data.summary.lines), `${method} summary 应有摘要行数组`);
-    const prompt = body.data.prompt;
-    assert.match(
-      prompt,
-      method === 'liuren' ? /【排盘信息】/ : /【占卜信息】/,
-      `${method} prompt 应包含排盘或占卜信息`,
-    );
-    assert.match(
-      prompt,
-      method === 'almanac' ? /择日补充：我近期事业应该注意什么/ : /我近期事业应该注意什么/,
-      `${method} prompt 应包含问题或择日补充`,
-    );
-    assertPromptIsPortableTaskText(prompt);
-  }
 });
 
 test('公开 API 黄历择日提示词不强制填写问题', async () => {


### PR DESCRIPTION
## 修改内容
- 人工生成并审查公开 API 真实提示词后，发现紫微流年换工作提示词证据偏薄。
- 在紫微公开 API 轻量提示词中加入【重点宫位】，按主题补充官禄、迁移、财帛、命宫等相关宫位摘要，不启用完整 evidence_pool，避免增加线上超时风险。
- 删除公开 API 占卜提示词全量刷接口测试、公开 API 多接口成功字段烟测、占卜引擎全占法重复烟测。
- 缩小 MCP 批量运行样本：保留代表性调用，工具 schema 仍静态检查全量提示词工具。

## 验证
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/public-api.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/mcp/structured-output.test.ts
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/divination-engine.test.ts
- pnpm lint
- git diff --check
- pnpm build

## 风险
- 紫微公开 API 提示词会变长，但只使用已在轻量 payload 中存在的宫位资料，不触发完整分析证据池。
- 已删除的测试属于弱断言或重复烟测，保留了错误边界、提示词结构和专项业务规则测试。