### PR TITLE
新增七政四余与八宅专业盘面并统一提示词入口

### DIFF
--- a/src/components/MetaphysicsPanel/index.tsx
+++ b/src/components/MetaphysicsPanel/index.tsx
@@ -1,14 +1,17 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { analyzeBaZhai } from '@core/ba_zhai';
-import { getSitFacingFromFacingDegree, type SitFacingPosition } from '@core/direction';
-import { generateQizheng } from '@core/qi_zheng';
-import { buildMetaphysicsPrompt } from '@/lib/metaphysics-prompt';
+import { useEffect, useMemo, useState } from 'react';
+import type { BaZhaiResult } from '@core/ba_zhai';
+import {
+  calculateBazhaiBaseChart,
+  calculateBazhaiChart,
+  resolveBazhaiDoorDirection,
+  type BazhaiMeasurement,
+} from '@/lib/bazhai-chart';
 
-export type ChartExtensionMethod = 'bazhai' | 'qizheng';
+export type { BazhaiMeasurement } from '@/lib/bazhai-chart';
 
 interface MetaphysicsPanelProps {
-  method: ChartExtensionMethod;
-  birthData?: {
+  method: 'bazhai';
+  birthData: {
     year: number;
     month: number;
     day: number;
@@ -20,481 +23,334 @@ interface MetaphysicsPanelProps {
     timezone?: number;
   };
   embedded?: boolean;
+  initialFacingDegree?: string;
+  onDirectionDegreeChange?: (value: string) => void;
+  onResultChange?: (result: BaZhaiResult, measurement: BazhaiMeasurement | null) => void;
 }
 
-const currentDate = new Date();
+const DIRECTIONS = ['北', '东北', '东', '东南', '南', '西南', '西', '西北'];
 
-function readInteger(value: string, label: string, min: number, max: number) {
-  const number = Number(value);
-  if (!Number.isInteger(number) || number < min || number > max) {
-    throw new Error(`${label}应填写 ${min} 至 ${max} 之间的整数。`);
-  }
-  return number;
+function BaZhaiCompass({
+  result,
+  measurement,
+}: {
+  result: BaZhaiResult;
+  measurement: BazhaiMeasurement | null;
+}) {
+  const palaces = result.housePalace ?? result.mingPalace;
+  const palaceByDirection = new Map(palaces.map((item) => [item.direction, item]));
+  return (
+    <svg
+      className="bazhai-compass-svg"
+      viewBox="0 0 400 400"
+      role="img"
+      aria-label="八宅八方专业盘面"
+    >
+      <circle cx="200" cy="200" r="184" className="bazhai-ring" />
+      <circle cx="200" cy="200" r="128" className="bazhai-ring" />
+      <circle cx="200" cy="200" r="67" className="bazhai-ring bazhai-ring-core" />
+      {DIRECTIONS.map((direction, index) => {
+        const angle = ((index * 45 - 90) * Math.PI) / 180;
+        const x = 200 + Math.cos(angle) * 153;
+        const y = 200 + Math.sin(angle) * 153;
+        const palace = palaceByDirection.get(direction);
+        const boundaryAngle = ((index * 45 - 22.5 - 90) * Math.PI) / 180;
+        return (
+          <g key={direction}>
+            <line
+              x1="200"
+              y1="200"
+              x2={200 + Math.cos(boundaryAngle) * 184}
+              y2={200 + Math.sin(boundaryAngle) * 184}
+              className="bazhai-sector-line"
+            />
+            <text
+              x={x}
+              y={y}
+              className={`bazhai-direction-label ${palace?.luck === '吉' ? 'is-lucky' : 'is-unlucky'}`}
+            >
+              <tspan>{direction}</tspan>
+              <tspan x={x} dy="15">
+                {palace?.label ?? '—'}
+              </tspan>
+              <tspan x={x} dy="13">
+                {palace?.gua ?? ''}宫
+              </tspan>
+            </text>
+          </g>
+        );
+      })}
+      {measurement ? (
+        <g transform={`rotate(${measurement.measuredDegree - 90} 200 200)`}>
+          <path d="M 200 20 L 192 42 L 208 42 Z" className="bazhai-facing-arrow" />
+          <line x1="200" y1="42" x2="200" y2="72" className="bazhai-facing-line" />
+        </g>
+      ) : null}
+      <text x="200" y="184" className="bazhai-core-title">
+        {result.houseGua ? `${result.houseGua}宅` : `${result.mingGua}命`}
+      </text>
+      <text x="200" y="205" className="bazhai-core-subtitle">
+        {measurement
+          ? `${measurement.sitMountain}山${measurement.facingMountain}向`
+          : result.mingGroup}
+      </text>
+      <text x="200" y="224" className="bazhai-core-subtitle">
+        {measurement ? `命卦 ${result.mingGua}` : '个人八方盘'}
+      </text>
+    </svg>
+  );
 }
 
-function readNumber(value: string, label: string, min: number, max: number) {
-  const number = Number(value);
-  if (!value.trim() || !Number.isFinite(number) || number < min || number > max) {
-    throw new Error(`${label}应填写 ${min} 至 ${max} 之间的数字。`);
-  }
-  return number;
-}
-
-function createSolarDate(year: number, month: number, day: number, hour: number, minute: number) {
-  const date = new Date(year, month - 1, day, hour, minute, 0);
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day ||
-    date.getHours() !== hour ||
-    date.getMinutes() !== minute
-  ) {
-    throw new Error('日期或时间无效，请检查后重试。');
-  }
-  return date;
-}
-
-function readDirectionPreview(value: string): {
-  position: SitFacingPosition | null;
-  error: string;
-} {
-  if (!value.trim()) {
-    return { position: null, error: '请填写房屋朝向度数。' };
-  }
-
-  try {
-    return {
-      position: getSitFacingFromFacingDegree(readNumber(value, '房屋朝向度数', 0, 360)),
-      error: '',
-    };
-  } catch (error) {
-    return {
-      position: null,
-      error: error instanceof Error ? error.message : '房屋朝向度数无效。',
-    };
-  }
-}
-
-export function MetaphysicsPanel({ method, birthData, embedded = false }: MetaphysicsPanelProps) {
-  const [question, setQuestion] = useState('');
-  const [currentSituation, setCurrentSituation] = useState('');
-  const [currentState, setCurrentState] = useState('');
-  const [knownFacts, setKnownFacts] = useState('');
-  const [desiredOutcome, setDesiredOutcome] = useState('');
-  const [constraints, setConstraints] = useState('');
-  const [birthYear, setBirthYear] = useState(String(birthData?.year ?? 1990));
-  const [birthMonth, setBirthMonth] = useState(String(birthData?.month ?? 6));
-  const [birthDay, setBirthDay] = useState(String(birthData?.day ?? 15));
-  const [gender, setGender] = useState<'male' | 'female'>(birthData?.gender ?? 'male');
-  const [facingDegree, setFacingDegree] = useState('180');
-  const [year, setYear] = useState(String(birthData?.year ?? currentDate.getFullYear()));
-  const [month, setMonth] = useState(String(birthData?.month ?? currentDate.getMonth() + 1));
-  const [day, setDay] = useState(String(birthData?.day ?? currentDate.getDate()));
-  const [hour, setHour] = useState(String(birthData?.hour ?? currentDate.getHours()));
-  const [minute, setMinute] = useState(String(birthData?.minute ?? currentDate.getMinutes()));
-  const [latitude, setLatitude] = useState(String(birthData?.latitude ?? 39.9042));
-  const [longitude, setLongitude] = useState(String(birthData?.longitude ?? 116.4074));
-  const [timezone, setTimezone] = useState(String(birthData?.timezone ?? 8));
-  const [result, setResult] = useState<Record<string, unknown> | null>(null);
-  const [prompt, setPrompt] = useState('');
+export function MetaphysicsPanel({
+  birthData,
+  initialFacingDegree = '',
+  onDirectionDegreeChange,
+  onResultChange,
+}: MetaphysicsPanelProps) {
+  const baseResult = useMemo(() => calculateBazhaiBaseChart(birthData), [birthData]);
+  const [facingDegree, setFacingDegree] = useState(initialFacingDegree);
+  const [result, setResult] = useState<BaZhaiResult>(baseResult);
+  const [measurement, setMeasurement] = useState<BazhaiMeasurement | null>(null);
   const [error, setError] = useState('');
-  const [copyText, setCopyText] = useState('复制提示词');
-  const didAutoGenerate = useRef(false);
 
-  const directionPreview = useMemo(() => readDirectionPreview(facingDegree), [facingDegree]);
-
+  const directionPreview = useMemo(() => {
+    if (!facingDegree.trim()) return { position: null, error: '' };
+    const degree = Number(facingDegree);
+    try {
+      return { position: resolveBazhaiDoorDirection(degree), error: '' };
+    } catch (currentError) {
+      return {
+        position: null,
+        error: currentError instanceof Error ? currentError.message : '角度无效。',
+      };
+    }
+  }, [facingDegree]);
   const boundaryMessage = useMemo(() => {
     const facing = directionPreview.position?.facing;
     if (!facing?.isBoundary || !facing.boundaryMountains) return '';
-    return `当前度数正好位于${facing.boundaryMountains[0]}向与${facing.boundaryMountains[1]}向的分界线，请重新测量并填写稍偏离分界线的实际度数。`;
+    return `当前度数位于${facing.boundaryMountains[0]}向与${facing.boundaryMountains[1]}向的分界线，请重新测量并填写稍偏离分界线的度数。`;
   }, [directionPreview]);
 
-  const resultText = useMemo(() => {
-    if (!result) return '';
-    const display = { ...result };
-    delete display.prompt;
-    return JSON.stringify(display, null, 2);
-  }, [result]);
-
-  function generate() {
-    setError('');
-    setResult(null);
-    setPrompt('');
-    setCopyText('复制提示词');
-
-    try {
-      let nextResult: Record<string, unknown> & { prompt: string };
-      let measurement = '';
-
-      if (method === 'bazhai') {
-        if (!directionPreview.position) {
-          throw new Error(directionPreview.error);
-        }
-        if (directionPreview.position.facing.isBoundary) {
-          throw new Error(boundaryMessage);
-        }
-
-        const { facing, sit, label } = directionPreview.position;
-        measurement = `测量方式：站在屋内面向大门外。房屋朝向 ${facing.degree}° 为${facing.mountain}向；相反方向的坐山 ${sit.degree}° 为${sit.mountain}山，换算结果为${label}。`;
-        const bazhaiResult = analyzeBaZhai({
-          birthYear: readInteger(birthYear, '出生年份', 1900, 2100),
-          birthMonth: readInteger(birthMonth, '出生月份', 1, 12),
-          birthDay: readInteger(birthDay, '出生日期', 1, 31),
-          gender,
-          sitMountain: sit.mountain,
-        }) as unknown as Record<string, unknown> & { prompt: string };
-        nextResult = {
-          ...bazhaiResult,
-          directionMeasurement: {
-            method: '站在屋内面向大门外测量朝向',
-            facingDegree: facing.degree,
-            facingMountain: facing.mountain,
-            sitDegree: sit.degree,
-            sitMountain: sit.mountain,
-            label,
-          },
-        };
-      } else {
-        const targetYear = readInteger(year, '年份', 1900, 2200);
-        const targetMonth = readInteger(month, '月份', 1, 12);
-        const targetDay = readInteger(day, '日期', 1, 31);
-        const targetHour = readInteger(hour, '小时', 0, 23);
-        const targetMinute = readInteger(minute, '分钟', 0, 59);
-        createSolarDate(targetYear, targetMonth, targetDay, targetHour, targetMinute);
-
-        nextResult = generateQizheng({
-          year: targetYear,
-          month: targetMonth,
-          day: targetDay,
-          hour: targetHour,
-          minute: targetMinute,
-          latitude: readNumber(latitude, '纬度', -90, 90),
-          longitude: readNumber(longitude, '经度', -180, 180),
-          timezone: readNumber(timezone, '时区', -12, 14),
-        }) as unknown as Record<string, unknown> & { prompt: string };
-      }
-
-      setResult(nextResult);
-      setPrompt(
-        buildMetaphysicsPrompt(nextResult.prompt, question, {
-          measurement,
-          context: { currentSituation, currentState, knownFacts, desiredOutcome, constraints },
-        }),
-      );
-    } catch (currentError) {
-      setError(currentError instanceof Error ? currentError.message : '生成失败，请检查输入。');
-    }
-  }
-
   useEffect(() => {
-    if (!embedded || method !== 'qizheng' || !birthData || didAutoGenerate.current) return;
-    didAutoGenerate.current = true;
-    generate();
-    // 复用结果页已经校验过的出生资料，只在首次进入七政四余页时自动生成。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [birthData, embedded, method]);
-
-  async function copyPrompt() {
-    if (!prompt) return;
-    try {
-      await navigator.clipboard.writeText(prompt);
-      setCopyText('已复制');
-    } catch {
-      setCopyText('复制失败');
+    if (!facingDegree.trim()) {
+      setResult(baseResult);
+      setMeasurement(null);
+      setError('');
+      onResultChange?.(baseResult, null);
+      return;
     }
-  }
-
-  const title = method === 'bazhai' ? '八宅排盘' : '七政四余排盘';
-  const description =
-    method === 'bazhai'
-      ? '输入容易测量的房屋朝向度数，系统会自动换算坐山和二十四山。'
-      : '按出生时间、地点与时区生成七政四余、十二宫与神煞。';
+    if (directionPreview.error || boundaryMessage) {
+      setError(directionPreview.error || boundaryMessage);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      try {
+        const next = calculateBazhaiChart(birthData, Number(facingDegree));
+        setResult(next.result);
+        setMeasurement(next.measurement);
+        setError('');
+        onResultChange?.(next.result, next.measurement);
+      } catch (currentError) {
+        setError(currentError instanceof Error ? currentError.message : '住宅角度换算失败。');
+      }
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [
+    baseResult,
+    birthData,
+    boundaryMessage,
+    directionPreview.error,
+    facingDegree,
+    onResultChange,
+  ]);
 
   return (
     <div className="metaphysics-panel-shell">
-      <section className="person-section divination-form-card">
-        <div className="person-section-head">
-          <h2>{title}</h2>
-          <p>{description}</p>
+      <section className="result-showcase-card bazhai-showcase-card">
+        <div className="result-showcase-head">
+          <div>
+            <p className="result-section-kicker">八宅结果</p>
+            <h2>{measurement?.label ?? '个人八宅方位'}</h2>
+          </div>
+          <div className="result-chip-row">
+            <span className="result-chip">命卦 {result.mingGua}</span>
+            {result.houseGua ? (
+              <span className="result-chip">宅卦 {result.houseGua}</span>
+            ) : (
+              <span className="result-chip">待补住宅角度</span>
+            )}
+          </div>
         </div>
-
-        <div className="person-info-form">
-          {method === 'bazhai' ? (
-            <>
-              {!birthData ? (
-                <div className="form-row">
-                  <div className="form-item">
-                    <label htmlFor="metaphysics-birth-year">出生年份</label>
-                    <input
-                      id="metaphysics-birth-year"
-                      className="form-input"
-                      inputMode="numeric"
-                      value={birthYear}
-                      onChange={(event) => setBirthYear(event.target.value.replace(/[^\d]/g, ''))}
-                    />
-                  </div>
-                  <div className="form-item">
-                    <label htmlFor="metaphysics-gender">性别</label>
-                    <select
-                      id="metaphysics-gender"
-                      className="form-input"
-                      value={gender}
-                      onChange={(event) => setGender(event.target.value as 'male' | 'female')}
-                    >
-                      <option value="male">男</option>
-                      <option value="female">女</option>
-                    </select>
-                  </div>
-                  <div className="form-item">
-                    <label htmlFor="metaphysics-birth-month">出生月份</label>
-                    <input
-                      id="metaphysics-birth-month"
-                      className="form-input"
-                      inputMode="numeric"
-                      value={birthMonth}
-                      onChange={(event) => setBirthMonth(event.target.value.replace(/[^\d]/g, ''))}
-                    />
-                  </div>
-                  <div className="form-item">
-                    <label htmlFor="metaphysics-birth-day">出生日期</label>
-                    <input
-                      id="metaphysics-birth-day"
-                      className="form-input"
-                      inputMode="numeric"
-                      value={birthDay}
-                      onChange={(event) => setBirthDay(event.target.value.replace(/[^\d]/g, ''))}
-                    />
-                    <span className="birth-time-hint">
-                      用完整日期判断是否在立春前，避免命卦差一年。
-                    </span>
-                  </div>
+        <div className="result-summary-grid">
+          <div className="result-stat-card result-stat-card-accent">
+            <span>命卦</span>
+            <strong>{result.mingGua}</strong>
+            <small>{result.mingGroup}</small>
+          </div>
+          <div className="result-stat-card">
+            <span>宅卦</span>
+            <strong>{result.houseGua ?? '待补充'}</strong>
+            <small>{result.houseGroup ?? '填写角度后自动生成'}</small>
+          </div>
+          <div className="result-stat-card">
+            <span>命宅关系</span>
+            <strong>{measurement ? result.match : '待合参'}</strong>
+            <small>{measurement ? '结合实际动线取舍' : '个人八方信息已生成'}</small>
+          </div>
+          <div className="result-stat-card">
+            <span>住宅坐向</span>
+            <strong>
+              {measurement
+                ? `${measurement.sitMountain}山${measurement.facingMountain}向`
+                : '尚未测量'}
+            </strong>
+            <small>
+              {measurement ? `入户读数 ${measurement.measuredDegree}°` : '可在下方补充'}
+            </small>
+          </div>
+        </div>
+        <div className="bazhai-board-layout">
+          <div className="result-side-card astrolabe-chart-shell">
+            <div className="result-side-head">
+              <h3>{measurement ? '命宅八方盘' : '个人八方盘'}</h3>
+              <p>
+                {measurement
+                  ? '宅卦八方游年已生成，箭头指向从大门进入屋内的实测方向。'
+                  : '先按命卦显示个人四吉四凶方；补充住宅角度后自动切换为命宅合参。'}
+              </p>
+            </div>
+            <BaZhaiCompass result={result} measurement={measurement} />
+          </div>
+          <div className="bazhai-board-legend">
+            <div className="result-side-card">
+              <div className="result-side-head">
+                <h3>盘面说明</h3>
+              </div>
+              <div className="result-meta-lines">
+                <div>
+                  <span>出生资料</span>
+                  <strong>
+                    {birthData.year} 年 {birthData.month} 月 {birthData.day} 日 ·{' '}
+                    {birthData.gender === 'male' ? '男' : '女'}
+                  </strong>
+                </div>
+                <div>
+                  <span>命卦分组</span>
+                  <strong>
+                    {result.mingGua}命 · {result.mingGroup}
+                  </strong>
+                </div>
+                {measurement ? (
+                  <>
+                    <div>
+                      <span>大门朝向屋内</span>
+                      <strong>{measurement.measuredDegree}°</strong>
+                    </div>
+                    <div>
+                      <span>传统坐向</span>
+                      <strong>
+                        {measurement.sitDegree}° {measurement.sitMountain}山 ·{' '}
+                        {measurement.facingDegree}° {measurement.facingMountain}向
+                      </strong>
+                    </div>
+                    <div>
+                      <span>命宅配合</span>
+                      <strong>{result.match}</strong>
+                    </div>
+                  </>
+                ) : null}
+              </div>
+            </div>
+            <div className="result-side-card bazhai-direction-card">
+              <div className="result-side-head">
+                <h3>补充住宅角度</h3>
+                <p>可选；填写后自动保存并生成宅卦。</p>
+              </div>
+              <label className="form-item" htmlFor="metaphysics-facing-degree">
+                <span>从大门面向屋内的度数</span>
+                <input
+                  id="metaphysics-facing-degree"
+                  className="form-input"
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  max="360"
+                  step="0.1"
+                  value={facingDegree}
+                  placeholder="例如：0"
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setFacingDegree(value);
+                    onDirectionDegreeChange?.(value);
+                  }}
+                />
+                <small className="birth-time-hint">
+                  站在大门处面向屋内，用手机指南针连续测三次，填写接近的平均度数。
+                </small>
+              </label>
+              {error ? (
+                <div className="form-error-text">{error}</div>
+              ) : directionPreview.position ? (
+                <div className="metaphysics-direction-preview">
+                  <strong>{directionPreview.position.label}</strong>
+                  <span>
+                    坐山 {directionPreview.position.sit.degree}°{' '}
+                    {directionPreview.position.sit.mountain}山；传统朝向{' '}
+                    {directionPreview.position.facing.degree}°{' '}
+                    {directionPreview.position.facing.mountain}向。
+                  </span>
                 </div>
               ) : (
-                <div className="metaphysics-direction-preview" role="status">
-                  <strong>出生资料已沿用排盘输入</strong>
-                  <span>
-                    {birthYear} 年 {birthMonth} 月 {birthDay} 日，{gender === 'male' ? '男' : '女'}
-                    。
-                  </span>
+                <div className="metaphysics-direction-preview">
+                  <span>不填写也可查看个人命卦八方信息。</span>
                 </div>
               )}
-
-              <div className="form-row">
-                <div className="form-item">
-                  <label htmlFor="metaphysics-facing-degree">房屋朝向度数</label>
-                  <input
-                    id="metaphysics-facing-degree"
-                    className="form-input"
-                    type="number"
-                    inputMode="decimal"
-                    min="0"
-                    max="360"
-                    step="0.1"
-                    value={facingDegree}
-                    onChange={(event) => setFacingDegree(event.target.value)}
-                  />
-                  <span className="birth-time-hint">
-                    打开手机指南针，站在房屋中心附近面向大门外，远离冰箱、铁门等金属物，连续测三次并填写接近的平均度数。
-                  </span>
-                </div>
-              </div>
-
-              <div
-                className={`metaphysics-direction-preview ${boundaryMessage ? 'is-warning' : ''}`}
-                role={boundaryMessage || directionPreview.error ? 'alert' : 'status'}
-              >
-                {boundaryMessage ? (
-                  <strong>{boundaryMessage}</strong>
-                ) : directionPreview.position ? (
-                  <>
-                    <strong>{directionPreview.position.label}</strong>
-                    <span>
-                      朝向 {directionPreview.position.facing.degree}° 为
-                      {directionPreview.position.facing.mountain}向；坐山{' '}
-                      {directionPreview.position.sit.degree}° 为
-                      {directionPreview.position.sit.mountain}山。
-                    </span>
-                  </>
-                ) : (
-                  <span>{directionPreview.error}</span>
-                )}
-              </div>
-            </>
-          ) : birthData ? (
-            <div className="metaphysics-direction-preview" role="status">
-              <strong>已复用排盘出生资料并自动生成</strong>
-              <span>
-                {year} 年 {month} 月 {day} 日 {hour}:{minute.padStart(2, '0')}，经度 {longitude}
-                °，纬度 {latitude}°。
-              </span>
-            </div>
-          ) : (
-            <>
-              <div className="form-row metaphysics-date-row">
-                <div className="form-item">
-                  <label htmlFor="metaphysics-year">年份</label>
-                  <input
-                    id="metaphysics-year"
-                    className="form-input"
-                    inputMode="numeric"
-                    value={year}
-                    onChange={(event) => setYear(event.target.value.replace(/[^\d]/g, ''))}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-month">月份</label>
-                  <input
-                    id="metaphysics-month"
-                    className="form-input"
-                    inputMode="numeric"
-                    value={month}
-                    onChange={(event) => setMonth(event.target.value.replace(/[^\d]/g, ''))}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-day">日期</label>
-                  <input
-                    id="metaphysics-day"
-                    className="form-input"
-                    inputMode="numeric"
-                    value={day}
-                    onChange={(event) => setDay(event.target.value.replace(/[^\d]/g, ''))}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-hour">小时</label>
-                  <input
-                    id="metaphysics-hour"
-                    className="form-input"
-                    inputMode="numeric"
-                    value={hour}
-                    onChange={(event) => setHour(event.target.value.replace(/[^\d]/g, ''))}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-minute">分钟</label>
-                  <input
-                    id="metaphysics-minute"
-                    className="form-input"
-                    inputMode="numeric"
-                    value={minute}
-                    onChange={(event) => setMinute(event.target.value.replace(/[^\d]/g, ''))}
-                  />
-                </div>
-              </div>
-
-              <div className="form-row">
-                <div className="form-item">
-                  <label htmlFor="metaphysics-latitude">纬度</label>
-                  <input
-                    id="metaphysics-latitude"
-                    className="form-input"
-                    value={latitude}
-                    onChange={(event) => setLatitude(event.target.value)}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-longitude">经度</label>
-                  <input
-                    id="metaphysics-longitude"
-                    className="form-input"
-                    value={longitude}
-                    onChange={(event) => setLongitude(event.target.value)}
-                  />
-                </div>
-                <div className="form-item">
-                  <label htmlFor="metaphysics-timezone">时区</label>
-                  <input
-                    id="metaphysics-timezone"
-                    className="form-input"
-                    value={timezone}
-                    onChange={(event) => setTimezone(event.target.value)}
-                  />
-                </div>
-              </div>
-            </>
-          )}
-
-          <div className="form-row">
-            <div className="form-item metaphysics-question-field">
-              <label htmlFor="metaphysics-question">希望 AI 重点解读的问题（可选）</label>
-              <textarea
-                id="metaphysics-question"
-                rows={3}
-                className="form-input divination-textarea"
-                value={question}
-                placeholder="例如：请重点看今年适合主动推进什么，哪些风险需要回避？"
-                onChange={(event) => setQuestion(event.target.value)}
-              />
             </div>
           </div>
-          <details className="form-item divination-context-fields">
-            <summary>补充现实信息（可选，填写越具体越利于解读）</summary>
-            <div className="form-row">
-              {[
-                ['当前情况', currentSituation, setCurrentSituation, '正在发生什么、有哪些选择'],
-                ['当前状态', currentState, setCurrentState, '目前的进度、情绪或资源状态'],
-                ['已知事实', knownFacts, setKnownFacts, '已经确认的人、事、时间和结果'],
-                ['期望结果', desiredOutcome, setDesiredOutcome, '最希望实现的结果'],
-                ['现实限制', constraints, setConstraints, '时间、预算、地点或责任限制'],
-              ].map(([label, value, setter, placeholder]) => (
-                <div className="form-item" key={label as string}>
-                  <label>{label as string}</label>
-                  <textarea
-                    rows={2}
-                    className="form-input divination-textarea"
-                    value={value as string}
-                    placeholder={placeholder as string}
-                    onChange={(event) =>
-                      (setter as React.Dispatch<React.SetStateAction<string>>)(event.target.value)
-                    }
-                  />
-                </div>
+        </div>
+        <div className="bazhai-result-grid">
+          <div className="result-side-card">
+            <div className="result-side-head">
+              <h3>四吉方</h3>
+              <p>{measurement ? '当前宅卦可优先利用的方向。' : '个人命卦可优先利用的方向。'}</p>
+            </div>
+            <div className="result-tag-cloud">
+              {result.luckyDirections.map((item) => (
+                <span
+                  className="result-soft-tag result-soft-tag-strong"
+                  key={`${item.direction}-${item.label}`}
+                >
+                  {item.direction} · {item.label}
+                </span>
               ))}
             </div>
-          </details>
+          </div>
+          <div className="result-side-card">
+            <div className="result-side-head">
+              <h3>四凶方</h3>
+              <p>布置时需要谨慎权衡的方向。</p>
+            </div>
+            <div className="result-tag-cloud">
+              {result.unluckyDirections.map((item) => (
+                <span className="result-soft-tag" key={`${item.direction}-${item.label}`}>
+                  {item.direction} · {item.label}
+                </span>
+              ))}
+            </div>
+          </div>
         </div>
-
-        {error ? <div className="form-error-text global-form-error">{error}</div> : null}
-
-        <div className="form-actions page-submit-actions metaphysics-submit-actions">
-          <button
-            className="primary-button start-submit-button"
-            type="button"
-            onClick={generate}
-            disabled={method === 'bazhai' && Boolean(boundaryMessage)}
-          >
-            开始排盘
-          </button>
+        <div className="result-side-card">
+          <div className="result-side-head">
+            <h3>{measurement ? '命宅建议' : '基础说明'}</h3>
+          </div>
+          <p className="bazhai-advice">
+            {measurement
+              ? result.matchAdvice
+              : '当前先按个人命卦八宫查看方位取舍；补充住宅角度后，会进一步结合宅卦判断命宅是否相合。'}
+          </p>
+          <p className="bazhai-boundary-note">{result.birthYearBoundaryNote}</p>
         </div>
       </section>
-
-      {result ? (
-        <div className="workspace-grid divination-output-grid metaphysics-output-grid">
-          <section className="panel divination-result-panel">
-            <div className="panel-head">
-              <div>
-                <h2>排盘结果</h2>
-                <p>以下数据由本地算法生成，不会上传出生信息。</p>
-              </div>
-            </div>
-            <pre className="result-pre">{resultText}</pre>
-          </section>
-
-          <section className="panel panel-output divination-result-panel">
-            <div className="panel-head divination-prompt-head">
-              <div>
-                <h2>解读提示词</h2>
-                <p>复制整段后，可发送到常用 AI 继续分析。</p>
-              </div>
-              <button className="copy-button secondary-button" type="button" onClick={copyPrompt}>
-                {copyText}
-              </button>
-            </div>
-            <pre className="result-pre">{prompt}</pre>
-          </section>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/lib/bazhai-chart.ts
+++ b/src/lib/bazhai-chart.ts
@@ -1,0 +1,65 @@
+import { analyzeBaZhai, type BaZhaiResult } from '@core/ba_zhai';
+import { getSitFacingFromFacingDegree, type SitFacingPosition } from '@core/direction';
+
+export interface BazhaiMeasurement {
+  method: string;
+  measuredDegree: number;
+  facingDegree: number;
+  facingMountain: string;
+  sitDegree: number;
+  sitMountain: string;
+  label: string;
+  promptText: string;
+}
+
+export function resolveBazhaiDoorDirection(measuredDegree: number): SitFacingPosition {
+  if (!Number.isFinite(measuredDegree) || measuredDegree < 0 || measuredDegree > 360) {
+    throw new Error('大门朝向屋内的度数应填写 0 至 360 之间的数字。');
+  }
+  return getSitFacingFromFacingDegree((measuredDegree + 180) % 360);
+}
+
+export function calculateBazhaiBaseChart(birthData: {
+  year: number;
+  month: number;
+  day: number;
+  gender: 'male' | 'female';
+}): BaZhaiResult {
+  return analyzeBaZhai({
+    birthYear: birthData.year,
+    birthMonth: birthData.month,
+    birthDay: birthData.day,
+    gender: birthData.gender,
+  });
+}
+
+export function calculateBazhaiChart(
+  birthData: { year: number; month: number; day: number; gender: 'male' | 'female' },
+  measuredDegree: number,
+): { result: BaZhaiResult; measurement: BazhaiMeasurement } {
+  const { facing, sit, label } = resolveBazhaiDoorDirection(measuredDegree);
+  if (facing.isBoundary) {
+    const mountains = facing.boundaryMountains?.join('向与') ?? '两个二十四山';
+    throw new Error(`当前度数正好位于${mountains}向的分界线，请重新测量。`);
+  }
+  const result = analyzeBaZhai({
+    birthYear: birthData.year,
+    birthMonth: birthData.month,
+    birthDay: birthData.day,
+    gender: birthData.gender,
+    sitMountain: sit.mountain,
+  });
+  return {
+    result,
+    measurement: {
+      method: '站在大门处面向屋内测量',
+      measuredDegree,
+      facingDegree: facing.degree,
+      facingMountain: facing.mountain,
+      sitDegree: sit.degree,
+      sitMountain: sit.mountain,
+      label,
+      promptText: `测量方式：站在大门处面向屋内，指南针读数为 ${measuredDegree}°。换算后住宅坐山 ${sit.degree}° 为${sit.mountain}山，传统朝向 ${facing.degree}° 为${facing.mountain}向，结果为${label}。`,
+    },
+  };
+}

--- a/src/lib/query-state.ts
+++ b/src/lib/query-state.ts
@@ -3,7 +3,7 @@ import { BIRTH_TIME_OPTIONS } from '@/lib/birth-time';
 import { getBirthDateValidationMessage } from '@/lib/date-validation';
 
 export type ResultTabKey = 'bazi' | 'ziwei' | 'astrolabe' | 'qizheng' | 'bazhai' | 'prompt';
-export type PromptSourceKey = 'bazi' | 'ziwei' | 'bazi-ziwei' | 'astrolabe';
+export type PromptSourceKey = 'bazi' | 'ziwei' | 'bazi-ziwei' | 'astrolabe' | 'qizheng' | 'bazhai';
 export type BaziFortuneScope = 'natal' | 'full' | 'dayun' | 'year' | 'month' | 'day';
 export type { AstrolabePromptTopic };
 export type ZiweiScopeMode =
@@ -66,6 +66,7 @@ export type QueryPromptState = {
   astrolabeQuickQuestion: string;
   astrolabeScope: AstrolabeScopeMode;
   astrolabeScopeDate: string;
+  bazhaiFacingDegree: string;
 };
 
 const BAZI_FORTUNE_SCOPES: readonly BaziFortuneScope[] = [
@@ -179,6 +180,7 @@ export const defaultPromptState: QueryPromptState = {
   astrolabeQuickQuestion: '',
   astrolabeScope: 'natal',
   astrolabeScopeDate: '',
+  bazhaiFacingDegree: '',
 };
 
 const INPUT_PARAM_KEYS: Record<keyof QueryInputState, string> = {
@@ -235,6 +237,7 @@ const PROMPT_PARAM_KEYS: Record<keyof QueryPromptState, string> = {
   astrolabeQuickQuestion: 'aq',
   astrolabeScope: 'as',
   astrolabeScopeDate: 'asd',
+  bazhaiFacingDegree: 'bhd',
 };
 
 const PARAM_KEY_ALIASES: Record<string, string> = {
@@ -420,6 +423,12 @@ function appendPromptStateParams(params: URLSearchParams, prompt: QueryPromptSta
     'astrolabeScopeDate',
     prompt.astrolabeScopeDate,
     defaultPromptState.astrolabeScopeDate,
+  );
+  setCompactParam(
+    params,
+    'bazhaiFacingDegree',
+    prompt.bazhaiFacingDegree,
+    defaultPromptState.bazhaiFacingDegree,
   );
 }
 
@@ -775,7 +784,9 @@ export function parsePromptState(params: URLSearchParams): QueryPromptState {
   const promptSource: PromptSourceKey =
     rawPromptSource === 'ziwei' ||
     rawPromptSource === 'bazi-ziwei' ||
-    rawPromptSource === 'astrolabe'
+    rawPromptSource === 'astrolabe' ||
+    rawPromptSource === 'qizheng' ||
+    rawPromptSource === 'bazhai'
       ? rawPromptSource
       : 'bazi';
 
@@ -825,6 +836,11 @@ export function parsePromptState(params: URLSearchParams): QueryPromptState {
       params,
       'astrolabeScopeDate',
       defaultPromptState.astrolabeScopeDate,
+    ),
+    bazhaiFacingDegree: parseDecimalText(
+      getString(params, 'bazhaiFacingDegree', defaultPromptState.bazhaiFacingDegree),
+      0,
+      360,
     ),
   });
 }

--- a/src/pages/ResultPage/components/QizhengBoard.tsx
+++ b/src/pages/ResultPage/components/QizhengBoard.tsx
@@ -1,0 +1,274 @@
+import { memo } from 'react';
+import type { QizhengAspect, QizhengResult, QizhengStar } from '@core/qi_zheng';
+
+const EARTHLY_BRANCHES = ['子', '丑', '寅', '卯', '辰', '巳', '午', '未', '申', '酉', '戌', '亥'];
+const STAR_STYLES: Array<{ match: string; symbol: string; color: string }> = [
+  { match: '太阳', symbol: '日', color: '#d97706' },
+  { match: '太阴', symbol: '月', color: '#64748b' },
+  { match: '岁星', symbol: '木', color: '#15803d' },
+  { match: '荧惑', symbol: '火', color: '#dc2626' },
+  { match: '镇星', symbol: '土', color: '#a16207' },
+  { match: '太白', symbol: '金', color: '#ca8a04' },
+  { match: '辰星', symbol: '水', color: '#2563eb' },
+  { match: '罗睺', symbol: '罗', color: '#7c3aed' },
+  { match: '计都', symbol: '计', color: '#9333ea' },
+  { match: '月孛', symbol: '孛', color: '#db2777' },
+  { match: '紫炁', symbol: '炁', color: '#0891b2' },
+];
+
+function getStarStyle(name: string) {
+  return (
+    STAR_STYLES.find((item) => name.startsWith(item.match)) ?? {
+      match: name,
+      symbol: name.slice(0, 1),
+      color: '#475569',
+    }
+  );
+}
+
+function polarPoint(longitude: number, radius: number) {
+  const angle = ((longitude - 90) * Math.PI) / 180;
+  return { x: 200 + Math.cos(angle) * radius, y: 200 + Math.sin(angle) * radius };
+}
+
+function starPoint(star: QizhengStar) {
+  return polarPoint(star.longitude, star.kind === '七政' ? 132 : 105);
+}
+
+function aspectLine(aspect: QizhengAspect, stars: QizhengStar[]) {
+  const first = stars.find((star) => star.name === aspect.star1);
+  const second = stars.find((star) => star.name === aspect.star2);
+  if (!first || !second) return null;
+  const start = starPoint(first);
+  const end = starPoint(second);
+  return { start, end };
+}
+
+function QizhengChart({ data }: { data: QizhengResult }) {
+  const palaceBySign = new Map(data.twelvePalaces.map((item) => [item.signIndex, item.palace]));
+  return (
+    <svg
+      className="qizheng-chart-svg"
+      viewBox="0 0 400 400"
+      role="img"
+      aria-label="七政四余十二宫圆盘"
+    >
+      <circle cx="200" cy="200" r="184" className="qizheng-ring" />
+      <circle cx="200" cy="200" r="148" className="qizheng-ring" />
+      <circle cx="200" cy="200" r="78" className="qizheng-ring qizheng-ring-core" />
+      {EARTHLY_BRANCHES.map((branch, index) => {
+        const line = polarPoint(index * 30, 184);
+        const inner = polarPoint(index * 30, 78);
+        const label = polarPoint(index * 30 + 15, 166);
+        return (
+          <g key={branch}>
+            <line
+              x1={inner.x}
+              y1={inner.y}
+              x2={line.x}
+              y2={line.y}
+              className="qizheng-sector-line"
+            />
+            <text x={label.x} y={label.y} className="qizheng-palace-label">
+              <tspan>{branch}</tspan>
+              <tspan x={label.x} dy="11">
+                {palaceBySign.get(index)}
+              </tspan>
+            </text>
+          </g>
+        );
+      })}
+      {data.aspects.slice(0, 12).map((aspect) => {
+        const line = aspectLine(aspect, data.stars);
+        return line ? (
+          <line
+            key={`${aspect.star1}-${aspect.star2}-${aspect.type}`}
+            x1={line.start.x}
+            y1={line.start.y}
+            x2={line.end.x}
+            y2={line.end.y}
+            className={`qizheng-aspect-line qizheng-aspect-${aspect.type}`}
+            style={{ opacity: 0.18 + aspect.strength / 180 }}
+          />
+        ) : null;
+      })}
+      {data.stars.map((star) => {
+        const point = starPoint(star);
+        return (
+          <g key={star.name} transform={`translate(${point.x} ${point.y})`}>
+            <circle
+              r={star.kind === '七政' ? 13 : 12}
+              fill={getStarStyle(star.name).color}
+              className="qizheng-star-dot"
+            />
+            <text className="qizheng-star-label">{getStarStyle(star.name).symbol}</text>
+            {star.retrograde ? (
+              <text y="22" className="qizheng-retrograde-label">
+                逆
+              </text>
+            ) : null}
+          </g>
+        );
+      })}
+      <text x="200" y="184" className="qizheng-core-title">
+        命宫 {EARTHLY_BRANCHES[data.mingGong]}
+      </text>
+      <text x="200" y="202" className="qizheng-core-title">
+        身宫 {EARTHLY_BRANCHES[data.shenGong]}
+      </text>
+      <text x="200" y="220" className="qizheng-core-subtitle">
+        命主 {data.mingZhu}
+      </text>
+    </svg>
+  );
+}
+
+export const QizhengBoard = memo(function QizhengBoard({
+  title,
+  name,
+  data,
+}: {
+  title: string;
+  name: string;
+  data: QizhengResult;
+}) {
+  const strongestAspects = data.aspects.slice(0, 8);
+  const ziqiStar = data.stars.find((star) => star.name.startsWith('紫炁'));
+  return (
+    <section className="result-showcase-card qizheng-showcase-card">
+      <div className="result-showcase-head">
+        <div>
+          <p className="result-section-kicker">{title}</p>
+          <h2>{name}</h2>
+        </div>
+        <div className="result-chip-row">
+          <span className="result-chip">七政四余 {data.stars.length} 星</span>
+          <span className="result-chip">吊照 {data.aspects.length} 组</span>
+        </div>
+      </div>
+      <div className="result-summary-grid">
+        <div className="result-stat-card result-stat-card-accent">
+          <span>命宫</span>
+          <strong>{EARTHLY_BRANCHES[data.mingGong]}宫</strong>
+          <small>
+            {data.twelvePalaces.find((item) => item.signIndex === data.mingGong)?.palace}
+          </small>
+        </div>
+        <div className="result-stat-card">
+          <span>身宫</span>
+          <strong>{EARTHLY_BRANCHES[data.shenGong]}宫</strong>
+          <small>
+            {data.twelvePalaces.find((item) => item.signIndex === data.shenGong)?.palace}
+          </small>
+        </div>
+        <div className="result-stat-card">
+          <span>命主</span>
+          <strong>{data.mingZhu}</strong>
+          <small>按命宫十二支取主星</small>
+        </div>
+        <div className="result-stat-card">
+          <span>紫炁</span>
+          <strong>{ziqiStar ? `${ziqiStar.xiu}${ziqiStar.xiuDegree.toFixed(2)}°` : '—'}</strong>
+          <small>周期进度 {(data.ziqi.cycleProgress * 100).toFixed(1)}%</small>
+        </div>
+      </div>
+      <div className="astrolabe-board-layout">
+        <div className="astrolabe-board-main">
+          <div className="result-side-card astrolabe-chart-shell">
+            <div className="result-side-head">
+              <h3>十二宫星盘</h3>
+              <p>外圈为十二支宫位，实线与虚线呈现主要吊照关系。</p>
+            </div>
+            <QizhengChart data={data} />
+          </div>
+        </div>
+        <div className="astrolabe-board-side">
+          <div className="result-side-card">
+            <div className="result-side-head">
+              <h3>星曜落点</h3>
+            </div>
+            <div className="qizheng-star-list">
+              {data.stars.map((star) => (
+                <div className="qizheng-star-item" key={star.name}>
+                  <span
+                    className="qizheng-star-name"
+                    style={{ color: getStarStyle(star.name).color }}
+                  >
+                    {star.name}
+                  </span>
+                  <strong>
+                    {star.palace} · {star.xiu}
+                    {star.xiuDegree.toFixed(2)}°
+                  </strong>
+                  <small>
+                    {star.kind}
+                    {star.dignity ? ` · ${star.dignity}` : ''}
+                    {star.retrograde ? ' · 逆行' : ' · 顺行'}
+                  </small>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="result-side-card">
+            <div className="result-side-head">
+              <h3>主要吊照</h3>
+              <p>按关系强度由高到低排列。</p>
+            </div>
+            <div className="astrolabe-aspect-list">
+              {strongestAspects.map((aspect) => (
+                <div
+                  className="astrolabe-aspect-item"
+                  key={`${aspect.star1}-${aspect.star2}-${aspect.type}`}
+                >
+                  <strong>
+                    {aspect.star1}－{aspect.star2}
+                  </strong>
+                  <span>
+                    {aspect.type} · {aspect.strength}% · 容许 {aspect.orb.toFixed(2)}°
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="qizheng-detail-grid">
+        <div className="result-side-card">
+          <div className="result-side-head">
+            <h3>神煞</h3>
+          </div>
+          <div className="result-tag-cloud">
+            {data.shensha.map((item) => (
+              <span className="result-soft-tag" key={item.name}>
+                {item.name} · {item.value}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="result-side-card">
+          <div className="result-side-head">
+            <h3>紫炁位置</h3>
+          </div>
+          <div className="result-meta-lines">
+            <div>
+              <span>恒星黄经</span>
+              <strong>{data.ziqi.siderealLongitude.toFixed(4)}°</strong>
+            </div>
+            <div>
+              <span>回归黄经</span>
+              <strong>{data.ziqi.tropicalLongitude.toFixed(4)}°</strong>
+            </div>
+            <div>
+              <span>运行方向</span>
+              <strong>{data.ziqi.direction}</strong>
+            </div>
+            <div>
+              <span>一周周期</span>
+              <strong>{data.ziqiModel.periodDays.toFixed(4)} 日</strong>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+});

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -25,6 +25,8 @@ import { ASTROLABE_SHORTCUT_ACTIONS } from '@/lib/astrolabe-prompts';
 import { formatBaziForPrompt } from '@core/bazi/baziAnalysisFormatter';
 import { buildDivinationPrompt } from '@/lib/divination/engine';
 import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
+import { generateQizheng, type QizhengResult } from '@core/qi_zheng';
+import type { BaZhaiResult } from '@core/ba_zhai';
 import type { AstrolabeData } from '@/types/divination';
 import type {
   BaziFortuneSelectionModule,
@@ -56,6 +58,7 @@ import {
   ZiweiBoardSkeleton,
 } from './components/skeletons';
 import { AstrolabeBoard } from './components/AstrolabeBoard';
+import { QizhengBoard } from './components/QizhengBoard';
 import { usePromptCopyShare } from '@/hooks/usePromptCopyShare';
 import { BaziChartBoard } from './components/BaziChartBoard';
 import { ThreePillarsBoard } from './components/ThreePillarsBoard';
@@ -71,9 +74,15 @@ import { AiChatPanel } from '@/components/AiChatPanel';
 import { useAiSettings } from '@/hooks/useAiSettings';
 import { buildAiRequestConfig } from '@/lib/ai/settings';
 import {
+  buildMetaphysicsPrompt,
   insertPromptRealWorldContext,
   type PromptRealWorldContext,
 } from '@/lib/metaphysics-prompt';
+import {
+  calculateBazhaiBaseChart,
+  calculateBazhaiChart,
+  type BazhaiMeasurement,
+} from '@/lib/bazhai-chart';
 import { PromptContextFields } from '@/components/PromptContextFields';
 import { BIRTH_TIME_OPTIONS } from '@/lib/birth-time';
 
@@ -90,6 +99,9 @@ const LazyMetaphysicsPanel = lazy(async () => {
 export function ResultPage() {
   const navigate = useNavigate();
   const [promptContext, setPromptContext] = useState<PromptRealWorldContext>({});
+  const [metaphysicsQuestionDraft, setMetaphysicsQuestionDraft] = useState('');
+  const [bazhaiResult, setBazhaiResult] = useState<BaZhaiResult | null>(null);
+  const [bazhaiMeasurement, setBazhaiMeasurement] = useState<BazhaiMeasurement | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const inputSearch = useMemo(() => buildInputSearch(searchParams), [searchParams]);
   const inputState = useMemo(
@@ -106,6 +118,8 @@ export function ResultPage() {
     Boolean(inputState.birthLongitude) &&
     Boolean(inputState.birthLatitude);
   const isAstrolabePromptSource = promptState.promptSource === 'astrolabe';
+  const isQizhengPromptSource = promptState.promptSource === 'qizheng';
+  const isBazhaiPromptSource = promptState.promptSource === 'bazhai';
   const baziDraftStorageKey = useMemo(
     () => `${PROMPT_DRAFT_STORAGE_PREFIX}:bazi:${inputSearch}`,
     [inputSearch],
@@ -276,6 +290,47 @@ export function ResultPage() {
 
   useEffect(() => {
     if (
+      (promptState.promptSource === 'qizheng' && !hasAstrolabeChart) ||
+      (promptState.promptSource === 'bazhai' && inputState.analysisMode !== 'single')
+    ) {
+      updatePromptState({ promptSource: 'bazi' });
+    }
+  }, [hasAstrolabeChart, inputState.analysisMode, promptState.promptSource, updatePromptState]);
+
+  useEffect(() => {
+    if (!sharedBirthData || bazhaiResult) return;
+    try {
+      if (promptState.bazhaiFacingDegree) {
+        const next = calculateBazhaiChart(sharedBirthData, Number(promptState.bazhaiFacingDegree));
+        setBazhaiResult(next.result);
+        setBazhaiMeasurement(next.measurement);
+      } else {
+        setBazhaiResult(calculateBazhaiBaseChart(sharedBirthData));
+        setBazhaiMeasurement(null);
+      }
+    } catch {
+      // URL 中的旧值或人工修改值无法生成时，八宅页仍允许用户重新测量。
+    }
+  }, [bazhaiResult, promptState.bazhaiFacingDegree, sharedBirthData]);
+
+  const handleBazhaiResultChange = useCallback(
+    (nextResult: BaZhaiResult, nextMeasurement: BazhaiMeasurement | null) => {
+      setBazhaiResult(nextResult);
+      setBazhaiMeasurement(nextMeasurement);
+    },
+    [],
+  );
+  const handleBazhaiDirectionDegreeChange = useCallback(
+    (value: string) => {
+      if (value !== promptState.bazhaiFacingDegree) {
+        updatePromptState({ bazhaiFacingDegree: value });
+      }
+    },
+    [promptState.bazhaiFacingDegree, updatePromptState],
+  );
+
+  useEffect(() => {
+    if (
       (shouldLoadBaziPromptModules ? promptEngine : true) &&
       (shouldLoadBaziPromptModules || isBaziFortuneModalOpen ? baziFortuneSelectionModule : true)
     ) {
@@ -419,6 +474,32 @@ export function ResultPage() {
     inputState.year,
     shouldCalculateAstrolabe,
   ]);
+  const shouldCalculateQizheng =
+    hasAstrolabeChart &&
+    (mountedTabs.qizheng || (promptState.tab === 'prompt' && isQizhengPromptSource));
+  const qizhengCalculation = useMemo<{ data: QizhengResult | null; error: string }>(() => {
+    if (!shouldCalculateQizheng || !sharedBirthData) return { data: null, error: '' };
+    try {
+      return {
+        data: generateQizheng({
+          year: sharedBirthData.year,
+          month: sharedBirthData.month,
+          day: sharedBirthData.day,
+          hour: sharedBirthData.hour,
+          minute: sharedBirthData.minute,
+          latitude: sharedBirthData.latitude,
+          longitude: sharedBirthData.longitude,
+          timezone: sharedBirthData.timezone,
+        }),
+        error: '',
+      };
+    } catch (error) {
+      return {
+        data: null,
+        error: error instanceof Error ? error.message : '七政四余排盘生成失败。',
+      };
+    }
+  }, [sharedBirthData, shouldCalculateQizheng]);
   const astrolabeScopeContext = useMemo(
     () =>
       buildAstrolabeScopeContext(
@@ -831,6 +912,35 @@ export function ResultPage() {
     promptState.promptSource,
     promptState.tab,
   ]);
+  const qizhengPromptText = useMemo(() => {
+    if (
+      promptState.tab !== 'prompt' ||
+      promptState.promptSource !== 'qizheng' ||
+      !qizhengCalculation.data
+    ) {
+      return '';
+    }
+    return buildMetaphysicsPrompt(qizhengCalculation.data.prompt, metaphysicsQuestionDraft);
+  }, [
+    metaphysicsQuestionDraft,
+    promptState.promptSource,
+    promptState.tab,
+    qizhengCalculation.data,
+  ]);
+  const bazhaiPromptText = useMemo(() => {
+    if (promptState.tab !== 'prompt' || promptState.promptSource !== 'bazhai' || !bazhaiResult) {
+      return '';
+    }
+    return buildMetaphysicsPrompt(bazhaiResult.prompt, metaphysicsQuestionDraft, {
+      measurement: bazhaiMeasurement?.promptText,
+    });
+  }, [
+    bazhaiMeasurement,
+    bazhaiResult,
+    metaphysicsQuestionDraft,
+    promptState.promptSource,
+    promptState.tab,
+  ]);
   const latestEnhancedPromptText = useMemo(
     () =>
       promptState.promptSource === 'bazi-ziwei'
@@ -896,13 +1006,17 @@ export function ResultPage() {
   );
 
   const basePreviewActivePromptText =
-    promptState.promptSource === 'astrolabe'
-      ? previewAstrolabePromptText
-      : promptState.promptSource === 'bazi-ziwei'
-        ? previewEnhancedPromptText
-        : promptState.promptSource === 'bazi'
-          ? previewBaziPromptText
-          : previewZiweiPromptText;
+    promptState.promptSource === 'qizheng'
+      ? qizhengPromptText
+      : promptState.promptSource === 'bazhai'
+        ? bazhaiPromptText
+        : promptState.promptSource === 'astrolabe'
+          ? previewAstrolabePromptText
+          : promptState.promptSource === 'bazi-ziwei'
+            ? previewEnhancedPromptText
+            : promptState.promptSource === 'bazi'
+              ? previewBaziPromptText
+              : previewZiweiPromptText;
   const previewActivePromptText = insertPromptRealWorldContext(
     basePreviewActivePromptText,
     promptContext,
@@ -926,13 +1040,17 @@ export function ResultPage() {
       : astrolabeScopeContext.displayText;
 
   const baseLatestActivePromptText =
-    promptState.promptSource === 'astrolabe'
-      ? latestAstrolabePromptText
-      : promptState.promptSource === 'bazi-ziwei'
-        ? latestEnhancedPromptText
-        : promptState.promptSource === 'bazi'
-          ? latestBaziPromptText
-          : latestZiweiPromptText;
+    promptState.promptSource === 'qizheng'
+      ? qizhengPromptText
+      : promptState.promptSource === 'bazhai'
+        ? bazhaiPromptText
+        : promptState.promptSource === 'astrolabe'
+          ? latestAstrolabePromptText
+          : promptState.promptSource === 'bazi-ziwei'
+            ? latestEnhancedPromptText
+            : promptState.promptSource === 'bazi'
+              ? latestBaziPromptText
+              : latestZiweiPromptText;
   const latestActivePromptText = insertPromptRealWorldContext(
     baseLatestActivePromptText,
     promptContext,
@@ -980,6 +1098,24 @@ export function ResultPage() {
       : promptState.promptSource === 'ziwei'
         ? activeZiweiShortcutMode
         : activeAstrolabeShortcutMode;
+  const metaphysicsPromptQuestionField =
+    isQizhengPromptSource || isBazhaiPromptSource ? (
+      <label className="field-card metaphysics-prompt-question-field">
+        <div className="field-header">
+          <span>希望重点解读的问题（可选）</span>
+        </div>
+        <textarea
+          rows={4}
+          value={metaphysicsQuestionDraft}
+          onChange={(event) => setMetaphysicsQuestionDraft(event.target.value)}
+          placeholder={
+            isBazhaiPromptSource
+              ? '例如：卧室、书房和大门分别怎样安排更合适？'
+              : '例如：请重点分析事业方向、关系模式和近期应注意的风险。'
+          }
+        />
+      </label>
+    ) : null;
 
   return (
     <div className="page-shell">
@@ -1191,11 +1327,17 @@ export function ResultPage() {
           aria-hidden={promptState.tab !== 'qizheng'}
         >
           {hasAstrolabeChart && mountedTabs.qizheng ? (
-            sharedBirthData ? (
-              <Suspense fallback={<InlineSkeleton />}>
-                <LazyMetaphysicsPanel method="qizheng" birthData={sharedBirthData} embedded />
-              </Suspense>
-            ) : null
+            qizhengCalculation.error ? (
+              <p className="error-text">{qizhengCalculation.error}</p>
+            ) : qizhengCalculation.data ? (
+              <QizhengBoard
+                title="七政四余本命盘"
+                name={inputState.name || '本人'}
+                data={qizhengCalculation.data}
+              />
+            ) : (
+              <InlineSkeleton />
+            )
           ) : null}
         </div>
 
@@ -1205,7 +1347,14 @@ export function ResultPage() {
         >
           {mountedTabs.bazhai && sharedBirthData ? (
             <Suspense fallback={<InlineSkeleton />}>
-              <LazyMetaphysicsPanel method="bazhai" birthData={sharedBirthData} embedded />
+              <LazyMetaphysicsPanel
+                method="bazhai"
+                birthData={sharedBirthData}
+                embedded
+                initialFacingDegree={promptState.bazhaiFacingDegree}
+                onDirectionDegreeChange={handleBazhaiDirectionDegreeChange}
+                onResultChange={handleBazhaiResultChange}
+              />
             </Suspense>
           ) : null}
         </div>
@@ -1229,16 +1378,18 @@ export function ResultPage() {
                         {isAiMobileSettingsOpen ? '收起设置' : '展开设置'}
                       </button>
 
-                      <button
-                        type="button"
-                        className={`ai-mobile-shortcut-btn ${isAiShortcutPopoverOpen ? 'is-active' : ''}`}
-                        onClick={() => setIsAiShortcutPopoverOpen((value) => !value)}
-                        title="快捷问题"
-                      >
-                        ✨ 快捷
-                      </button>
+                      {aiMobileShortcutActions.length > 0 ? (
+                        <button
+                          type="button"
+                          className={`ai-mobile-shortcut-btn ${isAiShortcutPopoverOpen ? 'is-active' : ''}`}
+                          onClick={() => setIsAiShortcutPopoverOpen((value) => !value)}
+                          title="快捷问题"
+                        >
+                          ✨ 快捷
+                        </button>
+                      ) : null}
 
-                      {isAiShortcutPopoverOpen ? (
+                      {isAiShortcutPopoverOpen && aiMobileShortcutActions.length > 0 ? (
                         <div className="ai-mobile-shortcut-popover">
                           <div className="ai-mobile-shortcut-popover-inner">
                             <PromptShortcutPanel
@@ -1279,6 +1430,8 @@ export function ResultPage() {
                             </option>
                           ) : null}
                           {hasAstrolabeChart ? <option value="astrolabe">星盘</option> : null}
+                          {hasAstrolabeChart ? <option value="qizheng">七政四余</option> : null}
+                          {bazhaiResult ? <option value="bazhai">八宅</option> : null}
                         </select>
 
                         {(promptState.promptSource === 'bazi' ||
@@ -1353,6 +1506,7 @@ export function ResultPage() {
                     </div>
                     <div className="field-list">
                       <PromptContextFields value={promptContext} onChange={setPromptContext} />
+                      {metaphysicsPromptQuestionField}
                       <div className="prompt-compact-grid">
                         <label className="field-card">
                           <div className="field-header">
@@ -1378,6 +1532,10 @@ export function ResultPage() {
                               </option>
                             ) : null}
                             {hasAstrolabeChart ? <option value="astrolabe">基于星盘</option> : null}
+                            {hasAstrolabeChart ? (
+                              <option value="qizheng">基于七政四余</option>
+                            ) : null}
+                            {bazhaiResult ? <option value="bazhai">基于八宅</option> : null}
                           </select>
                         </label>
 
@@ -1531,15 +1689,14 @@ export function ResultPage() {
                     <div>
                       <h2 className="prompt-settings-title">提示词设置</h2>
                       <p>
-                        {hasAstrolabeChart
-                          ? '选择星盘解读重点，生成可复制给 AI 的提示词。'
-                          : '选择基于八字、紫微或八字+紫微的已选分析对象，再用快捷按钮生成问题。'}
+                        选择已生成的排盘作为解读依据，再补充问题和现实情况，即可生成完整提示词。
                       </p>
                     </div>
                   </div>
 
                   <div className="field-list">
                     <PromptContextFields value={promptContext} onChange={setPromptContext} />
+                    {metaphysicsPromptQuestionField}
                     <>
                       <div className="prompt-compact-grid">
                         <label className="field-card">
@@ -1566,6 +1723,10 @@ export function ResultPage() {
                               </option>
                             ) : null}
                             {hasAstrolabeChart ? <option value="astrolabe">基于星盘</option> : null}
+                            {hasAstrolabeChart ? (
+                              <option value="qizheng">基于七政四余</option>
+                            ) : null}
+                            {bazhaiResult ? <option value="bazhai">基于八宅</option> : null}
                           </select>
                         </label>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3318,7 +3318,11 @@ select {
   border-radius: var(--radius-page-card);
   border: 1px solid var(--border-soft);
   background:
-    linear-gradient(180deg, rgba(var(--surface-base-rgb), 0.94), rgba(var(--surface-base-rgb), 0.88)),
+    linear-gradient(
+      180deg,
+      rgba(var(--surface-base-rgb), 0.94),
+      rgba(var(--surface-base-rgb), 0.88)
+    ),
     var(--surface-soft);
   box-shadow: var(--shadow-md);
   pointer-events: auto;
@@ -3539,7 +3543,11 @@ select {
 .person-section {
   border: 1px solid var(--border-soft);
   background:
-    linear-gradient(180deg, rgba(var(--surface-base-rgb), 0.96), rgba(var(--surface-base-rgb), 0.9)),
+    linear-gradient(
+      180deg,
+      rgba(var(--surface-base-rgb), 0.96),
+      rgba(var(--surface-base-rgb), 0.9)
+    ),
     var(--surface-soft);
   border-radius: var(--radius-page-card);
   box-shadow: var(--shadow-card);
@@ -4136,6 +4144,179 @@ select {
   border-radius: 20px;
   border: 1px solid var(--border-soft);
   background: linear-gradient(180deg, var(--surface-base), var(--surface-soft));
+}
+
+.qizheng-chart-svg,
+.bazhai-compass-svg {
+  width: min(430px, 100%);
+  aspect-ratio: 1;
+  justify-self: center;
+  padding: 10px;
+  border-radius: 20px;
+  border: 1px solid var(--border-soft);
+  background: radial-gradient(circle at center, var(--surface-base), var(--surface-soft));
+}
+
+.qizheng-ring,
+.bazhai-ring {
+  fill: none;
+  stroke: var(--border-strong);
+  stroke-width: 1.2;
+}
+
+.qizheng-ring-core,
+.bazhai-ring-core {
+  fill: color-mix(in srgb, var(--accent-soft) 35%, transparent);
+}
+
+.qizheng-sector-line,
+.bazhai-sector-line {
+  stroke: var(--border-soft);
+  stroke-width: 1;
+}
+
+.qizheng-palace-label,
+.bazhai-direction-label {
+  fill: var(--text-secondary);
+  font-size: 9px;
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+.qizheng-star-dot {
+  stroke: var(--surface-base);
+  stroke-width: 2;
+}
+
+.qizheng-star-label {
+  fill: white;
+  font-size: 10px;
+  font-weight: 800;
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+.qizheng-retrograde-label {
+  fill: var(--danger-text);
+  font-size: 8px;
+  font-weight: 700;
+  text-anchor: middle;
+}
+
+.qizheng-aspect-line {
+  stroke: var(--accent-strong);
+  stroke-width: 1.2;
+}
+
+.qizheng-aspect-四正,
+.qizheng-aspect-对照 {
+  stroke: var(--danger-text);
+  stroke-dasharray: 4 3;
+}
+
+.qizheng-core-title,
+.bazhai-core-title {
+  fill: var(--text-strong);
+  font-size: 12px;
+  font-weight: 800;
+  text-anchor: middle;
+}
+
+.qizheng-core-subtitle,
+.bazhai-core-subtitle {
+  fill: var(--text-secondary);
+  font-size: 10px;
+  text-anchor: middle;
+}
+
+.qizheng-star-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.qizheng-star-item {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--surface-muted);
+}
+
+.qizheng-star-name {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.qizheng-star-item strong {
+  color: var(--text-strong);
+  font-size: 12px;
+}
+
+.qizheng-star-item small {
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
+.qizheng-detail-grid,
+.bazhai-result-grid,
+.bazhai-board-layout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.bazhai-board-layout {
+  grid-template-columns: minmax(260px, 430px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.bazhai-board-legend {
+  display: grid;
+  gap: 12px;
+}
+
+.bazhai-direction-label.is-lucky {
+  fill: var(--success-text);
+  font-weight: 800;
+}
+
+.bazhai-direction-label.is-unlucky {
+  fill: var(--danger-text);
+}
+
+.bazhai-facing-arrow {
+  fill: var(--accent-strong);
+}
+
+.bazhai-facing-line {
+  stroke: var(--accent-strong);
+  stroke-width: 3;
+}
+
+.bazhai-advice,
+.bazhai-boundary-note {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.bazhai-boundary-note {
+  margin-top: 8px;
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .qizheng-detail-grid,
+  .bazhai-result-grid,
+  .bazhai-board-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .qizheng-star-list {
+    grid-template-columns: 1fr;
+  }
 }
 
 .astrolabe-board-layout {

--- a/tests/bazhai-chart.test.ts
+++ b/tests/bazhai-chart.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { calculateBazhaiChart } from '../src/lib/bazhai-chart';
+import { MetaphysicsPanel } from '../src/components/MetaphysicsPanel';
+
+test('八宅统一按从大门面向屋内的读数换算传统坐向', () => {
+  const { result, measurement } = calculateBazhaiChart(
+    { year: 1990, month: 6, day: 15, gender: 'male' },
+    0,
+  );
+
+  assert.equal(measurement.measuredDegree, 0);
+  assert.equal(measurement.sitDegree, 0);
+  assert.equal(measurement.sitMountain, '子');
+  assert.equal(measurement.facingDegree, 180);
+  assert.equal(measurement.facingMountain, '午');
+  assert.equal(result.houseGua, '坎');
+  assert.match(measurement.promptText, /站在大门处面向屋内/);
+});
+
+test('八宅页面无需开始排盘即可显示个人盘并在盘面说明下补充角度', () => {
+  const html = renderToStaticMarkup(
+    createElement(MetaphysicsPanel, {
+      method: 'bazhai',
+      birthData: {
+        year: 1990,
+        month: 6,
+        day: 15,
+        hour: 10,
+        minute: 30,
+        gender: 'male',
+      },
+    }),
+  );
+
+  assert.match(html, /个人八宅方位/);
+  assert.match(html, /盘面说明/);
+  assert.match(html, /补充住宅角度/);
+  assert.match(html, /从大门面向屋内的度数/);
+  assert.doesNotMatch(html, /开始排盘/);
+  assert.doesNotMatch(html, /<pre/);
+});

--- a/tests/qizheng-board.test.ts
+++ b/tests/qizheng-board.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { generateQizheng } from '@core/qi_zheng';
+import { QizhengBoard } from '../src/pages/ResultPage/components/QizhengBoard';
+
+test('七政四余盘应展示专业盘面且不输出原始数据和提示词', () => {
+  const data = generateQizheng({
+    year: 1990,
+    month: 6,
+    day: 15,
+    hour: 10,
+    minute: 30,
+    latitude: 39.9042,
+    longitude: 116.4074,
+    timezone: 8,
+  });
+  const html = renderToStaticMarkup(
+    createElement(QizhengBoard, { title: '七政四余本命盘', name: '测试命盘', data }),
+  );
+
+  assert.match(html, /十二宫星盘/);
+  assert.match(html, /主要吊照/);
+  assert.match(html, /紫炁位置/);
+  assert.match(html, /七政四余十二宫圆盘/);
+  assert.doesNotMatch(html, /<pre/);
+  assert.doesNotMatch(html, /提示词正文/);
+});

--- a/tests/query-state-defaults.test.ts
+++ b/tests/query-state-defaults.test.ts
@@ -465,6 +465,39 @@ test('星盘提示词完整输出版会写入并清空日期', () => {
   assert.equal(parsed.astrolabeScopeDate, '');
 });
 
+test('七政四余和八宅提示词来源可从地址栏恢复', () => {
+  const qizhengSearch = buildResultSearch(defaultInputState, {
+    ...defaultPromptState,
+    tab: 'prompt',
+    promptSource: 'qizheng',
+  });
+  assert.match(qizhengSearch, /ps=qizheng/);
+  assert.equal(parsePromptState(new URLSearchParams(qizhengSearch)).promptSource, 'qizheng');
+
+  const bazhaiSearch = buildResultSearch(defaultInputState, {
+    ...defaultPromptState,
+    tab: 'prompt',
+    promptSource: 'bazhai',
+    bazhaiFacingDegree: '12.5',
+  });
+  assert.match(bazhaiSearch, /ps=bazhai/);
+  assert.match(bazhaiSearch, /bhd=12.5/);
+  const parsed = parsePromptState(new URLSearchParams(bazhaiSearch));
+  assert.equal(parsed.promptSource, 'bazhai');
+  assert.equal(parsed.bazhaiFacingDegree, '12.5');
+});
+
+test('八宅入户方向缓存应拒绝越界度数', () => {
+  assert.equal(
+    parsePromptState(new URLSearchParams({ bazhaiFacingDegree: '361' })).bazhaiFacingDegree,
+    '',
+  );
+  assert.equal(
+    parsePromptState(new URLSearchParams({ bazhaiFacingDegree: '-1' })).bazhaiFacingDegree,
+    '',
+  );
+});
+
 test('星盘提示词范围日期应按范围校验并清空非法日期', () => {
   assert.equal(
     parsePromptState(new URLSearchParams({ astrolabeScope: 'yearly', astrolabeScopeDate: '2028' }))


### PR DESCRIPTION
## 修改内容

- 新增七政四余十二宫圆盘，展示十一星曜、吊照关系、命身宫、神煞与紫炁摘要
- 八宅改为进入页面即显示个人命卦八方盘，去掉开始排盘按钮
- 住宅角度统一按站在大门处面向屋内测量，填写后自动生成命宅合参
- 将住宅角度保存到排盘链接，刷新或再次打开时自动恢复
- 七政四余和八宅页面移除原始 JSON 与完整提示词，统一接入提示词 / AI 解析页
- 增加七政四余、八宅提示词来源与相关回归测试

## 验证结果

- 应用与 MCP TypeScript 类型检查通过
- 提示词检查与审计通过
- 主测试 1163 项全部通过
- MCP 端到端测试 21 项全部通过
- ESLint、Prettier、生产构建和 git diff 检查通过
- 已用真实浏览器检查桌面与手机布局、角度自动换算及链接缓存

## 风险说明

- 未修改七政四余和八宅核心算法，只调整前端展示、状态复用和提示词入口
- 未修改三山国王灵签内容
- 用户原有 .workbuddy 目录未纳入提交