### PR TITLE
收紧占卜算法输入与成局判断

### DIFF
--- a/packages/core/src/divination/algorithms/jinkoujue.ts
+++ b/packages/core/src/divination/algorithms/jinkoujue.ts
@@ -63,6 +63,7 @@ const MONTH_LEADER_BY_ZHONGQI: Record<string, string> = {
 };
 
 const DAYTIME_BRANCHES = new Set(['卯', '辰', '巳', '午', '未', '申']);
+const VALID_WUXING = new Set(['木', '火', '土', '金', '水']);
 
 /** 五子元遁：甲己还加甲，乙庚丙作初，丙辛从戊起，丁壬庚子居，戊癸何方发，壬子是真途 */
 const WUZI_YUAN_STEM: Record<string, string> = {
@@ -137,7 +138,9 @@ function getYuanStemOnBranch(dayStem: string, branch: string) {
 }
 
 function describeElementRelation(sourceElement: string, targetElement: string) {
-  if (!sourceElement || !targetElement) return '关系未定';
+  if (!VALID_WUXING.has(sourceElement) || !VALID_WUXING.has(targetElement)) {
+    throw new Error(`金口诀四位五行无效：${sourceElement || '空'} -> ${targetElement || '空'}。`);
+  }
   if (sourceElement === targetElement) return '比和';
   if (isSheng(sourceElement, targetElement)) return '生';
   if (isSheng(targetElement, sourceElement)) return '被生';
@@ -155,6 +158,11 @@ function buildPosition(params: {
   xunKong: string[];
 }): JinkoujueFourPosition {
   const element = params.stem ? getStemWuxing(params.stem) : getBranchWuxing(params.branch);
+  if (!VALID_WUXING.has(element)) {
+    throw new Error(
+      `金口诀${params.name}五行数据缺失：${params.stem ? `天干${params.stem}` : `地支${params.branch}`}。`,
+    );
+  }
   const seasonState = getSeasonState(element, params.monthBranch);
   const isVoid = params.xunKong.includes(params.branch);
   const support: string[] = [];
@@ -167,7 +175,10 @@ function buildPosition(params: {
   if (isVoid) constraints.push('落日旬空');
   if (params.god) {
     const attr = TIANJIANG_ATTRIBUTES[params.god as TianJiangName];
-    if (attr) support.push(`天将属${attr.category}`);
+    if (!attr) {
+      throw new Error(`金口诀${params.name}天将数据缺失：${params.god}。`);
+    }
+    support.push(`天将属${attr.category}`);
   }
 
   return {

--- a/packages/core/src/divination/algorithms/liuren/helpers/lessons.ts
+++ b/packages/core/src/divination/algorithms/liuren/helpers/lessons.ts
@@ -31,6 +31,7 @@ const STEM_RESIDENCE_MAP = DAY_STEM_RESIDENCE_MAP;
 const MENG_BRANCHES = new Set(['寅', '巳', '申', '亥']);
 const ZHONG_BRANCHES = new Set(['子', '卯', '午', '酉']);
 const JI_BRANCHES = new Set(['辰', '戌', '丑', '未']);
+const VALID_WUXING = new Set(['木', '火', '土', '金', '水']);
 const STEMS_BY_RESIDENCE: Record<string, string[]> = Object.entries(STEM_RESIDENCE_MAP).reduce<
   Record<string, string[]>
 >((acc, [stem, branch]) => {
@@ -205,7 +206,14 @@ function isSameYinYangAsDayStem(branch: string, dayStem: string) {
 
 function getStemWuxing(stem: string) {
   const stemIndex = HEAVENLY_STEMS.indexOf(stem as (typeof HEAVENLY_STEMS)[number]);
-  return stemIndex >= 0 ? BASIC_MAPPINGS.STEM_WUXING[stemIndex] : '';
+  if (stemIndex < 0) {
+    throw new Error(`无法识别天干 "${stem}" 的五行属性。`);
+  }
+  const element = BASIC_MAPPINGS.STEM_WUXING[stemIndex];
+  if (!VALID_WUXING.has(element)) {
+    throw new Error(`天干 ${stem} 的五行数据缺失。`);
+  }
+  return element;
 }
 
 function uniqueCandidatesByUpper(candidates: KeCandidate[]) {
@@ -220,16 +228,15 @@ function uniqueCandidatesByUpper(candidates: KeCandidate[]) {
 }
 
 function hasSameDayAndHourElement(context: ResolveTransmissionContext) {
+  if (!context.hourStem || !context.hourBranch) {
+    return false;
+  }
   const dayStemElement = getGanZhiWuxing(context.dayStem);
   const dayBranchElement = getGanZhiWuxing(context.dayBranch);
-  const hourStemElement = getGanZhiWuxing(context.hourStem || '');
-  const hourBranchElement = getGanZhiWuxing(context.hourBranch || '');
+  const hourStemElement = getGanZhiWuxing(context.hourStem);
+  const hourBranchElement = getGanZhiWuxing(context.hourBranch);
 
-  return (
-    Boolean(dayStemElement && hourStemElement) &&
-    dayStemElement === dayBranchElement &&
-    hourStemElement === hourBranchElement
-  );
+  return dayStemElement === dayBranchElement && hourStemElement === hourBranchElement;
 }
 
 function getBranchAt(rawIndex: number) {
@@ -240,7 +247,7 @@ function getBranchAt(rawIndex: number) {
 function shiftBranch(branch: string, steps: number) {
   const index = getBranchIndex(branch);
   if (index < 0) {
-    return branch;
+    throw new Error(`无法移动非法地支 "${branch}"。`);
   }
   return getBranchAt(index + steps);
 }
@@ -249,7 +256,7 @@ function walkBranches(start: string, end: string) {
   const startIndex = getBranchIndex(start);
   const endIndex = getBranchIndex(end);
   if (startIndex < 0 || endIndex < 0) {
-    return [];
+    throw new Error(`涉害深度计算收到非法地支：${start} -> ${end}。`);
   }
 
   const branches: string[] = [];
@@ -270,7 +277,10 @@ function getHarmDepth(candidate: KeCandidate, context: ResolveTransmissionContex
   const walkedBranches = walkBranches(startUnder, candidate.lesson.upper);
 
   return walkedBranches.reduce((count, branch) => {
-    const branchElement = BRANCH_WUXING[branch] || '';
+    const branchElement = BRANCH_WUXING[branch];
+    if (!VALID_WUXING.has(branchElement)) {
+      throw new Error(`地支 ${branch} 的五行数据缺失。`);
+    }
     const housedStemElements = (STEMS_BY_RESIDENCE[branch] || [])
       .map(getStemWuxing)
       .filter(Boolean);
@@ -319,10 +329,13 @@ function pickByHarmDepth(candidates: KeCandidate[], context: ResolveTransmission
   const preferredUpper = YANG_STEMS.has(context.dayStem)
     ? context.dayStemResidence
     : context.dayBranch;
-  return (
-    tied.find((item) => item.candidate.lesson.upper === preferredUpper)?.candidate ||
-    tied[0].candidate
-  );
+  const picked =
+    tied.find((item) => item.candidate.lesson.upper === preferredUpper)?.candidate ??
+    tied[0]?.candidate;
+  if (!picked) {
+    throw new Error('涉害法没有可供比较的候选课。');
+  }
+  return picked;
 }
 
 function resolveMultipleCandidates(
@@ -381,7 +394,7 @@ function pickZhiYiVariant(
     return null;
   }
 
-  return lessons[1] || null;
+  return lessons[1];
 }
 
 function resolveKeCandidates(
@@ -469,15 +482,19 @@ function getUniqueLessonPairCount(lessons: LiurenLesson[]) {
 }
 
 function getPunishment(branch: string) {
-  return SANXING_MAP[branch] || branch;
+  const punishment = SANXING_MAP[branch];
+  if (!punishment) {
+    throw new Error(`地支 ${branch} 的三刑映射缺失。`);
+  }
+  return punishment;
 }
 
 function resolveFuyinTransmission(
   lessons: LiurenLesson[],
   context: ResolveTransmissionContext,
 ): InitialTransmissionResult {
-  const yiKeUpper = lessons[0]?.upper || context.dayStemResidence;
-  const sanKeUpper = lessons[2]?.upper || context.dayBranch;
+  const yiKeUpper = lessons[0].upper;
+  const sanKeUpper = lessons[2].upper;
   const isSelfResponsibility =
     YANG_STEMS.has(context.dayStem) || context.dayStem === '乙' || context.dayStem === '癸';
   const useDayStemSide = isSelfResponsibility;
@@ -490,7 +507,11 @@ function resolveFuyinTransmission(
 
   let final = getPunishment(middle);
   if (final === middle || getPunishment(middle) === initial) {
-    final = LIUCHONG_MAP[middle] || middle;
+    const opposite = LIUCHONG_MAP[middle];
+    if (!opposite) {
+      throw new Error(`地支 ${middle} 的六冲映射缺失。`);
+    }
+    final = opposite;
   }
 
   return {
@@ -522,9 +543,12 @@ function resolveFanyinTransmission(
     return keResult;
   }
 
-  const yiKeUpper = lessons[0]?.upper || context.dayStemResidence;
-  const sanKeUpper = lessons[2]?.upper || context.dayBranch;
-  const initial = getYiMa(context.dayBranch) || getUpperByUnder(context.heavenlyPlate, '寅');
+  const yiKeUpper = lessons[0].upper;
+  const sanKeUpper = lessons[2].upper;
+  const initial = getYiMa(context.dayBranch);
+  if (!initial) {
+    throw new Error(`日支 ${context.dayBranch} 的驿马映射缺失。`);
+  }
 
   return {
     initial,
@@ -538,9 +562,9 @@ function resolveSpecialTransmission(
   lessons: LiurenLesson[],
   context: ResolveTransmissionContext,
 ): InitialTransmissionResult {
-  const yiKeUpper = lessons[0]?.upper || context.dayStemResidence;
-  const sanKeUpper = lessons[2]?.upper || context.dayBranch;
-  const siKeUpper = lessons[3]?.upper || sanKeUpper;
+  const yiKeUpper = lessons[0].upper;
+  const sanKeUpper = lessons[2].upper;
+  const siKeUpper = lessons[3].upper;
   const isYangDay = YANG_STEMS.has(context.dayStem);
   const isBazhuanDay = BAZHUAN_DAYS.has(`${context.dayStem}${context.dayBranch}`);
 
@@ -568,8 +592,14 @@ function resolveSpecialTransmission(
 
   if (getUniqueLessonPairCount(lessons) === 3) {
     if (isYangDay) {
-      const heStem = TIAN_GAN_HE[context.dayStem]?.partner || context.dayStem;
-      const heStemResidence = STEM_RESIDENCE_MAP[heStem] || context.dayStemResidence;
+      const heStem = TIAN_GAN_HE[context.dayStem]?.partner;
+      if (!heStem) {
+        throw new Error(`日干 ${context.dayStem} 的天干五合映射缺失。`);
+      }
+      const heStemResidence = STEM_RESIDENCE_MAP[heStem];
+      if (!heStemResidence) {
+        throw new Error(`合干 ${heStem} 的寄宫映射缺失。`);
+      }
       const initial = getUpperByUnder(context.heavenlyPlate, heStemResidence);
       return {
         initial,

--- a/packages/core/src/divination/algorithms/liuren/helpers/plate.ts
+++ b/packages/core/src/divination/algorithms/liuren/helpers/plate.ts
@@ -8,6 +8,7 @@ import { BRANCH_WUXING, getBranchIndex, isKe, isSheng } from '../../../../ganzhi
 
 export const DIZHI = EARTHLY_BRANCHES;
 export const TIANGAN = HEAVENLY_STEMS;
+const VALID_WUXING = new Set(['木', '火', '土', '金', '水']);
 
 /**
  * 十二天将（《大六壬大全》天将体系）：
@@ -259,10 +260,6 @@ function assertDayNight(value: string): asserts value is '昼占' | '夜占' {
 export function describeRelation(sourceBranch: string, targetBranch: string) {
   const sourceElement = getGanZhiWuxing(sourceBranch);
   const targetElement = getGanZhiWuxing(targetBranch);
-
-  if (!sourceElement || !targetElement) {
-    return '关系待定';
-  }
   if (sourceElement === targetElement) {
     return '比和';
   }
@@ -285,25 +282,30 @@ export function describeRelation(sourceBranch: string, targetBranch: string) {
 export function getGanZhiWuxing(value: string) {
   const stemIndex = TIANGAN.indexOf(value as (typeof TIANGAN)[number]);
   if (stemIndex >= 0) {
-    return BASIC_MAPPINGS.STEM_WUXING[stemIndex] || '';
+    const element = BASIC_MAPPINGS.STEM_WUXING[stemIndex];
+    if (!VALID_WUXING.has(element)) {
+      throw new Error(`天干 ${value} 的五行数据缺失。`);
+    }
+    return element;
   }
-
-  return BRANCH_WUXING[value] || '';
+  const element = BRANCH_WUXING[value];
+  if (!VALID_WUXING.has(element)) {
+    throw new Error(`无法识别干支 "${value}" 的五行属性。`);
+  }
+  return element;
 }
 
 export function isBranchKe(sourceBranch: string, targetBranch: string) {
   const sourceElement = getGanZhiWuxing(sourceBranch);
   const targetElement = getGanZhiWuxing(targetBranch);
-  if (!sourceElement || !targetElement) {
-    return false;
-  }
-
   return isKe(sourceElement, targetElement);
 }
 
 export function isElementKe(sourceElement: string, targetElement: string) {
-  if (!sourceElement || !targetElement) {
-    return false;
+  if (!VALID_WUXING.has(sourceElement) || !VALID_WUXING.has(targetElement)) {
+    throw new Error(
+      `大六壬五行比较参数无效：${sourceElement || '空'} -> ${targetElement || '空'}。`,
+    );
   }
 
   return isKe(sourceElement, targetElement);
@@ -364,10 +366,13 @@ export function buildHeavenlyPlate(args: {
     byUpperGod.set(DIZHI[branchIndex], TIANJIANG[godIndex]);
   }
 
-  return basePlate.map((item) => ({
-    ...item,
-    god: byUpperGod.get(item.branch) || '贵人',
-  }));
+  return basePlate.map((item) => {
+    const god = byUpperGod.get(item.branch);
+    if (!god || !TIANJIANG.includes(god as TianJiangName)) {
+      throw new Error(`上神 ${item.branch} 的十二天将映射缺失。`);
+    }
+    return { ...item, god };
+  });
 }
 
 export function getPlateItemByBranch(plate: LiurenPlateItem[], branch: string) {

--- a/packages/core/src/divination/algorithms/liuren/index.ts
+++ b/packages/core/src/divination/algorithms/liuren/index.ts
@@ -303,8 +303,17 @@ export function generateLiuren(customDate?: Date): LiurenData {
     heavenlyPlate,
   });
   const chu = initialResult.initial;
-  const zhong = initialResult.branches?.[1] || getUpperByUnder(heavenlyPlate, chu);
-  const mo = initialResult.branches?.[2] || getUpperByUnder(heavenlyPlate, zhong);
+  let zhong: string;
+  let mo: string;
+  if (initialResult.branches) {
+    if (initialResult.branches.length !== 3 || initialResult.branches[0] !== chu) {
+      throw new Error(`${initialResult.rule}返回的三传结构不完整或与初传不一致。`);
+    }
+    [, zhong, mo] = initialResult.branches;
+  } else {
+    zhong = getUpperByUnder(heavenlyPlate, chu);
+    mo = getUpperByUnder(heavenlyPlate, zhong);
+  }
   const inferredTransmissionPattern = getTransmissionPattern(chu, zhong, mo);
   const transmissionPattern = initialResult.rule.includes('伏吟')
     ? '伏吟'
@@ -370,7 +379,7 @@ export function generateLiuren(customDate?: Date): LiurenData {
       evidence: [
         `${initialResult.rule}取为初传`,
         `月令${firstTransmission.seasonState}`,
-        firstTransmission.dayRelation || '与日支关系平',
+        firstTransmission.dayRelation,
       ],
       limitations: firstTransmission.isVoid ? ['初传空亡，主证需待填实'] : [],
     },

--- a/packages/core/src/divination/algorithms/liuyao.ts
+++ b/packages/core/src/divination/algorithms/liuyao.ts
@@ -120,18 +120,17 @@ function isRiMu(branch: string, dayBranch: string): boolean {
  * "三合主久远、多人协力，事势增强，吉凶随局而定。"
  */
 function checkSanheWithTrigger(
-  yaoBranches: string[],
+  activeBranches: string[],
   triggerBranch: string,
   triggerLabel: '日辰' | '月建',
 ): { group: string; members: string[]; description: string } | null {
-  const allBranches = new Set([...yaoBranches, triggerBranch]);
-  // 完整三合局
+  const activeBranchSet = new Set(activeBranches);
   for (const [group, members] of Object.entries(SANHE_GROUPS)) {
     if (!members.includes(triggerBranch)) {
       continue;
     }
-    const present = members.filter((m) => allBranches.has(m));
-    if (present.length === members.length) {
+    const requiredYaoBranches = members.filter((member) => member !== triggerBranch);
+    if (requiredYaoBranches.every((member) => activeBranchSet.has(member))) {
       return {
         group,
         members,
@@ -983,10 +982,16 @@ export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOpti
     voidBranches: voids,
   });
 
-  // 三合局检测：日辰/月建与爻中静爻/动爻组成的三合局
+  // 三合局只取明动、暗动及其变爻；静态纳甲支不能自行凑局。
   const yaoBranches = yaosInfo.map((i) => i.dizhi);
-  const sanheWithDay = checkSanheWithTrigger(yaoBranches, dayBranch, '日辰');
-  const sanheWithMonth = checkSanheWithTrigger(yaoBranches, monthBranch, '月建');
+  const activeBranches = yaosDetail.flatMap((yao) => {
+    if (!yao.isChanging && !yao.isHiddenMove) {
+      return [];
+    }
+    return yao.changedYao ? [yao.najiaDizhi, yao.changedYao.dizhi] : [yao.najiaDizhi];
+  });
+  const sanheWithDay = checkSanheWithTrigger(activeBranches, dayBranch, '日辰');
+  const sanheWithMonth = checkSanheWithTrigger(activeBranches, monthBranch, '月建');
 
   const sanxingInYaos = collectSanxingInBranches(yaoBranches);
 

--- a/packages/core/src/divination/algorithms/meihua/index.ts
+++ b/packages/core/src/divination/algorithms/meihua/index.ts
@@ -32,12 +32,16 @@ import { hasRandomOptions } from '../../../shared/random';
 import { analyzeMeihuaEvidence } from '../../meihua-evidence';
 
 const trigrams = trigramsByIndex;
+const VALID_WUXING = new Set(['木', '火', '土', '金', '水']);
+const MOVING_YAO_NAMES = ['初爻', '二爻', '三爻', '四爻', '五爻', '上爻'] as const;
 
 /**
  * 体用生克关系判定字串
  */
 function getTiYongRelation(yongElement: string, tiElement: string): string {
-  if (!yongElement || !tiElement) return '无';
+  if (!VALID_WUXING.has(yongElement) || !VALID_WUXING.has(tiElement)) {
+    throw new Error(`梅花易数体用五行无效：用${yongElement || '空'}、体${tiElement || '空'}。`);
+  }
   if (yongElement === tiElement) return '比和';
   if (isSheng(yongElement, tiElement)) return '用生体';
   if (isSheng(tiElement, yongElement)) return '体生用';
@@ -190,11 +194,12 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
 
   const interLowerResult = findTrigramByBottomUpLines(interLowerLines);
   const interUpperResult = findTrigramByBottomUpLines(interUpperLines);
-
-  const interHexagram =
-    interLowerResult && interUpperResult
-      ? findHexagramByTrigrams(interUpperResult.index, interLowerResult.index)
-      : null;
+  if (!interLowerResult || !interUpperResult) {
+    throw new Error(
+      `梅花易数互卦经卦匹配失败：下互${interLowerLines.join('')}、上互${interUpperLines.join('')}。`,
+    );
+  }
+  const interHexagram = findHexagramByTrigrams(interUpperResult.index, interLowerResult.index);
 
   const changedLines = [...mainLines];
   changedLines[movingYaoIndex - 1] = 1 - changedLines[movingYaoIndex - 1];
@@ -204,24 +209,33 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
 
   const changedLowerResult = findTrigramByBottomUpLines(changedLowerLines);
   const changedUpperResult = findTrigramByBottomUpLines(changedUpperLines);
-
-  const changingHexagram =
-    changedLowerResult && changedUpperResult
-      ? findHexagramByTrigrams(changedUpperResult.index, changedLowerResult.index)
-      : null;
+  if (!changedLowerResult || !changedUpperResult) {
+    throw new Error(
+      `梅花易数变卦经卦匹配失败：下卦${changedLowerLines.join('')}、上卦${changedUpperLines.join('')}。`,
+    );
+  }
+  const changingHexagram = findHexagramByTrigrams(
+    changedUpperResult.index,
+    changedLowerResult.index,
+  );
 
   // 定体用之法，以动爻为准：动爻所在的经卦为“用”，静止的另一经卦为“体”。
   // 动爻在四、五、上爻时，上卦为用、下卦为体；反之则下卦为用、上卦为体。
   const { tiGua, yongGua } = resolveTiYongByMovingYao(upperTrigram, lowerTrigram, movingYaoIndex);
 
-  const changedTiYong =
-    changedUpperResult && changedLowerResult
-      ? resolveTiYongByMovingYao(
-          changedUpperResult.trigram,
-          changedLowerResult.trigram,
-          movingYaoIndex,
-        )
-      : null;
+  const changedTiYong = resolveTiYongByMovingYao(
+    changedUpperResult.trigram,
+    changedLowerResult.trigram,
+    movingYaoIndex,
+  );
+  const movingYaoName = MOVING_YAO_NAMES[movingYaoIndex - 1];
+  if (!movingYaoName) {
+    throw new Error(`梅花易数动爻层位无效：${movingYaoIndex}。`);
+  }
+  const movingYaoCi = mainHexagram.yaoCi?.[movingYaoIndex - 1];
+  if (!movingYaoCi) {
+    throw new Error(`梅花易数${mainHexagram.name}缺少第${movingYaoIndex}爻爻辞。`);
+  }
 
   const yaosDetail = mainLines.map((line, index) => ({
     position: index + 1,
@@ -244,26 +258,22 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
 
   const result: MeihuaData = {
     originalName: mainHexagram.name,
-    changedName: changingHexagram?.name || '',
-    interName: interHexagram?.name || '',
+    changedName: changingHexagram.name,
+    interName: interHexagram.name,
 
     // 核心体用关系
     tiGua: { name: tiGua.name, element: tiGua.element, nature: tiGua.nature },
     yongGua: { name: yongGua.name, element: yongGua.element, nature: yongGua.nature },
-    changedTiGua: changedTiYong
-      ? {
-          name: changedTiYong.tiGua.name,
-          element: changedTiYong.tiGua.element,
-          nature: changedTiYong.tiGua.nature,
-        }
-      : null,
-    changedYongGua: changedTiYong
-      ? {
-          name: changedTiYong.yongGua.name,
-          element: changedTiYong.yongGua.element,
-          nature: changedTiYong.yongGua.nature,
-        }
-      : null,
+    changedTiGua: {
+      name: changedTiYong.tiGua.name,
+      element: changedTiYong.tiGua.element,
+      nature: changedTiYong.tiGua.nature,
+    },
+    changedYongGua: {
+      name: changedTiYong.yongGua.name,
+      element: changedTiYong.yongGua.element,
+      nature: changedTiYong.yongGua.nature,
+    },
 
     // 卦象详情
     mainHexagram: {
@@ -273,37 +283,33 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
       lower: lowerTrigram.name,
       description: mainHexagram.description,
       yaoCi: mainHexagram.yaoCi,
-      movingYaoCi: mainHexagram.yaoCi?.[movingYaoIndex - 1] || '',
+      movingYaoCi,
       yongCi: mainHexagram.yongCi,
     },
-    changedHexagram: changingHexagram
-      ? {
-          name: changingHexagram.name,
-          symbol: changingHexagram.symbol,
-          upper: changedUpperResult?.trigram?.name || '',
-          lower: changedLowerResult?.trigram?.name || '',
-          description: changingHexagram.description,
-          yaoCi: changingHexagram.yaoCi,
-          yongCi: changingHexagram.yongCi,
-        }
-      : null,
-    interHexagram: interHexagram
-      ? {
-          name: interHexagram.name,
-          symbol: interHexagram.symbol,
-          upper: interUpperResult?.trigram?.name || '',
-          lower: interLowerResult?.trigram?.name || '',
-          description: interHexagram.description,
-          yaoCi: interHexagram.yaoCi,
-          yongCi: interHexagram.yongCi,
-        }
-      : null,
+    changedHexagram: {
+      name: changingHexagram.name,
+      symbol: changingHexagram.symbol,
+      upper: changedUpperResult.trigram.name,
+      lower: changedLowerResult.trigram.name,
+      description: changingHexagram.description,
+      yaoCi: changingHexagram.yaoCi,
+      yongCi: changingHexagram.yongCi,
+    },
+    interHexagram: {
+      name: interHexagram.name,
+      symbol: interHexagram.symbol,
+      upper: interUpperResult.trigram.name,
+      lower: interLowerResult.trigram.name,
+      description: interHexagram.description,
+      yaoCi: interHexagram.yaoCi,
+      yongCi: interHexagram.yongCi,
+    },
 
     // 动爻信息
     movingYao: {
       position: movingYaoIndex,
       description: `第${movingYaoIndex}爻动`,
-      yaoName: ['初爻', '二爻', '三爻', '四爻', '五爻', '上爻'][movingYaoIndex - 1] || '未知',
+      yaoName: movingYaoName,
     },
 
     analysis: {
@@ -315,33 +321,23 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
       // 原动爻在下卦（1/2/3爻）→互卦的下卦为互体、上卦为互用；
       // 原动爻在上卦（4/5/6爻）→互卦的上卦为互体、下卦为互用。
       // 以互用对互体论生克，反映事态发展过程中的关键关系。
-      inter1Relation:
-        interLowerResult && interUpperResult
-          ? MeihuaHelpers.getElementRelation(
-              movingYaoIndex <= 3
-                ? interUpperResult.trigram.element
-                : interLowerResult.trigram.element,
-              movingYaoIndex <= 3
-                ? interLowerResult.trigram.element
-                : interUpperResult.trigram.element,
-            )
-          : '无',
+      inter1Relation: MeihuaHelpers.getElementRelation(
+        movingYaoIndex <= 3 ? interUpperResult.trigram.element : interLowerResult.trigram.element,
+        movingYaoIndex <= 3 ? interLowerResult.trigram.element : interUpperResult.trigram.element,
+      ),
       // 另一互卦经卦对原体卦的辅助关系（非正统，仅作参考）
-      inter2Relation: interUpperResult
-        ? MeihuaHelpers.getElementRelation(interUpperResult.trigram.element, tiGua.element)
-        : '无',
-      changedRelation: changedTiYong
-        ? MeihuaHelpers.getElementRelation(
-            changedTiYong.yongGua.element,
-            changedTiYong.tiGua.element,
-          )
-        : '无变卦',
-      changedTiYongRelation: changedTiYong
-        ? MeihuaHelpers.getElementRelation(
-            changedTiYong.yongGua.element,
-            changedTiYong.tiGua.element,
-          )
-        : '无变卦',
+      inter2Relation: MeihuaHelpers.getElementRelation(
+        interUpperResult.trigram.element,
+        tiGua.element,
+      ),
+      changedRelation: MeihuaHelpers.getElementRelation(
+        changedTiYong.yongGua.element,
+        changedTiYong.tiGua.element,
+      ),
+      changedTiYongRelation: MeihuaHelpers.getElementRelation(
+        changedTiYong.yongGua.element,
+        changedTiYong.tiGua.element,
+      ),
       tiYongRaw: getTiYongRelation(yongGua.element, tiGua.element),
       yingQi: estimateYingQi({
         movingYaoIndex,

--- a/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
@@ -300,15 +300,26 @@ const MOON_PHASE_MAP: Record<number, LunarPhase> = {
   7: '下弦',
 };
 
+export function getLunarPhaseByIndex(index: number): LunarPhase {
+  const phase = MOON_PHASE_MAP[index];
+  if (!phase) {
+    throw new Error(`无法识别历法月相索引 "${index}"。`);
+  }
+  return phase;
+}
+
 /**
  * 获取农历日对应的四相月相
  * @param date 公历日期
  * @returns 月相
  */
 export function getLunarPhase(date: Date): LunarPhase {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error('月相日期必须是有效日期。');
+  }
   const solarDay = SolarDay.fromYmd(date.getFullYear(), date.getMonth() + 1, date.getDate());
   const phase = solarDay.getLunarDay().getPhase();
-  return MOON_PHASE_MAP[phase.getIndex()] ?? '新月';
+  return getLunarPhaseByIndex(phase.getIndex());
 }
 
 // ============================================================================
@@ -382,6 +393,14 @@ const DAY_OFFICER_INFO: Record<string, { fortune: '吉' | '凶' | '平'; meaning
   闭: { fortune: '凶', meaning: '闭为天狱，宜安葬、收藏，忌开市出行' },
 };
 
+export function getDayOfficerInfo(dayOfficer: string) {
+  const info = DAY_OFFICER_INFO[dayOfficer];
+  if (!info) {
+    throw new Error(`无法识别建除十二神 "${dayOfficer}"。`);
+  }
+  return info;
+}
+
 /**
  * 构建完整节令背景信息
  *
@@ -409,7 +428,7 @@ export function buildSeasonality(ganzhi: BaseGanZhi, jieQi: string, date: Date):
   const solarDay = SolarDay.fromYmd(date.getFullYear(), date.getMonth() + 1, date.getDate());
   const tymePhase = solarDay.getLunarDay().getPhase();
   const phaseIndex = tymePhase.getIndex();
-  const lunarPhase = MOON_PHASE_MAP[phaseIndex] ?? '新月';
+  const lunarPhase = getLunarPhaseByIndex(phaseIndex);
   const lunarPhaseDetail = tymePhase.getName();
   const moonPhaseEvidence = calculateMoonPhaseEvidence(date.getTime());
   const lunarPhaseConsistency = lunarPhaseDetail === moonPhaseEvidence.eightPhaseName;
@@ -417,10 +436,7 @@ export function buildSeasonality(ganzhi: BaseGanZhi, jieQi: string, date: Date):
   // ── 4. 建除十二神 ──
   const duty = solarDay.getLunarDay().getDuty();
   const dayOfficer = duty.getName();
-  const officerInfo = DAY_OFFICER_INFO[dayOfficer] ?? {
-    fortune: '平' as const,
-    meaning: '未知建除',
-  };
+  const officerInfo = getDayOfficerInfo(dayOfficer);
 
   // ── 5. 干支互动分析 ──
   const ganzhiInteractions = analyzeGanzhiInteractions(ganzhi);

--- a/packages/core/src/divination/algorithms/qimen/helpers/stem-pair-patterns.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/stem-pair-patterns.ts
@@ -67,14 +67,7 @@ function getAutoPattern(heavenStem: string, earthStem: string): StemPairPattern 
   const earthElem = stemElements[earthStem];
 
   if (!heavenElem || !earthElem) {
-    return {
-      name: '未知',
-      type: 'neutral',
-      score: 0,
-      summary: `天盘${heavenStem}与地盘${earthStem}的五行属性无法识别。`,
-      interpretation: '无法判断两者关系。',
-      manifestation: '需结合其他宫位信息综合判断。',
-    };
+    throw new Error(`奇门十干组合五行数据缺失：天盘${heavenStem}、地盘${earthStem}。`);
   }
 
   // 五行相同 → 比和
@@ -1348,11 +1341,9 @@ const NAMED_PATTERNS: Record<string, StemPairPattern> = {
  * // { name: '比和', type: 'neutral', score: 0, ... }
  * ```
  */
-export function getStemPairPattern(heavenStem: string, earthStem: string): StemPairPattern | null {
-  // 参数校验
-  if (!heavenStem || !earthStem) return null;
-  if (heavenStem === '甲' || earthStem === '甲') return null;
-  if (!stemElements[heavenStem] || !stemElements[earthStem]) return null;
+export function getStemPairPattern(heavenStem: string, earthStem: string): StemPairPattern {
+  assertValidStem(heavenStem, '天盘干');
+  assertValidStem(earthStem, '地盘干');
 
   // 优先查找命名格局
   const key = `${heavenStem}_${earthStem}`;
@@ -1375,12 +1366,17 @@ export function getNamedStemPairPattern(
   heavenStem: string,
   earthStem: string,
 ): StemPairPattern | null {
-  if (!heavenStem || !earthStem) return null;
-  if (heavenStem === '甲' || earthStem === '甲') return null;
-  if (!stemElements[heavenStem] || !stemElements[earthStem]) return null;
+  assertValidStem(heavenStem, '天盘干');
+  assertValidStem(earthStem, '地盘干');
 
   const named = NAMED_PATTERNS[`${heavenStem}_${earthStem}`];
   return named ? { ...named } : null;
+}
+
+function assertValidStem(stem: string, label: string): void {
+  if (!stemElements[stem]) {
+    throw new Error(`${label}必须是合法十天干（甲乙丙丁戊己庚辛壬癸）。`);
+  }
 }
 
 /**
@@ -1400,10 +1396,7 @@ export function listAllStemPairs(): StemPairPattern[] {
   for (const heavenStem of HEAVEN_STEMS) {
     for (const earthStem of EARTH_STEMS) {
       const pattern = getStemPairPattern(heavenStem, earthStem);
-      // 内部调用不会返回 null
-      if (pattern) {
-        results.push(pattern);
-      }
+      results.push(pattern);
     }
   }
 

--- a/packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts
@@ -18,6 +18,7 @@ import { LIUCHONG_MAP } from '../../../../ganzhi';
 
 /** 阳干 */
 const YANG_STEMS = ['甲', '丙', '戊', '庚', '壬'];
+const ALL_STEMS = new Set(['甲', '乙', '丙', '丁', '戊', '己', '庚', '辛', '壬', '癸']);
 
 /** 阳遁内四宫：冬至以后，自坎至巽四宫为内 */
 const YANG_DUN_INNER_PALACES = new Set([1, 8, 3, 4]);
@@ -44,6 +45,12 @@ function getPalaceDistance(gong: number, isYangDun?: boolean): PalaceDistance {
   if (gong <= 3) return 'inner';
   if (gong <= 6) return 'middle';
   return 'outer';
+}
+
+function assertPalaceNumber(gong: number, label: string): void {
+  if (!Number.isInteger(gong) || gong < 1 || gong > 9) {
+    throw new Error(`${label}必须是 1-9 的整数宫位。`);
+  }
 }
 
 function getPalaceDistanceLabel(distance: PalaceDistance, isYangDun?: boolean): string {
@@ -140,7 +147,20 @@ export function estimateYingQi(
   // ==========================================================================
   // 阴阳遁内外宫随冬至/夏至后切换；未传阴阳遁时保留旧固定宫号兼容。
 
-  const baseGong = useShenPalace || options?.zhiFuLandingPalace || 5;
+  const baseGong = useShenPalace ?? options?.zhiFuLandingPalace;
+  if (baseGong === undefined) {
+    throw new Error('奇门应期必须提供用神落宫；未选定具体用神时应明确传入值符落宫。');
+  }
+  assertPalaceNumber(baseGong, '用神落宫');
+  if (options?.zhiFuLandingPalace !== undefined) {
+    assertPalaceNumber(options.zhiFuLandingPalace, '值符落宫');
+  }
+  if (options?.zhiShiLandingPalace !== undefined) {
+    assertPalaceNumber(options.zhiShiLandingPalace, '值使落宫');
+  }
+  for (const palace of jiuGongGe) {
+    assertPalaceNumber(palace.gong, '九宫格宫位');
+  }
   const baseDistance = getPalaceDistance(baseGong, options?.isYangDun);
   let fastSignals = 0;
   let slowSignals = 0;
@@ -217,6 +237,9 @@ export function estimateYingQi(
   const ganZhi = options?.dayGanZhi || options?.hourGanZhi || '';
   if (ganZhi) {
     const dayStem = ganZhi.charAt(0);
+    if (!ALL_STEMS.has(dayStem)) {
+      throw new Error(`奇门应期无法识别日干 "${dayStem || '空'}"。`);
+    }
     const isYangDay = YANG_STEMS.includes(dayStem);
 
     // 遍历九宫查找庚的位置

--- a/tests/divination-engine.test.ts
+++ b/tests/divination-engine.test.ts
@@ -4233,13 +4233,15 @@ test('塔罗与雷诺曼提示词应保留牌面资料且不混入工程证据�
   assert.doesNotMatch(lenormandSession.prompt, /成功率为\d|成功率提升至|吉凶总分[：=]\d/);
 });
 
-test('六爻提示词应同时写出日辰和月建参与的三合局', async () => {
+test('六爻提示词应写出动爻、变爻与日辰月建形成的三合局', async () => {
   const session = await generateDivinationSession(
     buildDraft({
       method: 'liuyao',
       divinationTimeMode: 'custom',
       customDivinationDate: '2025-01-01',
       customDivinationTime: '00:21',
+      liuyaoMethod: 'manual',
+      liuyaoYaos: [6, 6, 6, 6, 6, 6],
     }),
   );
   const data = session.data as ReturnType<typeof generateLiuyao>;

--- a/tests/jinkoujue-algorithm.test.ts
+++ b/tests/jinkoujue-algorithm.test.ts
@@ -57,8 +57,16 @@ test('金口诀：五子元遁应按日干起遁干', () => {
 });
 
 test('金口诀：同种子随机起课可复现，并保留随机轨迹', () => {
-  const a = generateJinkoujue({ method: 'random', seed: 'jinkoujue-seed', customDate: SAMPLE_DATE });
-  const b = generateJinkoujue({ method: 'random', seed: 'jinkoujue-seed', customDate: SAMPLE_DATE });
+  const a = generateJinkoujue({
+    method: 'random',
+    seed: 'jinkoujue-seed',
+    customDate: SAMPLE_DATE,
+  });
+  const b = generateJinkoujue({
+    method: 'random',
+    seed: 'jinkoujue-seed',
+    customDate: SAMPLE_DATE,
+  });
 
   assert.equal(a.diFenBranch, b.diFenBranch);
   assert.ok(a.randomTrace?.samples.length);
@@ -74,4 +82,15 @@ test('金口诀：证据层应覆盖四位、关系、焦点与主线', () => {
   assert.ok(evidence.focusFacts.length >= 3);
   assert.match(evidence.mainLine, /贵神/);
   assert.equal(evidence.calculationFact.status, '完整');
+});
+
+test('金口诀：十二地分的四位五行与天将必须完整，不得输出未定关系', () => {
+  for (let number = 1; number <= 12; number += 1) {
+    const data = generateJinkoujue({ method: 'number', number, customDate: SAMPLE_DATE });
+    const positions = Object.values(data.positions);
+
+    assert.ok(positions.every((item) => ['木', '火', '土', '金', '水'].includes(item.element)));
+    assert.ok(data.positions.guiShen.god);
+    assert.doesNotMatch(JSON.stringify(data.relations), /未定|未知|^$/);
+  }
 });

--- a/tests/liuren-algorithm.test.ts
+++ b/tests/liuren-algorithm.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   buildHeavenlyPlate,
   getDayStemResidence,
+  getGanZhiWuxing,
   getNoblemanBranch,
   getPlateItemByBranch,
 } from '../packages/core/src/divination/algorithms/liuren/helpers/plate.ts';
@@ -834,6 +835,7 @@ test('大六壬底层参数非法时应明确报错，不应用默认贵人或�
     dayNight: '昼占',
   });
   assert.throws(() => getPlateItemByBranch(plate, 'A'), /天盘地支必须是有效地支/);
+  assert.throws(() => getGanZhiWuxing('A'), /无法识别干支/);
 });
 
 test('大六壬取传入口应拒绝坏四课和坏天盘，不应静默套用取传规则', () => {

--- a/tests/liuyao-strength-change.test.ts
+++ b/tests/liuyao-strength-change.test.ts
@@ -213,7 +213,7 @@ test('六爻：八宫卦位应输出首卦一世游魂归魂等卦序', () => {
   assert.equal(data.palaceStage, '五世');
 });
 
-test('六爻：三合局应区分日辰与月建的实际参与', () => {
+test('六爻：静卦不能仅凭静态纳甲支凑成三合局', () => {
   const data = generateLiuyao(new Date('2025-01-01T00:00:00+08:00'), {
     yaos: KAN_WEI_SHUI_YAOS,
   });
@@ -222,13 +222,30 @@ test('六爻：三合局应区分日辰与月建的实际参与', () => {
   assert.equal(data.ganzhi.day.slice(1), '午');
   assert.deepEqual(data.najiaDizhi, ['寅', '辰', '午', '申', '戌', '子']);
 
+  assert.equal(data.changingYaos.length, 0);
+  assert.equal(data.sanheWithDay, null);
+  assert.equal(data.sanheWithMonth, null);
+});
+
+test('六爻：动爻的变爻可以与日辰补成完整三合局', () => {
+  const data = generateLiuyao(new Date('2025-01-01T00:00:00+08:00'), {
+    yaos: [7, 6, 7, 7, 7, 6],
+  });
+
+  assert.equal(data.ganzhi.day.slice(1), '午');
+  assert.deepEqual(
+    data.yaosDetail
+      .filter((yao) => yao.isChanging)
+      .map((yao) => [yao.najiaDizhi, yao.changedYao?.dizhi]),
+    [
+      ['丑', '寅'],
+      ['卯', '戌'],
+    ],
+  );
   assert.equal(data.sanheWithDay?.group, '火局');
   assert.deepEqual(data.sanheWithDay?.members, ['寅', '午', '戌']);
   assert.match(data.sanheWithDay?.description || '', /日辰午引动三合火局/);
-
-  assert.equal(data.sanheWithMonth?.group, '水局');
-  assert.deepEqual(data.sanheWithMonth?.members, ['申', '子', '辰']);
-  assert.match(data.sanheWithMonth?.description || '', /月建子引动三合水局/);
+  assert.equal(data.sanheWithMonth, null);
 });
 
 test('六爻：月卦身应按阳世起子、阴世起午逐爻顺数', () => {

--- a/tests/meihua-algorithm.test.ts
+++ b/tests/meihua-algorithm.test.ts
@@ -50,6 +50,22 @@ test('梅花：互卦应取二三四爻为下互、三四五爻为上互', () =>
   assert.equal(data.interHexagram?.lower, '艮');
 });
 
+test('梅花：数字起卦生成的主互变三卦与动爻资料必须始终完整', () => {
+  for (let number = 1; number <= 192; number += 1) {
+    const data = generateMeihua(SAMPLE_DATE, { method: 'number', number });
+
+    assert.ok(data.originalName);
+    assert.ok(data.interName);
+    assert.ok(data.changedName);
+    assert.ok(data.interHexagram?.upper && data.interHexagram.lower);
+    assert.ok(data.changedHexagram?.upper && data.changedHexagram.lower);
+    assert.ok(data.changedTiGua && data.changedYongGua);
+    assert.ok(data.mainHexagram.movingYaoCi);
+    assert.doesNotMatch(data.movingYao.yaoName, /未知/);
+    assert.doesNotMatch(JSON.stringify(data.analysis), /无变卦|关系未定/);
+  }
+});
+
 test('梅花：爻位详情应从初爻往上排列并准确标出动爻', () => {
   const data = generateMeihua(SAMPLE_DATE, { method: 'number', number: 123 });
 

--- a/tests/qimen-boundary.test.ts
+++ b/tests/qimen-boundary.test.ts
@@ -14,7 +14,10 @@ import {
   getZhiFuStarJudgement,
 } from '../packages/core/src/divination/algorithms/qimen/helpers/star-palace.ts';
 import {
+  getDayOfficerInfo,
   getDaySeasonRelation,
+  getLunarPhase,
+  getLunarPhaseByIndex,
   getSeasonalElement,
 } from '../packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts';
 import {
@@ -22,6 +25,11 @@ import {
   getYearQimenJuShu,
 } from '../packages/core/src/divination/algorithms/qimen/helpers/jushu-extended.ts';
 import { getQimenPatternTags } from '../packages/core/src/divination/algorithms/qimen/helpers/patterns.ts';
+import {
+  getNamedStemPairPattern,
+  getStemPairPattern,
+} from '../packages/core/src/divination/algorithms/qimen/helpers/stem-pair-patterns.ts';
+import { estimateYingQi } from '../packages/core/src/divination/algorithms/qimen/helpers/ying-qi.ts';
 
 test('奇门拆补法在交节当天应按具体时刻换节气，不应按整日提前换局', () => {
   const beforeXiaoman = generateQimen(new Date('2024-05-20T10:00:00+08:00'));
@@ -169,6 +177,29 @@ test('奇门节令：未知节气或日干应明确报错，不应降级成无�
   assert.throws(() => getSeasonalElement('假节气'), /无法识别节气 "假节气" 的五行属性/);
   assert.throws(() => getDaySeasonRelation('假', '木'), /无法识别日干 "假" 的五行属性/);
   assert.throws(() => getDaySeasonRelation('甲', ''), /节令五行不能为空/);
+});
+
+test('奇门月相与建除映射缺失时应报错，不得默认新月或平', () => {
+  assert.equal(getLunarPhaseByIndex(0), '新月');
+  assert.equal(getLunarPhaseByIndex(7), '下弦');
+  assert.equal(getDayOfficerInfo('成').fortune, '吉');
+  assert.throws(() => getLunarPhaseByIndex(8), /无法识别历法月相索引/);
+  assert.throws(() => getLunarPhase(new Date(Number.NaN)), /月相日期必须是有效日期/);
+  assert.throws(() => getDayOfficerInfo('未知'), /无法识别建除十二神/);
+});
+
+test('奇门十干格局应正常返回合法组合并拒绝非法输入', () => {
+  assert.ok(getStemPairPattern('壬', '癸'));
+  assert.equal(getStemPairPattern('甲', '癸').name, '生');
+  assert.equal(getNamedStemPairPattern('壬', '癸')?.name, '螣蛇飞空');
+  assert.throws(() => getStemPairPattern('A', '癸'), /合法十天干/);
+  assert.throws(() => getNamedStemPairPattern('A', '癸'), /合法十天干/);
+});
+
+test('奇门应期必须有明确基准宫并校验宫位与日干', () => {
+  assert.throws(() => estimateYingQi([]), /必须提供用神落宫/);
+  assert.throws(() => estimateYingQi([], 0), /用神落宫必须是 1-9/);
+  assert.throws(() => estimateYingQi([], 1, { dayGanZhi: 'A子' }), /无法识别日干/);
 });
 
 test('奇门定局方法应支持拆补与置闰，并在结果中标明', () => {


### PR DESCRIPTION
## 目标
继续审查命理与占卜算法，收紧会掩盖资料缺失或非法输入的默认值，并修正六爻三合成局范围。

## 主要修改
- 金口诀：非法五行和缺失天将映射改为明确报错
- 梅花易数：强制校验主互变卦、体用、动爻名称与爻辞完整性
- 大六壬：收紧干支五行、天将、寄宫、刑冲合马及四课三传完整性校验
- 奇门遁甲：收紧月相、建除、十干组合和应期基准宫校验，同时保留甲干参与传统格局判断
- 六爻：三合局只采用明动、暗动及对应变爻，静卦不再靠静态纳甲支误判成局

## 验证
- `pnpm test`：1407 项通过
- `pnpm test:e2e`：36 项通过
- `pnpm exec tsc -p tsconfig.app.json --noEmit`：通过
- `pnpm lint`：通过
- 本次文件 Prettier 检查：通过
- 核心包构建与 Vite 生产构建：通过（本机使用 `GOMAXPROCS=1` 降低并行内存占用）
- `git diff --check`：通过

## 兼容风险
以往依赖非法输入、缺失内部映射或不完整四课三传继续生成结果的调用，现在会收到明确错误；合法排盘路径保持兼容。