### PR TITLE
发布 mingyu-core 0.1.16 并清理旧构建产物

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingyu-core",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Mingyu core algorithms: traditional Chinese metaphysics (八字Bazi, 紫微斗数Ziwei, 奇门遁甲Qimen, 六爻Liuyao, 六壬Liuren, 梅花易数Meihua, and more)",
   "type": "module",
   "main": "./dist/index.js",
@@ -146,7 +146,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.json && node scripts/add-esm-extensions.mjs",
+    "build": "node scripts/clean-dist.mjs && tsc --build tsconfig.json --force && node scripts/add-esm-extensions.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "test": "node scripts/run-core-tests.mjs"

--- a/packages/core/scripts/clean-dist.mjs
+++ b/packages/core/scripts/clean-dist.mjs
@@ -1,0 +1,6 @@
+import { rmSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const distDirectory = fileURLToPath(new URL('../dist', import.meta.url));
+
+rmSync(distDirectory, { recursive: true, force: true });


### PR DESCRIPTION
## 修改内容

- 将 mingyu-core 从 0.1.15 升级到 0.1.16
- 核心包构建前自动清理 dist，并强制重新生成全部产物
- 防止已删除的铁板神数等历史文件残留在 npm 发布包中

## 验证结果

- mingyu-core 相关测试 1031 项通过
- 核心包构建通过
- npm 打包干运行确认版本为 0.1.16
- 发布包中铁板残留 0 个，意外源码、本地配置和 node_modules 文件 0 个
- Prettier 和 git diff 检查通过

## 发布计划

PR 检查通过并合并后，从最新 main 发布 mingyu-core@0.1.16，并验证 npm latest 标签。