### PR TITLE
修正 Pages 运行时配置路由

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -3,8 +3,10 @@ import { getAiRuntimeConfigScript, type AiRuntimeEnv } from '../src/lib/ai/runti
 type PagesContext = {
   request: Request;
   env?: AiRuntimeEnv;
+  next: () => Response | Promise<Response>;
 };
 
+const RUNTIME_CONFIG_PATH = '/mingyu-runtime-config.js';
 const SCRIPT_HEADERS = {
   'Content-Type': 'text/javascript; charset=utf-8',
   'Cache-Control': 'no-store',
@@ -12,6 +14,11 @@ const SCRIPT_HEADERS = {
 };
 
 export function onRequest(context: PagesContext) {
+  const url = new URL(context.request.url);
+  if (url.pathname !== RUNTIME_CONFIG_PATH) {
+    return context.next();
+  }
+
   const method = context.request.method.toUpperCase();
 
   if (method === 'OPTIONS') {

--- a/tests/ai-config.test.ts
+++ b/tests/ai-config.test.ts
@@ -8,7 +8,7 @@ import {
   isServerDefaultAiEnabled,
 } from '../src/lib/ai/settings';
 import { getAiRuntimeConfig, getAiRuntimeConfigScript } from '../src/lib/ai/runtime-config';
-import { onRequest as handleRuntimeConfigRequest } from '../functions/mingyu-runtime-config.js';
+import { onRequest as handleRuntimeConfigRequest } from '../functions/_middleware';
 
 type RuntimeConfigGlobal = typeof globalThis & {
   __MINGYU_RUNTIME_CONFIG__?: {
@@ -84,8 +84,9 @@ test('运行时 AI 配置脚本可被页面直接加载', () => {
 });
 
 test('Pages 运行时配置入口返回不缓存脚本', async () => {
-  const response = handleRuntimeConfigRequest({
+  const response = await handleRuntimeConfigRequest({
     request: new Request('https://aov.cc/mingyu-runtime-config.js'),
+    next: () => new Response('next'),
     env: {
       AI_API_KEY: 'test-key',
       AI_BUILTIN_ENABLED: 'true',
@@ -100,6 +101,15 @@ test('Pages 运行时配置入口返回不缓存脚本', async () => {
     await response.text(),
     'window.__MINGYU_RUNTIME_CONFIG__ = {"aiBuiltinEnabled":true,"aiDefaultEnabled":false,"aiProviderName":"DeepSeek"};\n',
   );
+});
+
+test('Pages middleware 不拦截其他路径', async () => {
+  const response = await handleRuntimeConfigRequest({
+    request: new Request('https://aov.cc/api/v1/manifest'),
+    next: () => new Response('next'),
+  });
+
+  assert.equal(await response.text(), 'next');
 });
 
 test('主动选择内置 AI 时不受默认关闭影响', async (t) => {


### PR DESCRIPTION
## 修改内容

- 将 \/mingyu-runtime-config.js\ 的 Pages 入口从双扩展名函数文件改为根级 middleware。
- middleware 只处理运行时配置脚本，其他路径继续交给原有静态资源或 API 流程。
- 增加测试确认配置脚本不缓存，且 middleware 不拦截普通路径。

## 验证结果

- \pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ai-config.test.ts\ 通过。
- \
px tsc --noEmit\ 通过。
- \
px wrangler pages functions build functions --outfile .wrangler-pages-functions-test.mjs\ 通过。
- \pnpm test\ 通过，共 975 条。
- \pnpm run test:e2e\ 通过，共 19 条。
- \pnpm run prompt:audit\ 通过。
- \pnpm run build\ 通过。

## 风险说明

- 这次只调整 Pages Functions 路由入口，不改业务算法和数据。