### PR TITLE
修复 Docker 自部署入口行为不一致

### DIFF
--- a/server/docker-server.ts
+++ b/server/docker-server.ts
@@ -4,7 +4,7 @@ import { stat } from 'node:fs/promises';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import { handlePublicApiRequest, isPublicApiRequestPath } from '../src/lib/public-api/handler';
 import { getPublicApiManifestForRequest } from '../src/lib/public-api/metadata';
 import type { AiEnv } from '../src/lib/ai/proxy';
 import { getAiRuntimeConfigScript } from '../src/lib/ai/runtime-config';
@@ -20,6 +20,11 @@ const projectRoot = path.resolve(__dirname, '..');
 const distDir = path.resolve(projectRoot, 'dist');
 const port = Number(process.env.PORT || 3000);
 const host = process.env.HOST || '0.0.0.0';
+const RUNTIME_CONFIG_PATH = '/mingyu-runtime-config.js';
+const RUNTIME_CONFIG_HEADERS = {
+  'Cache-Control': 'no-store',
+  Allow: 'GET,HEAD,OPTIONS',
+};
 
 const mimeTypes: Record<string, string> = {
   '.css': 'text/css; charset=utf-8',
@@ -178,15 +183,24 @@ async function handleStaticRequest(request: IncomingMessage, response: ServerRes
     return;
   }
 
-  if (url.pathname === '/mingyu-runtime-config.js') {
+  if (url.pathname === RUNTIME_CONFIG_PATH) {
+    const method = (request.method || 'GET').toUpperCase();
+    if (method === 'OPTIONS') {
+      sendText(response, 204, '', 'text/javascript; charset=utf-8', RUNTIME_CONFIG_HEADERS);
+      return;
+    }
+
+    if (method !== 'GET' && method !== 'HEAD') {
+      sendText(response, 405, '方法不支持。', 'text/plain; charset=utf-8', RUNTIME_CONFIG_HEADERS);
+      return;
+    }
+
     sendText(
       response,
       200,
-      getAiRuntimeConfigScript(process.env),
+      method === 'HEAD' ? '' : getAiRuntimeConfigScript(process.env),
       'text/javascript; charset=utf-8',
-      {
-        'Cache-Control': 'no-store',
-      },
+      RUNTIME_CONFIG_HEADERS,
     );
     return;
   }
@@ -216,7 +230,7 @@ const server = createServer((request, response) => {
   void (async () => {
     const url = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`);
 
-    if (url.pathname.startsWith('/api/v1/')) {
+    if (isPublicApiRequestPath(url.pathname)) {
       await handleApiRequest(request, response, url);
       return;
     }

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -123,6 +123,12 @@ const JSON_HEADERS = {
   'Content-Type': 'application/json; charset=utf-8',
 };
 
+export const PUBLIC_API_BASE_PATH = `/api/${API_VERSION}`;
+
+export function isPublicApiRequestPath(pathname: string) {
+  return pathname === PUBLIC_API_BASE_PATH || pathname.startsWith(`${PUBLIC_API_BASE_PATH}/`);
+}
+
 const DIVINATION_METHODS = [
   'liuyao',
   'meihua',
@@ -576,10 +582,10 @@ export function getPublicApiOpenApiDocument(
 }
 
 export function normalizeApiPath(pathname: string) {
-  return pathname
-    .replace(/^\/api\/v1\/?/, '')
-    .split('/')
-    .filter(Boolean);
+  const path = isPublicApiRequestPath(pathname)
+    ? pathname.slice(PUBLIC_API_BASE_PATH.length)
+    : pathname;
+  return path.replace(/^\/+/, '').split('/').filter(Boolean);
 }
 
 export async function handlePublicApiRequest(request: Request, segments?: string[], env?: AiEnv) {

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import { handlePublicApiRequest, isPublicApiRequestPath } from '../src/lib/public-api/handler';
 import { onRequest as handleWellKnownApiRequest } from '../functions/.well-known/[[path]]';
 import { buildZiweiChartInput, calculateFullZiweiChart } from '../src/lib/full-chart-engine/ziwei';
 import {
@@ -48,6 +48,20 @@ test('公开 API 健康检查应返回统一成功结构', async () => {
   assert.equal(body.ok, true);
   assert.equal(body.data.status, 'ok');
   assert.equal(body.meta.service, 'aov.cc');
+});
+
+test('公开 API 基础路径本身应返回健康检查', async () => {
+  const request = new Request('https://example.pages.dev/api/v1');
+  const response = await handlePublicApiRequest(request);
+  const body = await response.json();
+
+  assert.equal(isPublicApiRequestPath('/api/v1'), true);
+  assert.equal(isPublicApiRequestPath('/api/v1/manifest'), true);
+  assert.equal(isPublicApiRequestPath('/api/v10'), false);
+  assert.equal(response.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.data.status, 'ok');
+  assert.equal(body.meta.service, 'example.pages.dev');
 });
 
 test('公开 API OPTIONS 应返回 CORS 预检响应', async () => {


### PR DESCRIPTION
## 修改内容
- 抽出公开 API 基础路径判断，避免 /api/v1 与 /api/v1/ 行为不一致。
- 修复 Docker/Node 自部署入口，使 /api/v1 能返回健康检查而不是落到前端页面。
- 让 Docker/Node 的 /mingyu-runtime-config.js 与 Cloudflare Pages 一样支持 HEAD、OPTIONS，并拒绝非 GET/HEAD/OPTIONS 方法。
- 补充公开 API 基础路径测试，避免相似路径 /api/v10 被误判。

## 验证
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/public-api.test.ts tests/ai-config.test.ts
- git diff --check
- 本地启动 Docker/Node 入口验证 /api/v1、/mingyu-runtime-config.js HEAD/OPTIONS/POST
- pnpm test
- pnpm run lint
- pnpm run build

## 风险
- 改动只影响 Docker/Node 自部署入口和共享路径判断；Cloudflare Pages 的域名绑定方式不变。