### PR TITLE
修正八字格局并收紧术数输入校验

### DIFF
--- a/packages/core/src/bazi/baziAnalysisPipeline.ts
+++ b/packages/core/src/bazi/baziAnalysisPipeline.ts
@@ -13,9 +13,9 @@ import type {
 } from './baziTypes';
 import { WUXING } from './baziTypes';
 import type { FormationAnalysis, SeasonalStatusAnalysis } from './baziStrengthAnalyzer';
-import { collectCompleteBranchFormations } from './baziFormationUtils';
+import { collectEstablishedBranchFormations } from './baziFormationUtils';
 import type { HiddenStemSource, VisibleStemSource } from './baziRuleMatcher';
-import { assertHeavenlyStem, assertPillars } from './baziUtils';
+import { assertHeavenlyStem, assertHiddenStemsMatchPillars } from './baziUtils';
 
 export interface BaziAnalysisPipelineDeps {
   getWuxing: (ganOrZhi: string) => Wuxing;
@@ -98,32 +98,14 @@ interface BaziAnalysisPipelineState {
   usefulGod: UsefulGodAnalysis & { favorableWuxing: string[]; unfavorableWuxing: string[] };
 }
 
-const PILLAR_KEYS = ['year', 'month', 'day', 'hour'] as const;
-
 function assertValidWuxing(value: string, label: string): asserts value is Wuxing {
   if (!(WUXING as readonly string[]).includes(value)) {
     throw new Error(`${label}五行无效：${value}`);
   }
 }
 
-function assertHiddenStems(hiddenStems: HiddenStems): void {
-  if (!hiddenStems) {
-    throw new Error('藏干缺失');
-  }
-
-  for (const key of PILLAR_KEYS) {
-    const stems = hiddenStems[key];
-    if (!Array.isArray(stems)) {
-      throw new Error(`藏干缺少${key}`);
-    }
-
-    stems.filter(Boolean).forEach((stem) => assertHeavenlyStem(stem, `${key}柱藏干`));
-  }
-}
-
 function assertAnalysisInput(input: BaziAnalysisPipelineInput): void {
-  assertPillars(input.pillars);
-  assertHiddenStems(input.hiddenStems);
+  assertHiddenStemsMatchPillars(input.pillars, input.hiddenStems);
 
   if (input.monthCommander) {
     assertHeavenlyStem(input.monthCommander, '月令司权天干');
@@ -165,7 +147,7 @@ function buildHiddenStemSources(pillars: Pillars, hiddenStems: HiddenStems): Hid
 
 function buildFormationWuxings(pillars: Pillars): string[] {
   return [
-    ...new Set(collectCompleteBranchFormations(pillars).map((formation) => formation.wuxing)),
+    ...new Set(collectEstablishedBranchFormations(pillars).map((formation) => formation.wuxing)),
   ];
 }
 

--- a/packages/core/src/bazi/baziFormationUtils.ts
+++ b/packages/core/src/bazi/baziFormationUtils.ts
@@ -1,10 +1,17 @@
+import { BASIC_MAPPINGS, SEASON_STATUS } from './baziDefinitions';
 import type { Pillars, Wuxing } from './baziTypes';
+import { assertPillars } from './baziUtils';
 
 export interface CompleteBranchFormation {
   type: '三合' | '三会';
   branches: string[];
   wuxing: Wuxing;
   includesMonthBranch: boolean;
+}
+
+export interface EstablishedBranchFormation extends CompleteBranchFormation {
+  monthStatus: string;
+  clashBreakBranches: string[];
 }
 
 const FORMATION_DEFINITIONS: Array<{
@@ -35,6 +42,7 @@ export function getRepresentativeStemByWuxing(wuxing: Wuxing): string {
 }
 
 export function collectCompleteBranchFormations(pillars: Pillars): CompleteBranchFormation[] {
+  assertPillars(pillars);
   const uniqueBranches = new Set(Object.values(pillars).map((pillar) => pillar.zhi));
 
   return FORMATION_DEFINITIONS.filter((formation) =>
@@ -43,4 +51,31 @@ export function collectCompleteBranchFormations(pillars: Pillars): CompleteBranc
     ...formation,
     includesMonthBranch: formation.branches.includes(pillars.month.zhi),
   }));
+}
+
+/**
+ * 三支齐全只证明会合结构存在；只有化神得月令且没有被局外地支冲破时，
+ * 才把该结构作为旺衰、特殊格和用神判断中的成势力量。
+ */
+export function collectEstablishedBranchFormations(pillars: Pillars): EstablishedBranchFormation[] {
+  const allBranches = Object.values(pillars).map((pillar) => pillar.zhi);
+
+  return collectCompleteBranchFormations(pillars).flatMap((formation) => {
+    const monthStatus = SEASON_STATUS[pillars.month.zhi]?.[formation.wuxing];
+    const isSeasonSupported = monthStatus === '旺' || monthStatus === '相';
+    const externalBranches = allBranches.filter((branch) => !formation.branches.includes(branch));
+    const clashBreakBranches = [
+      ...new Set(
+        externalBranches.filter((branch) =>
+          formation.branches.some((member) => BASIC_MAPPINGS.DI_ZHI_CHONG[member] === branch),
+        ),
+      ),
+    ];
+
+    if (!isSeasonSupported || clashBreakBranches.length > 0) {
+      return [];
+    }
+
+    return [{ ...formation, monthStatus, clashBreakBranches }];
+  });
 }

--- a/packages/core/src/bazi/baziPatternStrategy.ts
+++ b/packages/core/src/bazi/baziPatternStrategy.ts
@@ -1,6 +1,6 @@
 import { HIDDEN_STEMS, LU_BRANCH_MAP, REN_BRANCH_MAP } from './baziDefinitions';
 import {
-  collectCompleteBranchFormations,
+  collectEstablishedBranchFormations,
   getRepresentativeStemByWuxing,
 } from './baziFormationUtils';
 import type { PatternAnalysis, Pillars } from './baziTypes';
@@ -25,27 +25,21 @@ function isSamePartyGod(tenGod: string) {
   return SAME_PARTY_GODS.includes(tenGod);
 }
 
-function getPatternNameByTenGod(tenGod: string, dayMaster?: string, monthBranch?: string) {
+function getPatternNameByTenGod(tenGod: string, dayMaster: string, monthBranch: string) {
   // 建禄格/月刃格需要精确校验月支是否为禄/刃位
-  if (tenGod === '比肩' && dayMaster && monthBranch) {
+  if (tenGod === '比肩') {
     if (LU_BRANCH_MAP[dayMaster] === monthBranch) {
       return '建禄格';
     }
     return '比肩格';
   }
-  if (tenGod === '劫财' && dayMaster && monthBranch) {
+  if (tenGod === '劫财') {
     if (REN_BRANCH_MAP[dayMaster] === monthBranch) {
       return '月刃格';
     }
     return '劫财格';
   }
-  // 降级：无月支信息时保留原逻辑
-  const specialPatternMap: Record<string, string> = {
-    比肩: '建禄格',
-    劫财: '月刃格',
-  };
-
-  return specialPatternMap[tenGod] || `${tenGod}格`;
+  return `${tenGod}格`;
 }
 
 function isSamePartyTenGod(tenGod: string): boolean {
@@ -112,7 +106,7 @@ function collectSpecialPatternForce(
     addForce(stem, 0.6, 'day', true);
   });
 
-  const formationForce = collectCompleteBranchFormations(pillars).reduce(
+  const formationForce = collectEstablishedBranchFormations(pillars).reduce(
     (summary, formation) => {
       const representativeStem = getRepresentativeStemByWuxing(formation.wuxing);
       const tenGod = getTenGod(representativeStem, dayMaster);
@@ -253,7 +247,7 @@ function resolveSubPattern(pillars: Pillars, dayMaster: string, getTenGod: GetTe
   });
 
   // 三合三会局加成
-  const formations = collectCompleteBranchFormations(pillars);
+  const formations = collectEstablishedBranchFormations(pillars);
   formations.forEach((formation) => {
     const representativeStem = getRepresentativeStemByWuxing(formation.wuxing);
     const tenGod = getTenGod(representativeStem, dayMaster);
@@ -358,16 +352,18 @@ export function determinePattern(
 
   const monthPrincipalStem = monthStems[0];
   const monthPrincipalGod = getTenGod(monthPrincipalStem, dayMaster);
-  const activeMonthStem =
-    monthCommander && monthStems.includes(monthCommander) ? monthCommander : monthStems[0];
+  const activeMonthStem = monthCommander || monthStems[0];
   const monthMainGod = getTenGod(activeMonthStem, dayMaster);
   let basis: string;
 
-  if (monthPrincipalGod === '劫财') {
-    if (REN_BRANCH_MAP[dayMaster] === monthBranch) {
-      patternName = '月刃格';
-      basis = `月令${monthBranch}为日主${dayMaster}之羊刃位，按月刃格处理`;
-    } else if (REN_BRANCH_MAP[dayMaster]) {
+  if (LU_BRANCH_MAP[dayMaster] === monthBranch) {
+    patternName = '建禄格';
+    basis = `月令${monthBranch}为日主${dayMaster}之禄位，按建禄格处理`;
+  } else if (REN_BRANCH_MAP[dayMaster] === monthBranch) {
+    patternName = '月刃格';
+    basis = `月令${monthBranch}为日主${dayMaster}之羊刃位，按月刃格处理`;
+  } else if (monthPrincipalGod === '劫财') {
+    if (REN_BRANCH_MAP[dayMaster]) {
       patternName = '劫财格';
       basis = `月令本气为${monthPrincipalStem}，对应劫财，但月支${monthBranch}非${dayMaster}刃位（刃在${REN_BRANCH_MAP[dayMaster]}），按劫财格处理`;
     } else {
@@ -377,18 +373,10 @@ export function determinePattern(
   } else if (monthCommander && exposedStems.includes(monthCommander)) {
     patternName = getPatternNameByTenGod(monthMainGod, dayMaster, monthBranch);
     basis = `月令司权为${monthCommander}，且已透干，按司令十神取格`;
-  } else if (monthMainGod === '比肩' && LU_BRANCH_MAP[dayMaster] === monthBranch) {
-    // 建禄格：月支必须确实是日干的临官禄位
-    patternName = '建禄格';
-    basis = `月令${monthBranch}为日主${dayMaster}之禄位，按建禄格处理`;
   } else if (monthMainGod === '比肩') {
     // 月令主气虽为比肩，但月支非禄位（如杂气中比肩透出），按普通比肩格处理
     patternName = '比肩格';
     basis = `月令主气为${activeMonthStem}，对应比肩，但月支${monthBranch}非${dayMaster}禄位，按比肩格处理`;
-  } else if (monthMainGod === '劫财' && REN_BRANCH_MAP[dayMaster] === monthBranch) {
-    // 月刃格：月支必须确实是阳干的帝旺羊刃位
-    patternName = '月刃格';
-    basis = `月令${monthBranch}为日主${dayMaster}之羊刃位，按月刃格处理`;
   } else if (monthMainGod === '劫财') {
     // 阳干但月支非刃位，或阴干，一律按劫财格处理
     patternName = '劫财格';

--- a/packages/core/src/bazi/baziStrengthAnalyzer.ts
+++ b/packages/core/src/bazi/baziStrengthAnalyzer.ts
@@ -1,5 +1,5 @@
 import { BASIC_MAPPINGS } from './baziDefinitions';
-import { collectCompleteBranchFormations } from './baziFormationUtils';
+import { collectEstablishedBranchFormations } from './baziFormationUtils';
 import type {
   ConstraintAnalysis,
   DayMasterStrengthAnalysis,
@@ -10,7 +10,12 @@ import type {
   Wuxing,
 } from './baziTypes';
 import { WUXING } from './baziTypes';
-import { assertEarthlyBranch, assertHeavenlyStem, assertPillars } from './baziUtils';
+import {
+  assertEarthlyBranch,
+  assertHeavenlyStem,
+  assertHiddenStemsMatchPillars,
+  assertPillars,
+} from './baziUtils';
 
 export interface SeasonalStatusAnalysis {
   status: string;
@@ -36,8 +41,6 @@ export interface FormationAnalysis {
 type GetWuxingFn = (ganOrZhi: string) => Wuxing;
 type GetSeasonStatusFn = (zhi: string) => Record<string, string>;
 
-const PILLAR_KEYS = ['year', 'month', 'day', 'hour'] as const;
-
 function assertValidWuxing(value: string, label: string): asserts value is Wuxing {
   if (!(WUXING as readonly string[]).includes(value)) {
     throw new Error(`${label}五行无效：${value}`);
@@ -48,21 +51,6 @@ function resolveWuxing(getWuxing: GetWuxingFn, value: string, label: string): Wu
   const wuxing = getWuxing(value);
   assertValidWuxing(wuxing, label);
   return wuxing;
-}
-
-function assertHiddenStems(hiddenStems: HiddenStems): void {
-  if (!hiddenStems) {
-    throw new Error('藏干缺失');
-  }
-
-  for (const key of PILLAR_KEYS) {
-    const stems = hiddenStems[key];
-    if (!Array.isArray(stems)) {
-      throw new Error(`藏干缺少${key}`);
-    }
-
-    stems.filter(Boolean).forEach((stem) => assertHeavenlyStem(stem, `${key}柱藏干`));
-  }
 }
 
 function assertStrengthPillars(dayMaster: string, pillars: Pillars): void {
@@ -108,7 +96,7 @@ export function analyzeRoot(
   getWuxing: GetWuxingFn,
 ): RootAnalysis {
   assertStrengthPillars(dayMaster, pillars);
-  assertHiddenStems(hiddenStems);
+  assertHiddenStemsMatchPillars(pillars, hiddenStems);
 
   const roots: { position: string; branch: string; strength: number }[] = [];
   let totalStrength = 0;
@@ -147,7 +135,7 @@ export function analyzeSupport(
   getWuxing: GetWuxingFn,
 ): SupportAnalysis {
   assertStrengthPillars(dayMaster, pillars);
-  assertHiddenStems(hiddenStems);
+  assertHiddenStemsMatchPillars(pillars, hiddenStems);
 
   const supporters: { position: string; stem: string; strength: number }[] = [];
   let totalStrength = 0;
@@ -210,7 +198,7 @@ export function analyzeConstraint(
   getWuxing: GetWuxingFn,
 ): ConstraintAnalysis {
   assertStrengthPillars(dayMaster, pillars);
-  assertHiddenStems(hiddenStems);
+  assertHiddenStemsMatchPillars(pillars, hiddenStems);
 
   const constraints: { position: string; stem: string; strength: number }[] = [];
   let totalStrength = 0;
@@ -309,7 +297,10 @@ export function analyzeSeasonalStatus(
     死: -4,
   };
 
-  const baseScore = scoreMap[seasonStatus] ?? 0;
+  if (!Object.hasOwn(scoreMap, seasonStatus)) {
+    throw new Error(`月令旺衰状态无效：${monthBranch}/${dayMasterWuxing}/${seasonStatus}`);
+  }
+  const baseScore = scoreMap[seasonStatus];
   const commanderWuxing = monthCommander
     ? resolveWuxing(getWuxing, monthCommander, '月令司权天干')
     : undefined;
@@ -345,7 +336,7 @@ export function analyzeFormation(
     ([, target]) => target === dayMasterWuxing,
   )?.[0] as Wuxing | undefined;
 
-  const formations = collectCompleteBranchFormations(pillars)
+  const formations = collectEstablishedBranchFormations(pillars)
     .map((formation) => {
       const monthBonus = formation.includesMonthBranch ? 0.4 : 0;
 

--- a/packages/core/src/bazi/baziUtils.ts
+++ b/packages/core/src/bazi/baziUtils.ts
@@ -4,7 +4,7 @@
  */
 
 import { BASIC_MAPPINGS, HIDDEN_STEMS, SEASON_STATUS, shenShaTypes } from './baziDefinitions';
-import type { Pillars, Wuxing } from './baziTypes';
+import type { HiddenStems, Pillars, Wuxing } from './baziTypes';
 
 const ctg = BASIC_MAPPINGS.HEAVENLY_STEMS as readonly string[];
 const cdz = BASIC_MAPPINGS.EARTHLY_BRANCHES as readonly string[];
@@ -75,6 +75,36 @@ export function assertPillars(pillars: Pillars): void {
 
     if (pillar.ganZhi && pillar.ganZhi !== `${pillar.gan}${pillar.zhi}`) {
       throw new Error(`${key}柱干支不一致：${pillar.ganZhi}`);
+    }
+  }
+}
+
+export function assertHiddenStemsMatchPillars(pillars: Pillars, hiddenStems: HiddenStems): void {
+  assertPillars(pillars);
+  if (!hiddenStems) {
+    throw new Error('藏干缺失');
+  }
+
+  const keys = ['year', 'month', 'day', 'hour'] as const;
+  for (const key of keys) {
+    const actual = hiddenStems[key];
+    if (!Array.isArray(actual)) {
+      throw new Error(`藏干缺少${key}`);
+    }
+    actual.forEach((stem) => assertHeavenlyStem(stem, `${key}柱藏干`));
+
+    const branch = pillars[key].zhi;
+    const expected = HIDDEN_STEMS[branch];
+    if (!expected) {
+      throw new Error(`${key}柱藏干数据缺失：${branch}`);
+    }
+    if (
+      actual.length !== expected.length ||
+      actual.some((stem, index) => stem !== expected[index])
+    ) {
+      throw new Error(
+        `${key}柱藏干与地支${branch}不一致：应为${expected.join('、')}，实际为${actual.join('、') || '空'}`,
+      );
     }
   }
 }

--- a/packages/core/src/divination/algorithms/liuren/helpers/plate.ts
+++ b/packages/core/src/divination/algorithms/liuren/helpers/plate.ts
@@ -379,7 +379,11 @@ export function getPlateItemByBranch(plate: LiurenPlateItem[], branch: string) {
   return item;
 }
 
-export function getDayStemResidence(dayStem: string, fallbackBranch: string) {
+export function getDayStemResidence(dayStem: string) {
   assertStem(dayStem, '日干');
-  return DAY_STEM_RESIDENCE_MAP[dayStem] || fallbackBranch;
+  const residence = DAY_STEM_RESIDENCE_MAP[dayStem];
+  if (!residence) {
+    throw new Error(`日干寄宫数据缺失：${dayStem}`);
+  }
+  return residence;
 }

--- a/packages/core/src/divination/algorithms/liuren/index.ts
+++ b/packages/core/src/divination/algorithms/liuren/index.ts
@@ -285,7 +285,7 @@ export function generateLiuren(customDate?: Date): LiurenData {
   });
   const noblemanGroundBranch = getUnderByUpper(heavenlyPlate, noblemanBranch);
 
-  const dayStemResidence = getDayStemResidence(dayStem, dayBranch);
+  const dayStemResidence = getDayStemResidence(dayStem);
   const fourLessons = buildFourLessons({
     heavenlyPlate,
     dayStem,

--- a/packages/core/src/divination/algorithms/qimen/helpers/jushu-extended.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/jushu-extended.ts
@@ -12,6 +12,7 @@
  */
 
 import { jiazi } from '../../../../divination/divination-data';
+import { assertGanZhiName } from '../../../../bazi/baziUtils';
 
 const SAN_YUAN_BASE_YEAR = 1864; // 甲子上元起点
 
@@ -32,12 +33,14 @@ const SAN_YUAN_BASE_YEAR = 1864; // 甲子上元起点
  */
 export function getMonthQimenJuShu(
   monthGanZhi: string,
-  _yearGanZhi: string,
+  yearGanZhi: string,
 ): {
   isYangDun: boolean;
   juShu: number;
   yuan: string;
 } {
+  assertGanZhiName(monthGanZhi, '月干支');
+  assertGanZhiName(yearGanZhi, '年干支');
   const monthZhi = monthGanZhi.charAt(1);
 
   // 月支对应的月数（寅=1，卯=2，…，丑=12）
@@ -101,6 +104,7 @@ export function getYearQimenJuShu(
   juShu: number;
   yuan: string;
 } {
+  assertGanZhiName(yearGanZhi, '年干支');
   const yearGan = yearGanZhi.charAt(0);
   const yearIndex = jiazi.indexOf(yearGanZhi);
   if (yearIndex === -1) {
@@ -130,7 +134,10 @@ export function getYearQimenJuShu(
   const isYangDun = yuanCycle === '上元' || yuanCycle === '下元';
 
   // 古法按年干分组定局，同年干各年均起同局
-  const juShu = ganJuMap[yearGan] || 1;
+  const juShu = ganJuMap[yearGan];
+  if (!juShu) {
+    throw new Error(`年干定局数据缺失：${yearGan}`);
+  }
 
   return { isYangDun, juShu, yuan: yuanCycle };
 }

--- a/packages/core/src/divination/algorithms/qimen/helpers/patterns.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/patterns.ts
@@ -242,16 +242,22 @@ export function getQimenPatternTags(params: QimenPatternTagParams): string[] {
   // 星伏吟：值符落回原宫（palaceStars 索引+1）
   // 星反吟：值符落原宫的对冲宫
   const zhiFuOriginalPalace = palaceStars.indexOf(zhiFu) + 1;
-  if (zhiFuLandingPalace === zhiFuOriginalPalace) {
+  if (zhiFu && zhiFuOriginalPalace === 0) {
+    throw new Error(`值符星 "${zhiFu}" 无法识别。`);
+  }
+  if (zhiFu && zhiFuLandingPalace === zhiFuOriginalPalace) {
     tags.push('星伏吟');
-  } else if (getOppositePalace(zhiFuOriginalPalace) === zhiFuLandingPalace) {
+  } else if (zhiFu && getOppositePalace(zhiFuOriginalPalace) === zhiFuLandingPalace) {
     tags.push('星反吟');
   }
 
   // ── 2. 门伏吟 / 门反吟 ──
   // 门伏吟：值使落回原宫（doorPalaceMap 中该门对应宫位）
   // 门反吟：值使落原宫的对冲宫
-  const zhiShiOriginalPalace = doorPalaceMap[zhiShi as keyof typeof doorPalaceMap] || 0;
+  const zhiShiOriginalPalace = doorPalaceMap[zhiShi as keyof typeof doorPalaceMap];
+  if (!zhiShiOriginalPalace) {
+    throw new Error(`值使门 "${zhiShi}" 无法识别。`);
+  }
   if (zhiShiLandingPalace === zhiShiOriginalPalace) {
     tags.push('门伏吟');
   } else if (getOppositePalace(zhiShiOriginalPalace) === zhiShiLandingPalace) {

--- a/packages/core/src/divination/algorithms/qimen/helpers/star-palace.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/star-palace.ts
@@ -135,10 +135,13 @@ export function evaluateSingleStar(
   palaceElement: string,
 ): StarPalaceResult {
   const starWuxing = starElements[star];
-  const originalPalace = STAR_ORIGINAL_PALACES[star] ?? 0;
+  const originalPalace = STAR_ORIGINAL_PALACES[star];
 
   if (!starWuxing) {
     throw new Error(`九星 "${star}" 无法识别，不能评估旺衰。`);
+  }
+  if (!originalPalace) {
+    throw new Error(`九星 "${star}" 缺少本宫映射，不能评估旺衰。`);
   }
   if (!Number.isInteger(currentGong) || currentGong < 1 || currentGong > 9) {
     throw new Error(`宫位 "${currentGong}" 无效，必须是 1-9 的整数。`);

--- a/packages/core/src/divination/algorithms/xiaoliuren.ts
+++ b/packages/core/src/divination/algorithms/xiaoliuren.ts
@@ -201,7 +201,11 @@ function describeElementToDay(dayElement: string, palaceElement: string): string
     水: { 水: '比和', 土: '被克', 金: '得生', 木: '所生', 火: '所克' },
     土: { 土: '比和', 木: '被克', 火: '得生', 金: '所生', 水: '所克' },
   };
-  return relationTables[palaceElement]?.[dayElement] || '关系未定';
+  const relation = relationTables[palaceElement]?.[dayElement];
+  if (!relation) {
+    throw new Error(`小六壬无法判断宫位${palaceElement}与日主${dayElement}的五行关系。`);
+  }
+  return relation;
 }
 
 function buildStageChart(params: {
@@ -408,11 +412,11 @@ export function generateXiaoliuren(
   };
 
   // 旺衰按月令分析（取月干支的地支）
-  const monthBranch = ganzhi?.month?.slice(-1) || '';
+  const monthBranch = ganzhi.month.slice(-1);
   const seasonStates = {
-    start: monthBranch ? getSeasonState(start.element, monthBranch) : '平',
-    process: monthBranch ? getSeasonState(process.element, monthBranch) : '平',
-    result: monthBranch ? getSeasonState(result.element, monthBranch) : '平',
+    start: getSeasonState(start.element, monthBranch),
+    process: getSeasonState(process.element, monthBranch),
+    result: getSeasonState(result.element, monthBranch),
   };
 
   const timingProfiles: Record<
@@ -439,7 +443,7 @@ export function generateXiaoliuren(
     primaryBasis: [
       `结果宫为${result.name}，宫义节奏为${timingProfile.rhythm}`,
       `过程至结果五行关系为${processToResult}：${wuxingRelations.description}`,
-      `结果宫${result.element}在${monthBranch || '未知月支'}月为${resultSeasonState}，只作条件成熟度辅助`,
+      `结果宫${result.element}在${monthBranch}月为${resultSeasonState}，只作条件成熟度辅助`,
     ],
     triggerConditions: [timingProfile.trigger],
     limitations: [
@@ -449,7 +453,11 @@ export function generateXiaoliuren(
     ],
   };
 
-  const hourBranch = getShichenByIndex(hourIndex)?.branch || '子';
+  const shichen = getShichenByIndex(hourIndex);
+  if (!shichen) {
+    throw new Error(`小六壬时辰索引无效：${hourIndex}`);
+  }
+  const hourBranch = shichen.branch;
   const dayBranch = ganzhi.day.slice(-1);
   const dayStem = ganzhi.day.slice(0, 1);
   const yearBranch = ganzhi.year.slice(-1);

--- a/tests/bazi-analysis-pipeline.test.ts
+++ b/tests/bazi-analysis-pipeline.test.ts
@@ -361,6 +361,17 @@ test('分析管道应拒绝非法藏干和司令天干，不应让取用规则�
         pillars: VALID_PILLARS,
         hiddenStems: {
           ...VALID_HIDDEN_STEMS,
+          month: ['戊', '癸', '乙'],
+        },
+      }),
+    /month柱藏干与地支辰不一致/,
+  );
+  assert.throws(
+    () =>
+      pipeline.run({
+        pillars: VALID_PILLARS,
+        hiddenStems: {
+          ...VALID_HIDDEN_STEMS,
           month: ['风'],
         },
       }),

--- a/tests/bazi-pattern.test.ts
+++ b/tests/bazi-pattern.test.ts
@@ -2,8 +2,33 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { determinePattern } from '@core/bazi/baziPatternStrategy';
+import {
+  HIDDEN_STEMS,
+  LU_BRANCH_MAP,
+  REN_BRANCH_MAP,
+  SIXTY_CYCLE,
+} from '@core/bazi/baziDefinitions';
 import { getTenGod } from '@core/bazi/baziUtils';
-import type { Pillars } from '@core/bazi/baziTypes';
+import type { Pillar, Pillars } from '@core/bazi/baziTypes';
+
+function createPillar(match: (ganZhi: string) => boolean): Pillar {
+  const ganZhi = SIXTY_CYCLE.find(match);
+  assert.ok(ganZhi, '测试夹具必须能找到有效六十甲子');
+  return { gan: ganZhi[0], zhi: ganZhi[1], ganZhi };
+}
+
+function createPatternPillars(
+  dayMaster: string,
+  monthBranch: string,
+  exposedStem: string,
+): Pillars {
+  return {
+    year: createPillar((ganZhi) => ganZhi[0] === exposedStem),
+    month: createPillar((ganZhi) => ganZhi[1] === monthBranch),
+    day: createPillar((ganZhi) => ganZhi[0] === dayMaster),
+    hour: createPillar((ganZhi) => ganZhi === '甲子'),
+  };
+}
 
 test('特殊从格判断不能忽略地支副气里的印比', () => {
   const pillars: Pillars = {
@@ -33,7 +58,7 @@ test('专旺格判断不能忽略地支副气里的财官食伤', () => {
   assert.notEqual(result.pattern, '专旺格');
 });
 
-test('格局判定应优先参考月令司权，而不是把寅月一律当建禄', () => {
+test('建禄应按日干禄位精确取格，不应被初气司令透干改判为偏财格', () => {
   const pillars: Pillars = {
     year: { gan: '戊', zhi: '辰', ganZhi: '戊辰' },
     month: { gan: '丙', zhi: '寅', ganZhi: '丙寅' },
@@ -44,8 +69,40 @@ test('格局判定应优先参考月令司权，而不是把寅月一律当建�
   const result = determinePattern(pillars, '身强', getTenGod, '戊');
 
   assert.equal(result.isSpecial, false);
-  assert.equal(result.pattern, '偏财格');
-  assert.match(result.basis || '', /司权/);
+  assert.equal(result.pattern, '建禄格');
+  assert.match(result.basis || '', /禄位/);
+});
+
+test('十干建禄应按固定禄位命中，包括月支本气不是比肩的戊己土', () => {
+  Object.entries(LU_BRANCH_MAP).forEach(([dayMaster, monthBranch]) => {
+    const monthStems = HIDDEN_STEMS[monthBranch];
+    const commander = monthStems.find((stem) => stem !== dayMaster) || monthStems[0];
+    const result = determinePattern(
+      createPatternPillars(dayMaster, monthBranch, commander),
+      '身强',
+      getTenGod,
+      commander,
+    );
+
+    assert.equal(result.pattern, '建禄格', `${dayMaster}日${monthBranch}月应为建禄格`);
+    assert.match(result.basis || '', /禄位/);
+  });
+});
+
+test('五阳干月刃应按固定刃位命中，包括月支本气不是劫财的戊土', () => {
+  Object.entries(REN_BRANCH_MAP).forEach(([dayMaster, monthBranch]) => {
+    const monthStems = HIDDEN_STEMS[monthBranch];
+    const commander = monthStems.find((stem) => stem !== dayMaster) || monthStems[0];
+    const result = determinePattern(
+      createPatternPillars(dayMaster, monthBranch, commander),
+      '身强',
+      getTenGod,
+      commander,
+    );
+
+    assert.equal(result.pattern, '月刃格', `${dayMaster}日${monthBranch}月应为月刃格`);
+    assert.match(result.basis || '', /羊刃位/);
+  });
 });
 
 test('丁火生巳月时不应被透出的庚金误判为正财格', () => {
@@ -61,6 +118,14 @@ test('丁火生巳月时不应被透出的庚金误判为正财格', () => {
   assert.equal(result.isSpecial, false);
   assert.equal(result.pattern, '劫财格');
   assert.match(result.basis || '', /月令本气为丙/);
+});
+
+test('交节初段的上一月余气司权即使不在本月藏干中，也应按实际司令十神取格', () => {
+  const pillars = createPatternPillars('癸', '卯', '甲');
+  const result = determinePattern(pillars, '身强', getTenGod, '甲');
+
+  assert.equal(result.pattern, '伤官格');
+  assert.match(result.basis || '', /司权为甲/);
 });
 
 test('杂气多透时本气优先于透干柱位，不应只按透干柱位优先定格', () => {

--- a/tests/bazi-strength-analyzer.test.ts
+++ b/tests/bazi-strength-analyzer.test.ts
@@ -13,6 +13,10 @@ import { analyzeTenGodStructure } from '@core/bazi/tenGodAnalysis';
 import { getSeasonStatus, getWuxing } from '@core/bazi/baziUtils';
 import { SEASON_STATUS, WUXING_MONTH_WEIGHTS } from '@core/bazi/baziDefinitions';
 import type { Wuxing } from '@core/bazi/baziTypes';
+import {
+  collectCompleteBranchFormations,
+  collectEstablishedBranchFormations,
+} from '@core/bazi/baziFormationUtils';
 
 const SEASON_STATUS_RANK: Record<string, number> = {
   旺: 5,
@@ -329,6 +333,38 @@ test('三合三会成局时，旺衰评分应额外计入成局助势，而不�
   assert.ok(result.totalStrength > 0);
 });
 
+test('三合三会三支齐全但月令不支持时，只记录结构，不应计入成势力量', () => {
+  const pillars = {
+    year: { gan: '癸', zhi: '亥', ganZhi: '癸亥' },
+    month: { gan: '壬', zhi: '申', ganZhi: '壬申' },
+    day: { gan: '丁', zhi: '卯', ganZhi: '丁卯' },
+    hour: { gan: '辛', zhi: '未', ganZhi: '辛未' },
+  };
+
+  assert.equal(collectCompleteBranchFormations(pillars).length, 1);
+  assert.equal(collectEstablishedBranchFormations(pillars).length, 0);
+  assert.deepEqual(analyzeFormation('丁', pillars, getWuxing as (value: string) => Wuxing), {
+    formations: [],
+    totalStrength: 0,
+  });
+});
+
+test('三合三会被局外地支冲破时，只记录结构，不应计入成势力量', () => {
+  const pillars = {
+    year: { gan: '丁', zhi: '卯', ganZhi: '丁卯' },
+    month: { gan: '癸', zhi: '亥', ganZhi: '癸亥' },
+    day: { gan: '辛', zhi: '未', ganZhi: '辛未' },
+    hour: { gan: '癸', zhi: '酉', ganZhi: '癸酉' },
+  };
+
+  assert.equal(collectCompleteBranchFormations(pillars).length, 1);
+  assert.equal(collectEstablishedBranchFormations(pillars).length, 0);
+  assert.deepEqual(analyzeFormation('辛', pillars, getWuxing as (value: string) => Wuxing), {
+    formations: [],
+    totalStrength: 0,
+  });
+});
+
 test('克泄耗一方三合成局时，旺衰评分也应计入成局破势，不应仍按普通身弱看待', () => {
   const formation = analyzeFormation(
     '甲',
@@ -490,6 +526,16 @@ test('克泄耗统计不应把地支主气与同支本气藏干重复计入', ()
 
 test('旺衰分析器应拒绝坏输入，不应把缺失旺衰或未知五行按零分继续计算', () => {
   assert.throws(
+    () =>
+      analyzeSeasonalStatus(
+        '甲',
+        '辰',
+        () => ({ 木: '未知状态' }),
+        getWuxing as (value: string) => Wuxing,
+      ),
+    /月令旺衰状态无效/,
+  );
+  assert.throws(
     () => analyzeSeasonalStatus('甲', '辰', () => ({}), getWuxing as (value: string) => Wuxing),
     /月令旺衰数据缺失/,
   );
@@ -536,5 +582,25 @@ test('旺衰分析器应拒绝坏输入，不应把缺失旺衰或未知五行�
         getWuxing as (value: string) => Wuxing,
       ),
     /month柱藏干无效/,
+  );
+  assert.throws(
+    () =>
+      analyzeConstraint(
+        '甲',
+        {
+          year: { gan: '庚', zhi: '申', ganZhi: '庚申' },
+          month: { gan: '丙', zhi: '午', ganZhi: '丙午' },
+          day: { gan: '甲', zhi: '寅', ganZhi: '甲寅' },
+          hour: { gan: '戊', zhi: '辰', ganZhi: '戊辰' },
+        },
+        {
+          year: ['庚', '壬', '戊'],
+          month: ['丁', '己'],
+          day: ['甲', '丙', '戊'],
+          hour: ['戊', '癸', '乙'],
+        },
+        getWuxing as (value: string) => Wuxing,
+      ),
+    /hour柱藏干与地支辰不一致/,
   );
 });

--- a/tests/liuren-algorithm.test.ts
+++ b/tests/liuren-algorithm.test.ts
@@ -197,7 +197,7 @@ function buildReferenceLiurenPlate(args: { day: string; hour: string; monthLeade
     noblemanBranch: GUIREN_BRANCH_BY_STEM[dayStem][dayNight === '昼占' ? 'day' : 'night'],
     dayNight,
   });
-  const dayStemResidence = getDayStemResidence(dayStem, dayBranch);
+  const dayStemResidence = getDayStemResidence(dayStem);
   const lessons = buildFourLessons({
     heavenlyPlate,
     dayStem,
@@ -319,7 +319,7 @@ test('大六壬十干寄宫与四课上下递取应符合传统口径', () => {
   });
 
   for (const [dayStem, expectedResidence] of residenceCases) {
-    const dayStemResidence = getDayStemResidence(dayStem, '子');
+    const dayStemResidence = getDayStemResidence(dayStem);
     const lessons = buildFourLessons({
       heavenlyPlate: plate,
       dayStem,
@@ -612,7 +612,7 @@ test('大六壬涉害法无孟候选时应先取仲上神，不应改取季上�
   });
   const dayStem = '甲';
   const dayBranch = '卯';
-  const dayStemResidence = getDayStemResidence(dayStem, dayBranch);
+  const dayStemResidence = getDayStemResidence(dayStem);
   const lessons = buildFourLessons({
     heavenlyPlate,
     dayStem,
@@ -815,7 +815,7 @@ test('大六壬应与传统排盘样本的申将午时天地盘和十二天将�
 test('大六壬底层参数非法时应明确报错，不应用默认贵人或首个天盘项兜底', () => {
   assert.equal(getNoblemanBranch('甲', '昼占'), '丑');
   assert.throws(() => getNoblemanBranch('A', '昼占'), /日干必须是有效天干/);
-  assert.throws(() => getDayStemResidence('A', '子'), /日干必须是有效天干/);
+  assert.throws(() => getDayStemResidence('A'), /日干必须是有效天干/);
   assert.throws(
     () =>
       buildHeavenlyPlate({

--- a/tests/qimen-boundary.test.ts
+++ b/tests/qimen-boundary.test.ts
@@ -17,6 +17,11 @@ import {
   getDaySeasonRelation,
   getSeasonalElement,
 } from '../packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts';
+import {
+  getMonthQimenJuShu,
+  getYearQimenJuShu,
+} from '../packages/core/src/divination/algorithms/qimen/helpers/jushu-extended.ts';
+import { getQimenPatternTags } from '../packages/core/src/divination/algorithms/qimen/helpers/patterns.ts';
 
 test('奇门拆补法在交节当天应按具体时刻换节气，不应按整日提前换局', () => {
   const beforeXiaoman = generateQimen(new Date('2024-05-20T10:00:00+08:00'));
@@ -127,6 +132,37 @@ test('奇门九星旺衰：未知星或非法宫位应明确报错，不应默�
   );
 });
 
+test('月家与年家奇门应校验完整干支，不应只读取单个天干或地支', () => {
+  assert.deepEqual(getMonthQimenJuShu('丙寅', '甲辰'), {
+    isYangDun: true,
+    juShu: 1,
+    yuan: '月局',
+  });
+  assert.throws(() => getMonthQimenJuShu('甲丑', '甲辰'), /月干支不是有效六十甲子/);
+  assert.throws(() => getMonthQimenJuShu('丙寅', '甲丑'), /年干支不是有效六十甲子/);
+  assert.throws(() => getYearQimenJuShu('甲丑'), /年干支不是有效六十甲子/);
+});
+
+test('奇门格局应拒绝未知值符和值使，不应按零宫位继续判断', () => {
+  const baseParams = {
+    zhiFu: '天蓬',
+    zhiShi: '休门',
+    zhiFuLandingPalace: 1,
+    zhiShiLandingPalace: 1,
+    jiuGongGe: [],
+    hourGanForFind: '戊',
+  };
+
+  assert.throws(
+    () => getQimenPatternTags({ ...baseParams, zhiFu: '假星' }),
+    /值符星 "假星" 无法识别/,
+  );
+  assert.throws(
+    () => getQimenPatternTags({ ...baseParams, zhiShi: '假门' }),
+    /值使门 "假门" 无法识别/,
+  );
+});
+
 test('奇门节令：未知节气或日干应明确报错，不应降级成无法判定', () => {
   assert.equal(getSeasonalElement('立春'), '木');
   assert.equal(getDaySeasonRelation('甲', '木').relation, '得时');
@@ -134,7 +170,6 @@ test('奇门节令：未知节气或日干应明确报错，不应降级成无�
   assert.throws(() => getDaySeasonRelation('假', '木'), /无法识别日干 "假" 的五行属性/);
   assert.throws(() => getDaySeasonRelation('甲', ''), /节令五行不能为空/);
 });
-
 
 test('奇门定局方法应支持拆补与置闰，并在结果中标明', () => {
   const date = new Date('2024-05-20T21:30:00+08:00');

--- a/tests/traditional-relations.test.ts
+++ b/tests/traditional-relations.test.ts
@@ -536,3 +536,23 @@ test('占法共享月令旺衰应按古籍口径区分囚死', () => {
   assert.throws(() => getBranchWuxing('风'), /地支无效/);
   assert.throws(() => getHiddenMainStem('风'), /地支无效/);
 });
+
+test('十二月司令表应完整覆盖每月三十日，并以月支本气收尾', () => {
+  assert.equal(Object.keys(coreMonthCommander).length, 12);
+  assert.deepEqual(coreMonthCommander, appMonthCommander);
+
+  for (const branch of EARTHLY_BRANCHES) {
+    const entries = coreMonthCommander[branch];
+    assert.ok(entries, `${branch}月缺少司令数据`);
+    assert.equal(
+      entries.reduce((total, [, days]) => total + days, 0),
+      30,
+      `${branch}月司令天数应合计三十日`,
+    );
+    entries.forEach(([stem, days]) => {
+      assert.ok(HEAVENLY_STEMS.includes(stem), `${branch}月司令天干${stem}无效`);
+      assert.ok(Number.isInteger(days) && days > 0, `${branch}月司令天数必须是正整数`);
+    });
+    assert.equal(entries.at(-1)?.[0], HIDDEN_STEMS[branch][0], `${branch}月末段应由本气司令`);
+  }
+});


### PR DESCRIPTION
## 目标

修正八字格局优先级和三合三会成势判断，并清理奇门、大六壬、小六壬中会掩盖坏输入的默认兜底。

## 主要修改

- 建禄、月刃按十干固定禄刃位优先取格，月令司权按实际司令天干参与判断
- 三合三会仅在化神得令且未被局外地支冲破时计入旺衰、特殊格和用神
- 严格核验四柱藏干与对应地支，拒绝未知旺衰状态
- 奇门严格校验月年干支、值符值使和九星本宫映射
- 大六壬寄宫、小六壬五行关系与时辰取消静默默认值
- 增加八字、奇门、大六壬与十二月司令表回归测试

## 验证

- pnpm test：1401 项通过
- pnpm test:e2e：36 项通过
- pnpm exec tsc -p tsconfig.app.json --noEmit：通过
- pnpm lint：通过
- pnpm build：通过
- 本次改动文件 Prettier 检查：通过
- 全仓 format:check 仍受主分支已有 7 个无关测试文件格式问题影响，本次未混入修改

## 兼容风险

以前被默认值掩盖的非法调用现在会明确报错；正常排盘输入与公开结果结构不变。