### PR TITLE
feat: 中国夏令时(1986-1991)自动校正 + 排盘边界预警 + 金标准边界测试

### DIFF
--- a/packages/core/src/bazi/baziAnalysisFormatter.ts
+++ b/packages/core/src/bazi/baziAnalysisFormatter.ts
@@ -154,6 +154,12 @@ function buildBaziText(baziResult: BaziChartResult, options: FormatBaziOptions):
   result += `出生历法: 阳历${solarDate.year}年${solarDate.month}月${solarDate.day}日 | 农历${formatLunarDate(baziResult)} | 生肖:${baziResult.zodiac}\n`;
   if (baziResult.timing?.enabled) {
     result += `真太阳时: ${baziResult.timing.correctedTime.year}年${baziResult.timing.correctedTime.month}月${baziResult.timing.correctedTime.day}日 ${String(baziResult.timing.correctedTime.hour).padStart(2, '0')}:${String(baziResult.timing.correctedTime.minute).padStart(2, '0')} | 出生地:${baziResult.timing.birthPlace || '未填写'} | 经度:${baziResult.timing.birthLongitude}\n`;
+    if (baziResult.timing.dstCorrectionMinutes) {
+      result += `夏令时校正: ${baziResult.timing.dstCorrectionMinutes} 分钟（中国夏令时 1986-1991）\n`;
+    }
+  }
+  if (baziResult.warnings?.length) {
+    result += `【排盘预警】\n${baziResult.warnings.map((w) => `⚠ ${w}`).join('\n')}\n`;
   }
   result += `日元本命: ${dayMaster.gan}${dayMaster.element} (${dayMaster.yinYang})\n`;
   if (baziResult.monthCommander) result += `月令司权: ${baziResult.monthCommander}\n`;

--- a/packages/core/src/bazi/baziCalculator.ts
+++ b/packages/core/src/bazi/baziCalculator.ts
@@ -1,6 +1,8 @@
 import { SolarTime, Gender, LunarHour } from 'tyme4ts';
 import { TIME_MAP } from './baziDefinitions';
 import { calculateTrueSolarTime } from './trueSolarTime';
+import { checkChinaDst, isDateInChinaDstRange } from './chinaDst';
+import { collectBoundaryWarnings } from './paipanWarnings';
 import { ShenShaCalculator } from './baziShenSha';
 import { BaziAnalyzer } from './baziAnalysis';
 import { LuckCalculator } from './LuckCalculator';
@@ -169,6 +171,9 @@ export class BaziCalculator {
       lunarHour = solarTime.getLunarHour();
     }
 
+    const applyChinaDst = person.applyChinaDst !== false;
+    const warnings: string[] = [];
+
     if (useTrueSolarTime) {
       const standardTime = {
         year: solarTime.getYear(),
@@ -178,7 +183,56 @@ export class BaziCalculator {
         minute: solarTime.getMinute(),
         second: solarTime.getSecond(),
       };
-      const trueSolarResult = calculateTrueSolarTime(standardTime, birthLongitude!);
+
+      // 中国夏令时（1986-1991）：钟表时间快 1 小时，先回拨再做真太阳时校正
+      let dstCorrectionMinutes = 0;
+      let dstInput = standardTime;
+      if (applyChinaDst) {
+        const dst = checkChinaDst(
+          standardTime.year,
+          standardTime.month,
+          standardTime.day,
+          standardTime.hour,
+          standardTime.minute,
+        );
+        if (dst.inDst) {
+          dstCorrectionMinutes = dst.offsetMinutes;
+          const shifted = new Date(
+            Date.UTC(
+              standardTime.year,
+              standardTime.month - 1,
+              standardTime.day,
+              standardTime.hour,
+              standardTime.minute,
+              standardTime.second,
+            ) +
+              dstCorrectionMinutes * 60000,
+          );
+          dstInput = {
+            year: shifted.getUTCFullYear(),
+            month: shifted.getUTCMonth() + 1,
+            day: shifted.getUTCDate(),
+            hour: shifted.getUTCHours(),
+            minute: shifted.getUTCMinutes(),
+            second: shifted.getUTCSeconds(),
+          };
+          warnings.push(
+            '出生时刻处于中国夏令时期间（1986-1991），钟表时间比北京标准时间快 1 小时，已自动回拨 60 分钟后排盘。如所记时间已折算为标准时间，请设置 applyChinaDst: false。',
+          );
+          if (dst.ambiguous) {
+            warnings.push(
+              '出生时刻落在夏令时结束日 01:00-02:00 的重复时段，该钟表时刻当天出现两次，无法唯一判定，建议按夏令时/标准时两种口径分别参详。',
+            );
+          }
+          if (dst.nonexistent) {
+            warnings.push(
+              '出生时刻落在夏令时开始日 02:00-03:00 的跳变时段，该钟表时刻当天并不存在，出生记录可能有误，请核实。',
+            );
+          }
+        }
+      }
+
+      const trueSolarResult = calculateTrueSolarTime(dstInput, birthLongitude!);
 
       solarTime = SolarTime.fromYmdHms(
         trueSolarResult.correctedTime.year,
@@ -198,7 +252,28 @@ export class BaziCalculator {
         longitudeCorrectionMinutes: trueSolarResult.longitudeCorrectionMinutes,
         equationOfTimeMinutes: trueSolarResult.equationOfTimeMinutes,
         totalCorrectionMinutes: trueSolarResult.totalCorrectionMinutes,
+        ...(dstCorrectionMinutes !== 0 ? { dstCorrectionMinutes } : {}),
       };
+
+      // 边界预警：基于校正后的最终时刻检查节气交接/时辰边界/换日线
+      warnings.push(
+        ...collectBoundaryWarnings({
+          year: solarTime.getYear(),
+          month: solarTime.getMonth(),
+          day: solarTime.getDay(),
+          hour: solarTime.getHour(),
+          minute: solarTime.getMinute(),
+          second: solarTime.getSecond(),
+        }),
+      );
+    } else if (
+      applyChinaDst &&
+      isDateInChinaDstRange(solarTime.getYear(), solarTime.getMonth(), solarTime.getDay())
+    ) {
+      // 仅时辰精度：无法安全做 -1 小时校正，只提示
+      warnings.push(
+        '出生日期位于中国夏令时期间（1986-1991），钟表时间比北京标准时间快 1 小时，时辰可能需前移。建议改用真太阳时模式并提供精确出生时间。',
+      );
     }
 
     const eightChar = lunarHour.getEightChar();
@@ -256,6 +331,7 @@ export class BaziCalculator {
       },
       timeInfo: finalTimeInfo,
       pillars,
+      warnings,
       dayMaster: {
         gan: dayMasterGan,
         element: getWuxingUtil(dayMasterGan),

--- a/packages/core/src/bazi/baziTypes.ts
+++ b/packages/core/src/bazi/baziTypes.ts
@@ -25,6 +25,12 @@ export interface Person {
   birthLongitude?: number;
   age?: number;
   shenShaVariants?: Partial<ShenShaVariantConfig>;
+  /**
+   * 是否自动校正中国夏令时（1986-1991，钟表时间快 1 小时）。
+   * 默认 true；仅在真太阳时模式（有精确时分）下执行 -60 分钟校正，
+   * 仅时辰精度时只输出提示不做校正。
+   */
+  applyChinaDst?: boolean;
 }
 
 export interface TimeInfo {
@@ -99,6 +105,8 @@ export interface TimingInfo {
   longitudeCorrectionMinutes: number;
   equationOfTimeMinutes: number;
   totalCorrectionMinutes: number;
+  /** 中国夏令时校正（命中 1986-1991 夏令时时为 -60，未命中时省略） */
+  dstCorrectionMinutes?: number;
 }
 
 export interface LuckCycle {
@@ -328,4 +336,9 @@ export interface BaziChartResult {
   age?: number;
   /** 流年列表 */
   liunian?: LiunianInfo[];
+  /**
+   * 排盘预警：出生时刻贴近节气交接/时辰边界/23:00 换日线，
+   * 或落于中国夏令时期间等可能翻柱的情形。无预警时为空数组。
+   */
+  warnings: string[];
 }

--- a/packages/core/src/bazi/chinaDst.ts
+++ b/packages/core/src/bazi/chinaDst.ts
@@ -1,0 +1,111 @@
+/**
+ * @file 中国夏令时（1986-1991）检测与校正
+ * @description
+ * 1986-1991 年中国实行夏令时：当年 4 月中旬第一个星期日 02:00（标准时）
+ * 将钟表拨快 1 小时，至 9 月中旬第一个星期日 02:00（夏令时钟表时刻）拨回。
+ * 该期间出生记录的"钟表时间"比北京标准时间快 1 小时，排盘前需先减 1 小时，
+ * 否则时柱（乃至日柱）可能整体偏移一个时辰。
+ *
+ * 区间依据国务院历年通知：
+ * 1986-05-04 ~ 1986-09-14（首年自 5 月 4 日起）
+ * 1987-04-12 ~ 1987-09-13
+ * 1988-04-10 ~ 1988-09-11
+ * 1989-04-16 ~ 1989-09-17
+ * 1990-04-15 ~ 1990-09-16
+ * 1991-04-14 ~ 1991-09-15
+ */
+
+export interface ChinaDstCheckResult {
+  /** 输入的钟表时刻是否处于夏令时期间 */
+  inDst: boolean;
+  /** 应施加的分钟修正（夏令时内为 -60，否则 0） */
+  offsetMinutes: number;
+  /** 是否落在重复时段（结束日 01:00-02:00 钟表出现两次，无法唯一确定） */
+  ambiguous: boolean;
+  /** 是否落在不存在时段（开始日 02:00-03:00 被直接跳过，记录可能有误） */
+  nonexistent: boolean;
+}
+
+type DstBoundary = [year: number, month: number, day: number, hour: number];
+
+/**
+ * 钟表时刻区间 [start, end)。
+ * 开始日 02:00（标准时）直接跳到 03:00（夏令时），故夏令钟表区间自开始日 03:00 起；
+ * 结束日 02:00（夏令时）回拨至 01:00（标准时），故夏令钟表区间至结束日 02:00 止。
+ */
+const CHINA_DST_RANGES: Array<{ start: DstBoundary; end: DstBoundary }> = [
+  { start: [1986, 5, 4, 3], end: [1986, 9, 14, 2] },
+  { start: [1987, 4, 12, 3], end: [1987, 9, 13, 2] },
+  { start: [1988, 4, 10, 3], end: [1988, 9, 11, 2] },
+  { start: [1989, 4, 16, 3], end: [1989, 9, 17, 2] },
+  { start: [1990, 4, 15, 3], end: [1990, 9, 16, 2] },
+  { start: [1991, 4, 14, 3], end: [1991, 9, 15, 2] },
+];
+
+const HOUR_MS = 3600000;
+
+function toUtcMs(year: number, month: number, day: number, hour: number, minute = 0): number {
+  return Date.UTC(year, month - 1, day, hour, minute);
+}
+
+/**
+ * 检测某"钟表时刻"（北京时间墙上时钟）是否处于中国夏令时期间。
+ */
+export function checkChinaDst(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute = 0,
+): ChinaDstCheckResult {
+  const none: ChinaDstCheckResult = {
+    inDst: false,
+    offsetMinutes: 0,
+    ambiguous: false,
+    nonexistent: false,
+  };
+  if (year < 1986 || year > 1991) {
+    return none;
+  }
+
+  const t = toUtcMs(year, month, day, hour, minute);
+  for (const { start, end } of CHINA_DST_RANGES) {
+    if (start[0] !== year) {
+      continue;
+    }
+    const startMs = toUtcMs(...start);
+    const endMs = toUtcMs(...end);
+
+    // 不存在时段：开始日 02:00-03:00 的钟表时刻被跳过
+    if (t >= startMs - HOUR_MS && t < startMs) {
+      return { inDst: true, offsetMinutes: -60, ambiguous: false, nonexistent: true };
+    }
+    if (t >= startMs && t < endMs) {
+      // 重复时段：结束日 01:00-02:00 的钟表时刻出现两次
+      const ambiguous = t >= endMs - HOUR_MS;
+      return { inDst: true, offsetMinutes: -60, ambiguous, nonexistent: false };
+    }
+  }
+  return none;
+}
+
+/**
+ * 按"日"粒度判断日期是否与夏令时区间有交集。
+ * 用于仅有时辰精度（无法安全做 -1 小时校正）时给出提示。
+ */
+export function isDateInChinaDstRange(year: number, month: number, day: number): boolean {
+  if (year < 1986 || year > 1991) {
+    return false;
+  }
+  const dayStart = toUtcMs(year, month, day, 0);
+  const dayEnd = dayStart + 24 * HOUR_MS;
+  return CHINA_DST_RANGES.some(({ start, end }) => {
+    if (start[0] !== year) {
+      return false;
+    }
+    // 区间起点取开始日 02:00（跳变时刻），保证开始日当天也能命中提示
+    const startMs = toUtcMs(start[0], start[1], start[2], 2);
+    const endMs = toUtcMs(...end);
+    return dayStart < endMs && dayEnd > startMs;
+  });
+}

--- a/packages/core/src/bazi/index.ts
+++ b/packages/core/src/bazi/index.ts
@@ -64,6 +64,15 @@ export { matchesRule } from './baziRuleMatcher/index';
 export { determinePattern } from './baziPatternStrategy';
 export { determineUsefulGod } from './baziUsefulGodStrategy';
 export { calculateTrueSolarTime } from './trueSolarTime';
+export { checkChinaDst, isDateInChinaDstRange } from './chinaDst';
+export type { ChinaDstCheckResult } from './chinaDst';
+export {
+  collectBoundaryWarnings,
+  checkJieqiBoundary,
+  checkShichenBoundary,
+  BOUNDARY_THRESHOLD_MINUTES,
+} from './paipanWarnings';
+export type { BoundaryCheckInput } from './paipanWarnings';
 export { LuckCalculator } from './LuckCalculator';
 export {
   formatSolarDateTime,

--- a/packages/core/src/bazi/paipanWarnings.ts
+++ b/packages/core/src/bazi/paipanWarnings.ts
@@ -1,0 +1,160 @@
+/**
+ * @file 排盘边界预警
+ * @description
+ * 当出生时刻贴近"换柱边界"时，排盘结果存在翻转风险：
+ * 1. 节气交接（换月柱，立春同时换年柱）——底层节气常数表存在 ±20 秒级偏差，
+ *    出生时间记录本身也常有数分钟误差；
+ * 2. 时辰边界（奇数整点换时柱）——真太阳时均时差为近似公式（±1~2 分钟）；
+ * 3. 23:00 换日线——早晚子时流派之争，日柱归属两可。
+ * 距边界 ±BOUNDARY_THRESHOLD_MINUTES 分钟内时输出预警并给出两种候选，
+ * 而非沉默地二选一。
+ */
+import { SolarTerm } from 'tyme4ts';
+
+/** 边界预警阈值（分钟） */
+export const BOUNDARY_THRESHOLD_MINUTES = 3;
+
+/** 十二"节"（换月柱的交接点；"气"不换柱，不预警） */
+const JIE_NAMES = new Set([
+  '立春',
+  '惊蛰',
+  '清明',
+  '立夏',
+  '芒种',
+  '小暑',
+  '立秋',
+  '白露',
+  '寒露',
+  '立冬',
+  '大雪',
+  '小寒',
+]);
+
+export interface BoundaryCheckInput {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second?: number;
+}
+
+const TIME_BRANCH_NAMES = [
+  '子',
+  '丑',
+  '寅',
+  '卯',
+  '辰',
+  '巳',
+  '午',
+  '未',
+  '申',
+  '酉',
+  '戌',
+  '亥',
+];
+
+function toUtcMs(t: BoundaryCheckInput): number {
+  return Date.UTC(t.year, t.month - 1, t.day, t.hour, t.minute, t.second ?? 0);
+}
+
+function formatMinutes(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+/** 奇数整点 hour 对应"其后开始的时辰"名（如 3 点 → 寅时） */
+function branchNameStartingAtHour(oddHour: number): string {
+  const index = (Math.floor((oddHour + 1) / 2) + 12) % 12;
+  return TIME_BRANCH_NAMES[index];
+}
+
+/**
+ * 检查出生时刻是否贴近节气交接（仅检查换柱的"节"）。
+ * 返回预警文案数组（无预警时为空数组）。
+ */
+export function checkJieqiBoundary(t: BoundaryCheckInput): string[] {
+  const warnings: string[] = [];
+  const birthMs = toUtcMs(t);
+  let best: { name: string; diffMinutes: number; before: boolean } | null = null;
+
+  for (const y of [t.year - 1, t.year, t.year + 1]) {
+    for (let i = 0; i < 24; i++) {
+      let term: SolarTerm;
+      try {
+        term = SolarTerm.fromIndex(y, i);
+      } catch {
+        continue;
+      }
+      const name = term.getName();
+      if (!JIE_NAMES.has(name)) {
+        continue;
+      }
+      const st = term.getJulianDay().getSolarTime();
+      const termMs = Date.UTC(
+        st.getYear(),
+        st.getMonth() - 1,
+        st.getDay(),
+        st.getHour(),
+        st.getMinute(),
+        st.getSecond(),
+      );
+      const diffMinutes = Math.abs(termMs - birthMs) / 60000;
+      if (!best || diffMinutes < best.diffMinutes) {
+        best = { name, diffMinutes, before: birthMs < termMs };
+      }
+    }
+  }
+
+  if (best && best.diffMinutes <= BOUNDARY_THRESHOLD_MINUTES) {
+    const side = best.before ? '前' : '后';
+    const extra = best.name === '立春' ? '年柱与月柱' : '月柱';
+    warnings.push(
+      `出生时刻距「${best.name}」交节仅约 ${formatMinutes(best.diffMinutes)} 分钟（交节${side}）。` +
+        `节气历表存在秒级偏差、出生时间记录亦常有误差，${extra}存在交节前后两种可能，建议按两种盘分别参详。`,
+    );
+  }
+  return warnings;
+}
+
+/**
+ * 检查出生时刻是否贴近时辰边界（奇数整点），23:00 边界额外提示换日流派问题。
+ * 返回预警文案数组（无预警时为空数组）。
+ */
+export function checkShichenBoundary(t: BoundaryCheckInput): string[] {
+  const warnings: string[] = [];
+  const minuteOfDay = t.hour * 60 + t.minute + (t.second ?? 0) / 60;
+
+  // 时辰边界位于奇数整点，即 minuteOfDay ≡ 60 (mod 120)
+  const phase = (((minuteOfDay - 60) % 120) + 120) % 120;
+  const distance = Math.min(phase, 120 - phase);
+  if (distance > BOUNDARY_THRESHOLD_MINUTES) {
+    return warnings;
+  }
+
+  // 找到最近的奇数整点
+  const nearestBoundaryMinute =
+    phase <= 60 ? minuteOfDay - phase : minuteOfDay + (120 - phase);
+  const boundaryHour = ((Math.round(nearestBoundaryMinute / 60) % 24) + 24) % 24;
+  const nextBranch = branchNameStartingAtHour(boundaryHour);
+  const prevBranch = TIME_BRANCH_NAMES[(TIME_BRANCH_NAMES.indexOf(nextBranch) + 11) % 12];
+
+  warnings.push(
+    `出生时刻距 ${String(boundaryHour).padStart(2, '0')}:00 时辰边界仅约 ${formatMinutes(distance)} 分钟，` +
+      `时柱存在「${prevBranch}时/${nextBranch}时」两种可能（真太阳时均时差近似亦有 ±1~2 分钟误差），建议按两种时柱分别参详。`,
+  );
+
+  if (boundaryHour === 23) {
+    warnings.push(
+      '出生时刻贴近 23:00 换日线：晚子时的日柱归属存在「换日（本引擎采用）/不换日」两派之争，日柱亦可能不同，请知悉流派差异。',
+    );
+  }
+  return warnings;
+}
+
+/**
+ * 汇总边界预警。仅在具备分钟级精度的输入（真太阳时模式）下调用才有意义。
+ */
+export function collectBoundaryWarnings(t: BoundaryCheckInput): string[] {
+  return [...checkJieqiBoundary(t), ...checkShichenBoundary(t)];
+}

--- a/src/utils/bazi/chinaDst.ts
+++ b/src/utils/bazi/chinaDst.ts
@@ -1,0 +1,1 @@
+export * from '../../../packages/core/src/bazi/chinaDst';

--- a/src/utils/bazi/paipanWarnings.ts
+++ b/src/utils/bazi/paipanWarnings.ts
@@ -1,0 +1,1 @@
+export * from '../../../packages/core/src/bazi/paipanWarnings';

--- a/tests/paipan-boundary.test.ts
+++ b/tests/paipan-boundary.test.ts
@@ -1,0 +1,248 @@
+/**
+ * 排盘金标准边界测试
+ * 覆盖:立春换年、节气换月、晚子时换日、真太阳时跨日、
+ * 中国夏令时(1986-1991)校正、边界预警、日支帮扶回归。
+ * 金标准四柱已与 lunar-javascript 独立实现交叉验证一致。
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { baziCalculator } from '../src/utils/bazi/baziCalculator';
+import { checkChinaDst, isDateInChinaDstRange } from '../src/utils/bazi/chinaDst';
+import {
+  checkJieqiBoundary,
+  checkShichenBoundary,
+} from '../src/utils/bazi/paipanWarnings';
+
+const ganZhi = (p: { gan: string; zhi: string }) => `${p.gan}${p.zhi}`;
+
+test('金标准盘:1994-12-04 03:15 男 佳木斯(真太阳时) → 甲戌 乙亥 甲子 丙寅', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 1994,
+    month: 12,
+    day: 4,
+    timeIndex: 2,
+    gender: 'male',
+    useTrueSolarTime: true,
+    birthHour: 3,
+    birthMinute: 15,
+    birthLongitude: 130.37,
+    birthPlace: '黑龙江佳木斯',
+  });
+  assert.equal(ganZhi(r.pillars.year), '甲戌');
+  assert.equal(ganZhi(r.pillars.month), '乙亥');
+  assert.equal(ganZhi(r.pillars.day), '甲子');
+  assert.equal(ganZhi(r.pillars.hour), '丙寅');
+  // 真太阳时校正约 +50 分钟,仍在寅时
+  assert.equal(r.timing?.enabled, true);
+  assert.equal(r.timing?.correctedTime.hour, 4);
+  // 正常盘不应产生边界预警噪音
+  assert.deepEqual(r.warnings, []);
+  // 甲木亥月调候:火为第一喜用
+  assert.equal(r.analysis.usefulGod.primaryFavorableWuxing, '火');
+});
+
+test('回归:日支坐印计入帮扶(甲子日,upstream #27)', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 1994,
+    month: 12,
+    day: 4,
+    timeIndex: 2,
+    gender: 'male',
+  });
+  // 帮扶 = 年甲(比)+月乙(劫)+月支亥(印)+日支子(印) = 4
+  assert.equal(r.analysis.dayMasterStrength.details.supportStrength, 4);
+});
+
+test('立春边界:2024-02-04 16:27 立春,前后年柱月柱翻转', () => {
+  const before = baziCalculator.calculateBazi({
+    year: 2024,
+    month: 2,
+    day: 4,
+    timeIndex: 5, // 巳时 09-11
+    gender: 'male',
+  });
+  assert.equal(ganZhi(before.pillars.year), '癸卯');
+  assert.equal(ganZhi(before.pillars.month), '乙丑');
+
+  const after = baziCalculator.calculateBazi({
+    year: 2024,
+    month: 2,
+    day: 4,
+    timeIndex: 9, // 酉时 17-19
+    gender: 'male',
+  });
+  assert.equal(ganZhi(after.pillars.year), '甲辰');
+  assert.equal(ganZhi(after.pillars.month), '丙寅');
+});
+
+test('节气换月:2024-03-05 10:23 惊蛰,前后月柱翻转', () => {
+  const before = baziCalculator.calculateBazi({
+    year: 2024,
+    month: 3,
+    day: 5,
+    timeIndex: 5, // 巳时代表时刻 09:00,在惊蛰前
+    gender: 'male',
+  });
+  assert.equal(ganZhi(before.pillars.month), '丙寅');
+
+  const after = baziCalculator.calculateBazi({
+    year: 2024,
+    month: 3,
+    day: 5,
+    timeIndex: 6, // 午时代表时刻 11:00,在惊蛰后
+    gender: 'male',
+  });
+  assert.equal(ganZhi(after.pillars.month), '丁卯');
+});
+
+test('晚子时:23:00 后日柱按子初换日(本引擎流派)', () => {
+  // 2024-06-15 为庚戌日,次日辛亥
+  const r = baziCalculator.calculateBazi({
+    year: 2024,
+    month: 6,
+    day: 15,
+    timeIndex: 12, // 晚子时 23:00-24:00
+    gender: 'male',
+  });
+  assert.equal(ganZhi(r.pillars.day), '辛亥');
+  assert.equal(ganZhi(r.pillars.hour), '戊子');
+});
+
+test('真太阳时跨日:喀什 2020-08-01 00:40 → 日柱退回前一日乙亥', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 2020,
+    month: 8,
+    day: 1,
+    timeIndex: 0,
+    gender: 'male',
+    useTrueSolarTime: true,
+    birthHour: 0,
+    birthMinute: 40,
+    birthLongitude: 75.98,
+    birthPlace: '新疆喀什',
+  });
+  assert.equal(ganZhi(r.pillars.day), '乙亥');
+  assert.equal(ganZhi(r.pillars.hour), '丁亥');
+  assert.equal(r.timing?.correctedTime.day, 31);
+});
+
+test('夏令时:1988-07-15 12:00 北京(钟表) → 自动回拨 60 分钟,时柱巳时', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 1988,
+    month: 7,
+    day: 15,
+    timeIndex: 6,
+    gender: 'male',
+    useTrueSolarTime: true,
+    birthHour: 12,
+    birthMinute: 0,
+    birthLongitude: 116.4,
+    birthPlace: '北京',
+  });
+  assert.equal(r.timing?.dstCorrectionMinutes, -60);
+  // 12:00 钟表 → 11:00 标准 → 经度-14.4min + 均时差≈-6min → 约 10:40,巳时
+  assert.equal(r.pillars.hour.zhi, '巳');
+  assert.ok(r.warnings.some((w) => w.includes('夏令时')));
+});
+
+test('夏令时:applyChinaDst=false 时不校正,时柱午时', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 1988,
+    month: 7,
+    day: 15,
+    timeIndex: 6,
+    gender: 'male',
+    useTrueSolarTime: true,
+    birthHour: 12,
+    birthMinute: 0,
+    birthLongitude: 116.4,
+    applyChinaDst: false,
+  });
+  assert.equal(r.timing?.dstCorrectionMinutes, undefined);
+  // 12:00 → 经度-14.4min + 均时差≈-6min → 约 11:40,午时
+  assert.equal(r.pillars.hour.zhi, '午');
+  assert.ok(!r.warnings.some((w) => w.includes('夏令时')));
+});
+
+test('夏令时:仅时辰精度时只提示不校正', () => {
+  const r = baziCalculator.calculateBazi({
+    year: 1988,
+    month: 7,
+    day: 15,
+    timeIndex: 6,
+    gender: 'male',
+  });
+  assert.ok(r.warnings.some((w) => w.includes('夏令时')));
+});
+
+test('夏令时区间函数:边界与非夏令时年份', () => {
+  // 区间内
+  assert.equal(checkChinaDst(1988, 7, 15, 12).inDst, true);
+  // 1988 区间外(4月10日 03:00 起)
+  assert.equal(checkChinaDst(1988, 4, 9, 12).inDst, false);
+  assert.equal(checkChinaDst(1988, 4, 10, 3).inDst, true);
+  // 结束日 02:00 后恢复标准时
+  assert.equal(checkChinaDst(1988, 9, 11, 2).inDst, false);
+  // 结束日 01:30 为重复时段
+  const amb = checkChinaDst(1988, 9, 11, 1, 30);
+  assert.equal(amb.inDst, true);
+  assert.equal(amb.ambiguous, true);
+  // 开始日 02:30 为不存在时段
+  const gap = checkChinaDst(1988, 4, 10, 2, 30);
+  assert.equal(gap.nonexistent, true);
+  // 非夏令时年份
+  assert.equal(checkChinaDst(1994, 7, 15, 12).inDst, false);
+  assert.equal(isDateInChinaDstRange(1994, 7, 15), false);
+  assert.equal(isDateInChinaDstRange(1990, 6, 1), true);
+});
+
+test('边界预警:距立春 1 分钟内提示年柱月柱两可', () => {
+  // 2024 立春 = 2024-02-04 16:27:07
+  const warnings = checkJieqiBoundary({
+    year: 2024,
+    month: 2,
+    day: 4,
+    hour: 16,
+    minute: 26,
+  });
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes('立春'));
+  assert.ok(warnings[0].includes('年柱'));
+});
+
+test('边界预警:距时辰边界 1 分钟内提示时柱两可', () => {
+  const warnings = checkShichenBoundary({
+    year: 2024,
+    month: 6,
+    day: 15,
+    hour: 14,
+    minute: 59,
+  });
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes('未时'));
+  assert.ok(warnings[0].includes('申时'));
+});
+
+test('边界预警:23:00 换日线额外提示流派差异', () => {
+  const warnings = checkShichenBoundary({
+    year: 2024,
+    month: 6,
+    day: 15,
+    hour: 22,
+    minute: 59,
+  });
+  assert.equal(warnings.length, 2);
+  assert.ok(warnings[1].includes('晚子时'));
+});
+
+test('边界预警:远离边界时不产生预警', () => {
+  assert.deepEqual(
+    checkJieqiBoundary({ year: 2024, month: 6, day: 15, hour: 12, minute: 0 }),
+    [],
+  );
+  assert.deepEqual(
+    checkShichenBoundary({ year: 2024, month: 6, day: 15, hour: 12, minute: 0 }),
+    [],
+  );
+});


### PR DESCRIPTION
## 内容

### 1. 中国夏令时自动校正(`chinaDst.ts`)
- 1986-1991 六段精确起止区间表(1986 年自 5 月 4 日起,其余年份 4 月中旬至 9 月中旬,均为 02:00 切换)
- 真太阳时模式(有精确时分)自动回拨 60 分钟排盘,可用 `applyChinaDst: false` 关闭
- 结束日 01:00-02:00 重复时段、开始日 02:00-03:00 跳变时段输出专门预警
- 仅时辰精度输入时只提示不校正(无法安全 -1 小时)

### 2. 排盘边界预警(`paipanWarnings.ts`)
- 出生时刻距节气交接(十二节)±3 分钟内:提示年柱/月柱两可,并给出两种候选
- 距时辰边界 ±3 分钟内:提示时柱两可
- 23:00 换日线附近:额外提示早晚子时流派差异
- `BaziChartResult` 新增 `warnings` 字段,`formatBaziForPrompt` 输出【排盘预警】段落,AI 解读可感知

### 3. 金标准边界测试(`tests/paipan-boundary.test.ts`,14 例)
- 立春换年、惊蛰换月(分钟级)、晚子时换日、真太阳时跨日(喀什 -182 分钟)、夏令时校正各口径
- 日支坐印帮扶回归测试(锁定 #27 修复行为)
- 全部金标准四柱已与 lunar-javascript 独立实现交叉验证一致

## 动机

1986-1991 出生用户的钟表时间普遍比北京标准时快 1 小时,不校正会系统性错排时柱(约 1/12 概率连带日柱);节气/时辰边界出生的盘"两可"而引擎静默择一,解读层无从知晓。这两类都是排盘正确性问题,PR 让引擎显式处理并把不确定性透出。

## 测试

- 新增 14 例全绿;既有测试套件(781 例)无回归
- 不改变任何默认排盘行为(夏令时校正仅影响 1986-1991 精确时分输入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)