### PR TITLE
修正黄历候选排序与参与人冲突判断

### DIFF
--- a/packages/core/src/divination/algorithms/almanac.ts
+++ b/packages/core/src/divination/algorithms/almanac.ts
@@ -43,7 +43,7 @@ type ScoredAlmanacDayCandidate = Omit<AlmanacDayCandidate, 'hours' | 'bestHours'
   hours?: ScoredAlmanacHourCandidate[];
   bestHours?: ScoredAlmanacHourCandidate[];
 };
-import { analyzeAlmanacEvidence } from '../almanac-evidence';
+import { analyzeAlmanacEvidence, classifyAlmanacCandidate } from '../almanac-evidence';
 
 export const ALMANAC_TOPIC_LABELS: Record<AlmanacTopic, string> = {
   move: '搬家入宅',
@@ -941,19 +941,31 @@ function scoreDay(params: {
     const avoidedGodHits = topicRule.avoidedGods.filter((name) => params.gods.includes(name));
     topicMatchFacts.push(
       buildTopicMatchFact({
-        key: `${params.dateKey}:topic:rule-gods`,
+        key: `${params.dateKey}:topic:rule-gods-support`,
         scope: '候选日',
         topic: params.topic,
         sourceType: '原始宜项',
-        status: preferredGodHits.length ? '支持' : avoidedGodHits.length ? '限制' : '中性',
+        status: preferredGodHits.length ? '支持' : '中性',
         inputItems: [...params.gods],
-        keywords: [...topicRule.preferredGods, ...topicRule.avoidedGods],
-        matchedItems: [...preferredGodHits, ...avoidedGodHits],
+        keywords: [...topicRule.preferredGods],
+        matchedItems: preferredGodHits,
         promptText: preferredGodHits.length
           ? `事项规则命中喜神${preferredGodHits.join('、')}`
-          : avoidedGodHits.length
-            ? `事项规则触及忌神${avoidedGodHits.join('、')}`
-            : '事项规则未命中专属喜忌神煞',
+          : '事项规则未命中专属喜神',
+        sources: ['事项硬规则表', '当日神煞'],
+      }),
+      buildTopicMatchFact({
+        key: `${params.dateKey}:topic:rule-gods-constraint`,
+        scope: '候选日',
+        topic: params.topic,
+        sourceType: '原始忌项',
+        status: avoidedGodHits.length ? '限制' : '中性',
+        inputItems: [...params.gods],
+        keywords: [...topicRule.avoidedGods],
+        matchedItems: avoidedGodHits,
+        promptText: avoidedGodHits.length
+          ? `事项规则触及忌神${avoidedGodHits.join('、')}`
+          : '事项规则未触及专属忌神',
         sources: ['事项硬规则表', '当日神煞'],
       }),
     );
@@ -1436,11 +1448,17 @@ export function generateAlmanacSelection(params: {
   }
 
   const participants = createParticipantProfiles(params.participants ?? []);
+  const statusPriority = { 可用候选: 0, 条件候选: 1, 慎用候选: 2 } as const;
   const days = Array.from({ length: diffDays + 1 }, (_, index) => {
     const current = new Date(start.date);
     current.setDate(start.date.getDate() + index);
     return buildDayCandidate(current, params.topic, participants);
-  }).sort((a, b) => b.score - a.score);
+  }).sort((a, b) => {
+    const statusDifference =
+      statusPriority[classifyAlmanacCandidate(a).status] -
+      statusPriority[classifyAlmanacCandidate(b).status];
+    return statusDifference || b.score - a.score || a.date.localeCompare(b.date);
+  });
 
   const scoredResult: Omit<AlmanacData, 'days'> & { days: ScoredAlmanacDayCandidate[] } = {
     topic: params.topic,

--- a/packages/core/src/divination/almanac-evidence.ts
+++ b/packages/core/src/divination/almanac-evidence.ts
@@ -374,8 +374,145 @@ function buildTraditionalFacts(day: AlmanacDayCandidate): AlmanacTraditionalFact
   return facts;
 }
 
-function isConflictNote(note: string) {
-  return /冲|刑|害|破|忌|不宜|避/.test(note) && !/未见|未冲|不冲|无明显/.test(note);
+function isDirectConflictNote(note: string): boolean {
+  return (
+    /(?:候选日地支|时支).*(?:冲|刑|害|破)(?:生肖|年支|日支)/.test(note) ||
+    /(?:冲|刑|害|破)(?:生肖|年支|日支)/.test(note)
+  );
+}
+
+function isDirectParticipantConstraint(fact: AlmanacParticipantRelationFact): boolean {
+  return (
+    fact.status === '限制' &&
+    (fact.basis === '年支' ||
+      fact.basis === '日支' ||
+      (fact.basis === '整体' && isDirectConflictNote(fact.promptText))) &&
+    (fact.relation === '冲' ||
+      fact.relation === '刑' ||
+      fact.relation === '害' ||
+      fact.relation === '破')
+  );
+}
+
+function getParticipantConstraintTexts(
+  facts: AlmanacParticipantRelationFact[] | undefined,
+  notes: string[],
+): string[] {
+  if (facts?.length) {
+    return unique(facts.filter((item) => item.status === '限制').map((item) => item.promptText));
+  }
+  return unique(notes.filter(isDirectConflictNote));
+}
+
+function getDirectParticipantConflictTexts(
+  facts: AlmanacParticipantRelationFact[] | undefined,
+  notes: string[],
+): string[] {
+  if (facts?.length) {
+    return unique(facts.filter(isDirectParticipantConstraint).map((item) => item.promptText));
+  }
+  return unique(notes.filter(isDirectConflictNote));
+}
+
+function getParticipantSupportTexts(
+  facts: AlmanacParticipantRelationFact[] | undefined,
+  notes: string[],
+): string[] {
+  if (facts?.length) {
+    return unique(facts.filter((item) => item.status === '支持').map((item) => item.promptText));
+  }
+  return unique(
+    notes.filter((item) => /辅助支持|未见.*刑冲破害/.test(item) && !isDirectConflictNote(item)),
+  );
+}
+
+function isStrongTopicConstraint(fact: AlmanacTopicMatchFact): boolean {
+  return (
+    fact.status === '限制' &&
+    /:topic:(?:day-avoids|rule-day-officer|rule-gods-constraint|day-officer-constraint)$/.test(
+      fact.key,
+    )
+  );
+}
+
+function classifyAlmanacHourCandidate(hour: AlmanacHourCandidate): {
+  status: AlmanacCandidateStatus;
+  strongConstraintTexts: string[];
+  constraintTexts: string[];
+} {
+  const topicConstraints = (hour.topicMatchFacts ?? []).filter((item) => item.status === '限制');
+  const participantConstraints = getParticipantConstraintTexts(
+    hour.participantRelationFacts,
+    hour.participantNotes,
+  );
+  const directParticipantConflicts = getDirectParticipantConflictTexts(
+    hour.participantRelationFacts,
+    hour.participantNotes,
+  );
+  const strongConstraintTexts = unique([
+    ...topicConstraints
+      .filter((item) => /:topic:avoids$/.test(item.key))
+      .map((item) => item.promptText),
+    ...directParticipantConflicts,
+    ...(hour.avoids.includes('诸事不宜') ? ['时辰明列诸事不宜'] : []),
+  ]);
+  const constraintTexts = unique([
+    ...hour.cautions,
+    ...topicConstraints.map((item) => item.promptText),
+    ...participantConstraints,
+  ]);
+  return {
+    status: strongConstraintTexts.length
+      ? '慎用候选'
+      : constraintTexts.length
+        ? '条件候选'
+        : '可用候选',
+    strongConstraintTexts,
+    constraintTexts,
+  };
+}
+
+export function classifyAlmanacCandidate(day: AlmanacDayCandidate): {
+  status: AlmanacCandidateStatus;
+  strongConstraintTexts: string[];
+  constraintTexts: string[];
+} {
+  const topicConstraints = (day.topicMatchFacts ?? []).filter((item) => item.status === '限制');
+  const participantConstraints = getParticipantConstraintTexts(
+    day.participantRelationFacts,
+    day.participantNotes,
+  );
+  const directParticipantConflicts = getDirectParticipantConflictTexts(
+    day.participantRelationFacts,
+    day.participantNotes,
+  );
+  const strongConstraintTexts = unique([
+    ...topicConstraints.filter(isStrongTopicConstraint).map((item) => item.promptText),
+    ...directParticipantConflicts,
+    ...(day.avoids.includes('诸事不宜') ? ['候选日明列诸事不宜'] : []),
+    ...day.cautions.filter((item) =>
+      /黄历忌项触及|事项规则限制执日|事项规则触及忌神|执日.*(?:不宜|忌)|诸事不宜/.test(item),
+    ),
+  ]);
+  const hasHourData = Array.isArray(day.hours) && day.hours.length > 0;
+  const usableHourCount = hasHourData
+    ? day.hours!.filter((hour) => classifyAlmanacHourCandidate(hour).status !== '慎用候选').length
+    : 0;
+  const constraintTexts = unique([
+    ...day.cautions,
+    ...topicConstraints.map((item) => item.promptText),
+    ...participantConstraints,
+    ...(hasHourData && usableHourCount === 0 ? ['未筛出无强冲突时辰'] : []),
+  ]);
+  return {
+    status: strongConstraintTexts.length
+      ? '慎用候选'
+      : constraintTexts.length
+        ? '条件候选'
+        : '可用候选',
+    strongConstraintTexts,
+    constraintTexts,
+  };
 }
 
 function buildCalendarFact(day: AlmanacDayCandidate): AlmanacCalendarFact {
@@ -495,7 +632,7 @@ function buildCompatibleParticipantFacts(params: {
   return params.notes.map((note, index) => {
     const participantName = note.split('：')[0] || `参与人${index + 1}`;
     const isUnused = /不用|未采用/.test(note);
-    const isLimit = isConflictNote(note);
+    const isLimit = isDirectConflictNote(note) || /触及忌神|要求喜用.*未命中/.test(note);
     const relationMatch = note.match(/[冲刑害破]/)?.[0] as '冲' | '刑' | '害' | '破' | undefined;
     const relation = isUnused
       ? '未采用'
@@ -526,20 +663,6 @@ function buildHourEvidence(
   topic: AlmanacTopic,
   topicLabel: string,
 ): AlmanacHourEvidence {
-  const participantSupport = unique(hour.participantNotes.filter((item) => !isConflictNote(item)));
-  const constraints = unique([
-    ...hour.cautions,
-    ...hour.participantNotes.filter(isConflictNote),
-    ...(hour.avoids.includes('诸事不宜') ? ['时辰明列诸事不宜'] : []),
-  ]);
-  const support = unique([...hour.highlights, ...participantSupport]);
-  const status: AlmanacCandidateStatus = constraints.some((item) =>
-    /诸事不宜|忌项触及|冲|刑|害|破/.test(item),
-  )
-    ? '慎用候选'
-    : constraints.length
-      ? '条件候选'
-      : '可用候选';
   const recommends = unique(hour.recommends);
   const avoids = unique(hour.avoids);
   const keyPrefix = `${date}:hour:${hour.ganzhi}:${hour.name}`;
@@ -568,6 +691,26 @@ function buildHourEvidence(
       candidateValue: hour.branch,
       notes: hour.participantNotes,
     });
+  const participantSupport = getParticipantSupportTexts(
+    participantRelationFacts,
+    hour.participantNotes,
+  );
+  const participantConstraints = getParticipantConstraintTexts(
+    participantRelationFacts,
+    hour.participantNotes,
+  );
+  const classification = classifyAlmanacHourCandidate({
+    ...hour,
+    topicMatchFacts,
+    participantRelationFacts,
+  });
+  const constraints = unique([
+    ...classification.constraintTexts,
+    ...participantConstraints,
+    ...(hour.avoids.includes('诸事不宜') ? ['时辰明列诸事不宜'] : []),
+  ]);
+  const support = unique([...hour.highlights, ...participantSupport]);
+  const status = classification.status;
   const promptText = `${hour.name}${hour.range}，${hour.ganzhi}（${hour.branch}支）、${hour.twelveStar}；${status}；宜${recommends.join('、') || '未列'}；忌${avoids.join('、') || '未列'}；支持${support.join('、') || '未见额外支持'}；限制${constraints.join('、') || '未见明确冲突'}`;
   return {
     key: keyPrefix,
@@ -773,8 +916,6 @@ function buildCandidateEvidence(
 ): AlmanacCandidateEvidence {
   const moonPhaseEvidence =
     day.moonPhaseEvidence ?? calculateMoonPhaseEvidence(Date.parse(`${day.date}T04:00:00Z`));
-  const participantConflicts = unique(day.participantNotes.filter(isConflictNote));
-  const participantSupport = unique(day.participantNotes.filter((item) => !isConflictNote(item)));
   const calendarFact = buildCalendarFact(day);
   const rawTabooFact = buildRawTabooFact({
     keyPrefix: day.date,
@@ -802,6 +943,14 @@ function buildCandidateEvidence(
       candidateValue: day.ganzhi.day.slice(-1),
       notes: day.participantNotes,
     });
+  const participantConflicts = getDirectParticipantConflictTexts(
+    participantRelationFacts,
+    day.participantNotes,
+  );
+  const participantSupport = getParticipantSupportTexts(
+    participantRelationFacts,
+    day.participantNotes,
+  );
   const traditionalConstraints = unique(day.cautions);
   const topicMatches = unique(day.highlights.filter((item) => /宜项命中|执日.*宜/.test(item)));
   const traditionalSupport = unique(day.highlights.filter((item) => !topicMatches.includes(item)));
@@ -812,19 +961,17 @@ function buildCandidateEvidence(
   const directionFacts = traditionalFacts
     .filter((item) => item.kind === '全年方位神')
     .map((item) => item.promptText);
-  const strongConstraintTexts = unique([
-    ...traditionalConstraints.filter((item) => /黄历忌项触及|诸事不宜|岁破/.test(item)),
-    ...participantConflicts,
-  ]);
-  const status: AlmanacCandidateStatus = strongConstraintTexts.length
-    ? '慎用候选'
-    : traditionalConstraints.length || participantConflicts.length
-      ? '条件候选'
-      : '可用候选';
   const usableHours = (day.hours ?? [])
     .map((hour) => buildHourEvidence(day.date, hour, topic, topicLabel))
     .filter((item) => item.status !== '慎用候选')
     .slice(0, 4);
+  const classification = classifyAlmanacCandidate({
+    ...day,
+    topicMatchFacts,
+    participantRelationFacts,
+  });
+  const strongConstraintTexts = classification.strongConstraintTexts;
+  const status = classification.status;
   const decisionFact = buildCandidateDecisionFact({
     date: day.date,
     status,

--- a/tests/almanac-evidence.test.ts
+++ b/tests/almanac-evidence.test.ts
@@ -262,6 +262,33 @@ test('择日参与人支持与冲突应保留逐项结构化依据', () => {
   assert.doesNotMatch(JSON.stringify(facts), /"score"\s*:/);
 });
 
+test('择日参与人忌神命中只作一般限制，不得误报为年支日支直接冲突', () => {
+  const result = generateAlmanacSelection({
+    topic: 'marriage',
+    startDate: '2025-06-02',
+    endDate: '2025-06-02',
+    participants: [
+      {
+        id: 'person-constraint',
+        name: '测试人',
+        gender: '男',
+        year: '1990',
+        month: '5',
+        day: '12',
+        timeIndex: '5',
+        dateType: 'solar',
+      },
+    ],
+  });
+  const candidate = result.evidenceAnalysis?.candidates[0];
+
+  assert.ok(candidate);
+  assert.deepEqual(candidate.participantConflicts, []);
+  assert.ok(candidate.decisionFact.limitingFactKeys.some((key) => key.endsWith(':avoid-elements')));
+  assert.ok(candidate.participantSupport.some((item) => item.includes('命中喜用木')));
+  assert.ok(!candidate.participantSupport.some((item) => item.includes('触及忌神')));
+});
+
 test('旧黄历字符串结果应生成兼容事实且不反推缺失参数', () => {
   const result = generateAlmanacSelection({
     topic: 'contract',

--- a/tests/almanac-topic-rules.test.ts
+++ b/tests/almanac-topic-rules.test.ts
@@ -16,6 +16,45 @@ test('黄历择日：事项硬规则应写入建除与神煞匹配事实', () =>
   assert.equal(hasRuleFact, true);
 });
 
+test('黄历择日：喜神与忌神同日出现时应分别保留，不得用喜神覆盖限制', () => {
+  const result = generateAlmanacSelection({
+    topic: 'marriage',
+    startDate: '2025-01-21',
+    endDate: '2025-01-21',
+  });
+  const day = result.days[0];
+  const supportFact = day.topicMatchFacts?.find((fact) =>
+    fact.key.endsWith(':topic:rule-gods-support'),
+  );
+  const constraintFact = day.topicMatchFacts?.find((fact) =>
+    fact.key.endsWith(':topic:rule-gods-constraint'),
+  );
+
+  assert.equal(supportFact?.status, '支持');
+  assert.deepEqual(supportFact?.matchedItems, ['天德', '月德']);
+  assert.equal(constraintFact?.status, '限制');
+  assert.deepEqual(constraintFact?.matchedItems, ['劫煞']);
+  assert.equal(result.evidenceAnalysis?.candidates[0].status, '慎用候选');
+});
+
+test('黄历择日：候选状态应先于内部同级分数决定日期顺序', () => {
+  const result = generateAlmanacSelection({
+    topic: 'move',
+    startDate: '2026-06-01',
+    endDate: '2026-06-30',
+  });
+  const statuses = result.evidenceAnalysis?.candidates.map((candidate) => candidate.status) ?? [];
+  const priority = { 可用候选: 0, 条件候选: 1, 慎用候选: 2 } as const;
+
+  assert.ok(statuses.includes('条件候选'));
+  assert.ok(statuses.includes('慎用候选'));
+  assert.deepEqual(
+    statuses.map((status) => priority[status]),
+    statuses.map((status) => priority[status]).sort((left, right) => left - right),
+  );
+  assert.notEqual(statuses[0], '慎用候选');
+});
+
 test('黄历择日：参与人适配证据字段应完整生成', () => {
   const result = generateAlmanacSelection({
     topic: 'marriage',


### PR DESCRIPTION
## 目标

修正黄历择日中候选状态排序、神煞限制覆盖及参与人冲突误判。

## 主要修改

- 候选日优先按可用、条件、慎用状态排序，同级再按内部得分排序
- 喜神与忌神同日命中时分别保留支持和限制证据
- 仅把明确的年支、日支刑冲破害列为参与人直接冲突
- 统一算法排序与证据层的候选分类口径

## 验证

- pnpm test：1410 项通过
- pnpm test:e2e：36 项通过
- pnpm exec tsc -p tsconfig.app.json --noEmit：通过
- pnpm lint：通过
- pnpm build：通过
- Prettier 与 git diff --check：通过

## 风险

不改变公开输入结构，仅修正候选顺序和证据分类。