### PR TITLE
修复移动端底部工具遮挡

### DIFF
--- a/src/pages/InputPage.tsx
+++ b/src/pages/InputPage.tsx
@@ -1,4 +1,12 @@
-import { lazy, Suspense, useEffect, useRef, useState, useTransition } from 'react';
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+  type CSSProperties,
+} from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { SegmentedControl } from '@/components/SegmentedControl';
 import { PrivacyHint } from '@/components/PrivacyHint';
@@ -41,6 +49,7 @@ export function InputPage() {
   const mainContentRef = useRef<HTMLDivElement | null>(null);
   const tutorialEntryRef = useRef<HTMLDivElement | null>(null);
   const [tutorialEntryPinned, setTutorialEntryPinned] = useState(false);
+  const [bottomToolsHeight, setBottomToolsHeight] = useState(0);
 
   const birthPlace = useBirthPlace({ form, setForm });
 
@@ -154,6 +163,9 @@ export function InputPage() {
       }
       const mainContentHeight = mainContentNode.getBoundingClientRect().height;
       const tutorialEntryHeight = tutorialEntryNode.getBoundingClientRect().height;
+      setBottomToolsHeight((current) =>
+        current === Math.ceil(tutorialEntryHeight) ? current : Math.ceil(tutorialEntryHeight),
+      );
       const shouldPin = mainContentHeight + tutorialEntryHeight + 56 <= window.innerHeight;
       setTutorialEntryPinned((current) => (current === shouldPin ? current : shouldPin));
     }
@@ -397,6 +409,7 @@ export function InputPage() {
   return (
     <div
       className={`page-shell input-page-shell ${tutorialEntryPinned ? 'has-floating-tutorial-entry' : ''}`}
+      style={{ '--input-bottom-tools-height': `${bottomToolsHeight}px` } as CSSProperties}
     >
       <div className="bazi-view-container">
         <div className="input-page-main-content" ref={mainContentRef}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1913,11 +1913,15 @@ select {
 }
 
 .input-page-shell {
+  --input-bottom-tools-height: 0px;
+  --input-bottom-tools-gap: max(28px, env(safe-area-inset-bottom, 0px) + 20px);
   padding-top: 12px;
 }
 
 .input-page-shell.has-floating-tutorial-entry {
-  padding-bottom: 132px;
+  padding-bottom: calc(
+    var(--input-bottom-tools-height, 104px) + var(--input-bottom-tools-gap, 28px)
+  );
 }
 
 .input-page-main-content {
@@ -5631,7 +5635,7 @@ div.form-actions.page-submit-actions {
   }
 
   .input-page-shell {
-    padding: 10px 6px 132px;
+    padding: 10px 6px 16px;
   }
 
   .tutorial-entry-button {
@@ -5709,11 +5713,11 @@ div.form-actions.page-submit-actions {
   }
 
   .input-page-shell.has-floating-tutorial-entry {
-    padding-bottom: 132px;
+    padding-bottom: calc(
+      var(--input-bottom-tools-height, 112px) + var(--input-bottom-tools-gap, 28px)
+    );
   }
 
-  .input-page-bottom-tools,
-  .input-page-bottom-tools.is-inline,
   .input-page-bottom-tools.is-floating {
     position: fixed;
     left: 50%;
@@ -5722,6 +5726,13 @@ div.form-actions.page-submit-actions {
     bottom: max(8px, env(safe-area-inset-bottom, 0px) + 8px);
     z-index: 20;
     pointer-events: none;
+  }
+
+  .input-page-bottom-tools.is-inline {
+    position: static;
+    transform: none;
+    width: 100%;
+    pointer-events: auto;
   }
 
   .donation-entry-button {
@@ -6412,6 +6423,12 @@ div.form-actions.page-submit-actions {
 
   .page-shell {
     padding: 10px 6px 16px;
+  }
+
+  .input-page-shell.has-floating-tutorial-entry {
+    padding-bottom: calc(
+      var(--input-bottom-tools-height, 112px) + var(--input-bottom-tools-gap, 28px)
+    );
   }
 
   .result-summary-grid,


### PR DESCRIPTION
## 修改内容
- 根据底部工具实际高度为固定状态动态预留空间。
- 移动端长页面不再强制固定底部工具，避免合盘、占卜、择日等页面遮挡输入项。
- 保留短页面底部工具贴底显示效果。

## 验证结果
- 已通过 pnpm run lint。
- 已通过 pnpm build。
- 已用移动端视口验证合盘、占卜、择日页面底部工具不再遮挡内容。

## 风险说明
- 改动范围集中在输入页底部工具布局，风险较低。