### PR TITLE
收紧黄历六爻资料并完善牌阵互参

### DIFF
--- a/packages/core/src/divination/algorithms/almanac.ts
+++ b/packages/core/src/divination/algorithms/almanac.ts
@@ -3,7 +3,7 @@ import { baziCalculator } from '../../bazi/baziCalculator';
 import { getBirthDateValidationMessage } from '../../calendar/date-validation';
 import { SHICHEN_PERIODS } from '../../calendar/dateUtils';
 import { calculateMoonPhaseEvidence } from '../../calendar/moon-phase-evidence';
-import { EARTHLY_BRANCHES } from '../../ganzhi/data';
+import { EARTHLY_BRANCHES, HEAVENLY_STEMS } from '../../ganzhi/data';
 import {
   getBranchWuxing,
   getOppositeBranch,
@@ -591,20 +591,36 @@ const NINE_STAR_SHORT_NAME_MAP: Record<
   Object.entries(NINE_STARS).map(([name, detail]) => [name.slice(0, 1), detail]),
 );
 
-function getNineStarDetail(name: string) {
-  return NINE_STARS[name] || NINE_STAR_SHORT_NAME_MAP[name.slice(0, 1)] || null;
+function requireReferenceValue<T>(record: Record<string, T>, key: string, label: string): T {
+  if (!key || !Object.prototype.hasOwnProperty.call(record, key)) {
+    throw new Error(`黄历${label}资料缺失：${key || '空值'}`);
+  }
+  return record[key];
 }
 
-function getAnnualDirectionGods(yearBranch: string): AlmanacAnnualDirectionGod[] {
+export function getAlmanacTwentyEightStarDetail(name: string) {
+  return requireReferenceValue(TWENTY_EIGHT_STARS, name, '二十八宿');
+}
+
+export function getAlmanacNineStarDetail(name: string) {
+  if (Object.prototype.hasOwnProperty.call(NINE_STARS, name)) {
+    return NINE_STARS[name];
+  }
+  return requireReferenceValue(NINE_STAR_SHORT_NAME_MAP, name.slice(0, 1), '九星');
+}
+
+export function getAlmanacAnnualDirectionGods(yearBranch: string): AlmanacAnnualDirectionGod[] {
   const startIndex = (EARTHLY_BRANCHES as readonly string[]).indexOf(yearBranch);
-  if (startIndex < 0) return [];
+  if (startIndex < 0) {
+    throw new Error(`黄历年支无效：${yearBranch || '空值'}`);
+  }
 
   return ANNUAL_DIRECTION_GOD_SEQUENCE.map((item, index) => {
     const branch = EARTHLY_BRANCHES[(startIndex + index) % EARTHLY_BRANCHES.length];
     return {
       ...item,
       branch,
-      direction: BRANCH_DIRECTIONS[branch] || '',
+      direction: requireReferenceValue(BRANCH_DIRECTIONS, branch, '地支方位'),
     };
   });
 }
@@ -644,6 +660,80 @@ const PENGZU_DAY_ZHI: Record<string, string> = {
   戌: '戌不吃狗作怪上床',
   亥: '亥不嫁娶不利新郎',
 };
+
+function assertExactReferenceKeys(
+  label: string,
+  record: Record<string, unknown>,
+  expectedKeys: readonly string[],
+): void {
+  const actualKeys = Object.keys(record);
+  const missingKeys = expectedKeys.filter(
+    (key) => !Object.prototype.hasOwnProperty.call(record, key),
+  );
+  const unexpectedKeys = actualKeys.filter((key) => !expectedKeys.includes(key));
+  if (missingKeys.length || unexpectedKeys.length) {
+    throw new Error(
+      `黄历${label}资料表不完整：缺少${missingKeys.join('、') || '无'}；多出${unexpectedKeys.join('、') || '无'}`,
+    );
+  }
+}
+
+export function validateAlmanacReferenceData(): void {
+  const twentyEightStarNames = [
+    '角',
+    '亢',
+    '氐',
+    '房',
+    '心',
+    '尾',
+    '箕',
+    '斗',
+    '牛',
+    '女',
+    '虚',
+    '危',
+    '室',
+    '壁',
+    '奎',
+    '娄',
+    '胃',
+    '昴',
+    '毕',
+    '觜',
+    '参',
+    '井',
+    '鬼',
+    '柳',
+    '星',
+    '张',
+    '翼',
+    '轸',
+  ] as const;
+  const nineStarNames = ['一白', '二黑', '三碧', '四绿', '五黄', '六白', '七赤', '八白', '九紫'];
+  const nineStarShortNames = nineStarNames.map((name) => name.slice(0, 1));
+
+  assertExactReferenceKeys('二十八宿', TWENTY_EIGHT_STARS, twentyEightStarNames);
+  assertExactReferenceKeys('九星', NINE_STARS, nineStarNames);
+  assertExactReferenceKeys('九星短名', NINE_STAR_SHORT_NAME_MAP, nineStarShortNames);
+  assertExactReferenceKeys('彭祖天干百忌', PENGZU_DAY_GAN, HEAVENLY_STEMS);
+  assertExactReferenceKeys('彭祖地支百忌', PENGZU_DAY_ZHI, EARTHLY_BRANCHES);
+  assertExactReferenceKeys('地支方位', BRANCH_DIRECTIONS, EARTHLY_BRANCHES);
+  if (
+    ANNUAL_DIRECTION_GOD_SEQUENCE.length !== EARTHLY_BRANCHES.length ||
+    new Set(ANNUAL_DIRECTION_GOD_SEQUENCE.map((item) => item.god)).size !== EARTHLY_BRANCHES.length
+  ) {
+    throw new Error('黄历岁支十二神资料表必须恰好包含 12 个不重复神名');
+  }
+}
+
+export function getAlmanacPengZuDetails(dayStem: string, dayBranch: string) {
+  return {
+    gan: requireReferenceValue(PENGZU_DAY_GAN, dayStem, '彭祖天干百忌'),
+    zhi: requireReferenceValue(PENGZU_DAY_ZHI, dayBranch, '彭祖地支百忌'),
+  };
+}
+
+validateAlmanacReferenceData();
 
 // 传统吉凶神煞清单（取自《协纪辨方书》，名称与 tyme4ts God.NAMES 对齐）。
 // tyme4ts 的 getGods() 已返回每日临值神煞及其吉凶（getLuck），此处按传统
@@ -1210,9 +1300,22 @@ function buildHourCandidates(
 ): ScoredAlmanacHourCandidate[] {
   const recommendKeywords = TOPIC_RECOMMEND_KEYWORDS[topic];
   const avoidKeywords = TOPIC_AVOID_KEYWORDS[topic];
-  return lunarDay.getHours().map((hour, index) => {
+  const lunarHours = lunarDay.getHours();
+  if (lunarHours.length !== SHICHEN_PERIODS.length) {
+    throw new Error(
+      `黄历时辰资料数量异常：应为${SHICHEN_PERIODS.length}项，实际${lunarHours.length}项`,
+    );
+  }
+  return lunarHours.map((hour, index) => {
     const ganzhi = hour.getSixtyCycle().getName();
-    const branch = ganzhi[1];
+    const branch = ganzhi.slice(-1);
+    const period = SHICHEN_PERIODS[index];
+    if (!period) {
+      throw new Error(`黄历第${index + 1}个时辰缺少时段定义`);
+    }
+    if (branch !== period.branch) {
+      throw new Error(`黄历第${index + 1}个时辰地支与时段不一致：${ganzhi}对应${period.name}`);
+    }
     const twelveStar = hour.getTwelveStar().getName();
     const recommends = normalizeTaboos(hour.getRecommends());
     const avoids = normalizeTaboos(hour.getAvoids());
@@ -1221,8 +1324,7 @@ function buildHourCandidates(
     const participantNotes: string[] = [];
     const topicMatchFacts: AlmanacTopicMatchFact[] = [];
     const participantRelationFacts: AlmanacParticipantRelationFact[] = [];
-    const period = SHICHEN_PERIODS[index] ?? SHICHEN_PERIODS[index % 12];
-    const hourName = index === 12 ? '晚子时' : period.name;
+    const hourName = period.name;
     const hourKey = `${dateKey}:hour:${ganzhi}:${hourName}`;
     const recommendMatches = findKeywordMatches(recommends, recommendKeywords);
     const avoidMatches = findKeywordMatches(avoids, [...avoidKeywords, '诸事不宜']);
@@ -1362,6 +1464,9 @@ function buildDayCandidate(
   // 彭祖百忌完整：天干+地支
   const dayStemName = dayCycle.getHeavenStem().getName();
   const dayZhiName = dayCycle.getEarthBranch().getName();
+  const twentyEightStar = lunarDay.getTwentyEightStar().getName();
+  const nineStar = lunarDay.getNineStar().getName();
+  const pengZuDetails = getAlmanacPengZuDetails(dayStemName, dayZhiName);
   const hours = buildHourCandidates(dateKey, lunarDay, topic, participants);
   const bestHours = [...hours]
     .filter((hour) => hour.score >= 55 && !hour.avoids.includes('诸事不宜'))
@@ -1381,19 +1486,21 @@ function buildDayCandidate(
     zodiac: dayBranch.getZodiac().getName(),
     dayOfficer: lunarDay.getDuty().getName(),
     twelveStar: lunarDay.getTwelveStar().getName(),
-    twentyEightStar: lunarDay.getTwentyEightStar().getName(),
-    twentyEightStarDetail: TWENTY_EIGHT_STARS[lunarDay.getTwentyEightStar().getName()] || null,
-    nineStar: lunarDay.getNineStar().getName(),
-    nineStarDetail: getNineStarDetail(lunarDay.getNineStar().getName()),
+    twentyEightStar,
+    twentyEightStarDetail: getAlmanacTwentyEightStarDetail(twentyEightStar),
+    nineStar,
+    nineStarDetail: getAlmanacNineStarDetail(nineStar),
     gods,
     recommends,
     avoids,
     pengZu: dayCycle.getPengZu().getName(),
     // 彭祖百忌完整：天干+地支
-    pengZuGan: PENGZU_DAY_GAN[dayStemName] || '',
-    pengZuZhi: PENGZU_DAY_ZHI[dayZhiName] || '',
+    pengZuGan: pengZuDetails.gan,
+    pengZuZhi: pengZuDetails.zhi,
     clash: `冲${dayBranch.getOpposite().getName()}，煞${dayBranch.getOminous().getName()}`,
-    annualDirectionGods: getAnnualDirectionGods(noonEightChar.getYear().getEarthBranch().getName()),
+    annualDirectionGods: getAlmanacAnnualDirectionGods(
+      noonEightChar.getYear().getEarthBranch().getName(),
+    ),
     score: scoring.score,
     highlights: scoring.highlights,
     cautions: scoring.cautions,

--- a/packages/core/src/divination/algorithms/lenormand.ts
+++ b/packages/core/src/divination/algorithms/lenormand.ts
@@ -225,10 +225,11 @@ export const LENORMAND_SPREADS: Record<LenormandSpreadType, { name: string; posi
     },
     grandTableau: {
       name: '大桌牌阵',
-      positions: Array.from(
-        { length: 36 },
-        (_, i) => `第${i + 1}宫（${LENORMAND_CARDS[i]?.name ?? '未知'}宫）`,
-      ),
+      positions: Array.from({ length: 36 }, (_, i) => {
+        const card = LENORMAND_CARDS[i];
+        if (!card) throw new Error(`雷诺曼第${i + 1}宫缺少对应宫位牌`);
+        return `第${i + 1}宫（${card.name}宫）`;
+      }),
     },
   };
 
@@ -253,7 +254,9 @@ export function resolveInteractiveLenormandCards(
   const remaining = [...LENORMAND_CARDS];
   return samples.map((sample) => {
     const index = Math.floor(sample * remaining.length);
-    return remaining.splice(index, 1)[0];
+    const card = remaining.splice(index, 1)[0];
+    if (!card) throw new Error(`第${remaining.length + 1}张雷诺曼抽牌无法映射到剩余牌组`);
+    return card;
   });
 }
 
@@ -301,6 +304,127 @@ export const LENORMAND_FIXED_COMBINATIONS: Record<string, string> = {
   '熊+鱼': '资源或资金充裕',
   '树+心': '深厚的感情基础',
 };
+
+type LenormandCardPlacement = LenormandData['cards'][number];
+type LenormandCombination = NonNullable<LenormandData['combinations']>[number];
+
+function getFixedCombinationMeaning(firstName: string, secondName: string): string | null {
+  return (
+    LENORMAND_FIXED_COMBINATIONS[`${firstName}+${secondName}`] ??
+    LENORMAND_FIXED_COMBINATIONS[`${secondName}+${firstName}`] ??
+    null
+  );
+}
+
+function getGridCombinationCandidates(cards: LenormandCardPlacement[]) {
+  cards.forEach((card, index) => {
+    if (!card.row || !card.column) {
+      throw new Error(`雷诺曼网格牌阵第${index + 1}张缺少行列坐标`);
+    }
+  });
+
+  return cards.flatMap((first, firstIndex) =>
+    cards.slice(firstIndex + 1).flatMap((second) => {
+      const rowDistance = Math.abs(first.row! - second.row!);
+      const columnDistance = Math.abs(first.column! - second.column!);
+      if (rowDistance > 1 || columnDistance > 1 || (rowDistance === 0 && columnDistance === 0)) {
+        return [];
+      }
+      return [
+        {
+          first,
+          second,
+          rowDistance,
+          columnDistance,
+          relation:
+            rowDistance === 0
+              ? ('横向相邻' as const)
+              : columnDistance === 0
+                ? ('纵向相邻' as const)
+                : ('对角相邻' as const),
+        },
+      ];
+    }),
+  );
+}
+
+function buildLenormandCombinations(
+  spreadType: LenormandSpreadType,
+  cards: LenormandCardPlacement[],
+): NonNullable<LenormandData['combinations']> {
+  const candidates =
+    spreadType === 'nine' || spreadType === 'grandTableau'
+      ? getGridCombinationCandidates(cards)
+      : cards.slice(1).map((second, index) => ({
+          first: cards[index],
+          second,
+          rowDistance: 0,
+          columnDistance: 0,
+          relation: '牌序相邻' as const,
+        }));
+
+  return candidates.flatMap(({ first, second, relation, rowDistance, columnDistance }) => {
+    const fixedMeaning = getFixedCombinationMeaning(first.name, second.name);
+    const isPersonNeighborhood =
+      spreadType === 'grandTableau' &&
+      (first.name === '男士' ||
+        first.name === '女士' ||
+        second.name === '男士' ||
+        second.name === '女士');
+    if (spreadType === 'grandTableau' && !fixedMeaning && !isPersonNeighborhood) {
+      return [];
+    }
+    const isSequential = relation === '牌序相邻';
+    const meaning =
+      fixedMeaning ??
+      (isSequential
+        ? `${first.position}${first.name}的“${first.keywords.slice(0, 2).join('、')}”与${second.position}${second.name}的“${second.keywords.slice(0, 2).join('、')}”前后相接，先按${first.meaning}，再看${second.meaning}`
+        : `${first.position}${first.name}与${second.position}${second.name}为${relation}，互参“${first.keywords.slice(0, 2).join('、')}”与“${second.keywords.slice(0, 2).join('、')}”两组线索`);
+    const combination: LenormandCombination = {
+      card1: first.name,
+      card2: second.name,
+      position1: first.position,
+      position2: second.position,
+      relation,
+      rowDistance,
+      columnDistance,
+      meaning,
+      source: fixedMeaning ? '固定组合' : '相邻牌义合读',
+    };
+    return [combination];
+  });
+}
+
+export function validateLenormandReferenceData(): void {
+  const ids = LENORMAND_CARDS.map((card) => card.id);
+  const names = LENORMAND_CARDS.map((card) => card.name);
+  if (
+    LENORMAND_CARDS.length !== 36 ||
+    ids.some((id, index) => id !== index + 1) ||
+    new Set(ids).size !== 36 ||
+    new Set(names).size !== 36
+  ) {
+    throw new Error('雷诺曼牌组必须按 1-36 完整登记且牌号、牌名不重复');
+  }
+  if (
+    LENORMAND_SPREADS.grandTableau.positions.length !== 36 ||
+    LENORMAND_SPREADS.grandTableau.positions.some((position) => position.includes('未知'))
+  ) {
+    throw new Error('雷诺曼大桌必须完整登记 36 个同序宫位');
+  }
+  for (const pair of Object.keys(LENORMAND_FIXED_COMBINATIONS)) {
+    const namesInPair = pair.split('+');
+    if (
+      namesInPair.length !== 2 ||
+      namesInPair.some((name) => !names.includes(name)) ||
+      namesInPair[0] === namesInPair[1]
+    ) {
+      throw new Error(`雷诺曼固定组合引用无效牌名：${pair}`);
+    }
+  }
+}
+
+validateLenormandReferenceData();
 
 /**
  * 抽取雷诺曼牌阵
@@ -363,33 +487,20 @@ export function drawLenormandSpread(
       : shuffleCards(context!.random).slice(0, spread.positions.length);
   const cards = selectedCards.map((card, index) => {
     const columns = spreadType === 'grandTableau' ? 9 : spreadType === 'nine' ? 3 : 0;
+    const houseCard = spreadType === 'grandTableau' ? LENORMAND_CARDS[index] : undefined;
+    if (spreadType === 'grandTableau' && !houseCard) {
+      throw new Error(`雷诺曼第${index + 1}宫缺少对应宫位牌`);
+    }
     return {
       ...card,
       position: spread.positions[index],
-      house: spreadType === 'grandTableau' ? LENORMAND_CARDS[index]?.name : undefined,
+      house: houseCard?.name,
       row: columns ? Math.floor(index / columns) + 1 : undefined,
       column: columns ? (index % columns) + 1 : undefined,
     };
   });
 
-  // 两牌组合分析（仅当至少有2张牌时）
-  const combinations: NonNullable<LenormandData['combinations']> = [];
-  for (let i = 0; i < cards.length - 1; i++) {
-    const comboKey = `${cards[i].name}+${cards[i + 1].name}`;
-    const reverseComboKey = `${cards[i + 1].name}+${cards[i].name}`;
-    const fixedMeaning =
-      LENORMAND_FIXED_COMBINATIONS[comboKey] ||
-      LENORMAND_FIXED_COMBINATIONS[reverseComboKey] ||
-      null;
-    combinations.push({
-      card1: cards[i].name,
-      card2: cards[i + 1].name,
-      meaning:
-        fixedMeaning ??
-        `${cards[i].name}的“${cards[i].keywords.slice(0, 2).join('、')}”与${cards[i + 1].name}的“${cards[i + 1].keywords.slice(0, 2).join('、')}”前后相接，先按${cards[i].meaning}，再看${cards[i + 1].meaning}`,
-      source: fixedMeaning ? '固定组合' : '相邻牌义合读',
-    });
-  }
+  const combinations = buildLenormandCombinations(spreadType, cards);
 
   const layoutEvidence: string[] = [];
   if (spreadType === 'nine') {

--- a/packages/core/src/divination/algorithms/liuyao.ts
+++ b/packages/core/src/divination/algorithms/liuyao.ts
@@ -154,14 +154,24 @@ function checkSanheWithTrigger(
  * - 化泄：动爻生变爻，本爻之气外泄
  * - 化耗：动爻克变爻，本爻用力而耗
  */
-function getChangeRelation(
+const VALID_LIUYAO_WUXING = new Set(Object.keys(wuxing));
+
+export function getLiuyaoChangeRelation(
   originalWuxing: string,
   changedWuxing: string,
   originalBranch: string,
   changedBranch: string,
   changedIsVoid: boolean,
-): '回头生' | '回头克' | '回头冲' | '化空' | '比和' | '化泄' | '化耗' | null {
-  if (!originalWuxing || !changedWuxing) return null;
+): '回头生' | '回头克' | '回头冲' | '化空' | '比和' | '化泄' | '化耗' {
+  if (!VALID_LIUYAO_WUXING.has(originalWuxing) || !VALID_LIUYAO_WUXING.has(changedWuxing)) {
+    throw new Error(`六爻动变五行无效：${originalWuxing || '空'}→${changedWuxing || '空'}`);
+  }
+  if (!BRANCH_ORDER.includes(originalBranch) || !BRANCH_ORDER.includes(changedBranch)) {
+    throw new Error(`六爻动变地支无效：${originalBranch || '空'}→${changedBranch || '空'}`);
+  }
+  if (typeof changedIsVoid !== 'boolean') {
+    throw new Error('六爻变爻旬空标记必须是布尔值');
+  }
   if (changedIsVoid) return '化空';
   if (isLiuchong(originalBranch, changedBranch)) return '回头冲';
   if (isSheng(changedWuxing, originalWuxing)) return '回头生';
@@ -170,6 +180,38 @@ function getChangeRelation(
   if (isSheng(originalWuxing, changedWuxing)) return '化泄';
   if (isKe(originalWuxing, changedWuxing)) return '化耗';
   throw new Error(`动变五行关系无法判定：${originalWuxing}→${changedWuxing}`);
+}
+
+const SHI_YANG_TO_GUA_SHEN: Record<number, string> = {
+  1: '子',
+  2: '丑',
+  3: '寅',
+  4: '卯',
+  5: '辰',
+  6: '巳',
+};
+
+const SHI_YIN_TO_GUA_SHEN: Record<number, string> = {
+  1: '午',
+  2: '未',
+  3: '申',
+  4: '酉',
+  5: '戌',
+  6: '亥',
+};
+
+export function getLiuyaoGuaShenBranch(shiPosition: number, shiYaoIsYang: boolean): string {
+  if (!Number.isInteger(shiPosition) || shiPosition < 1 || shiPosition > 6) {
+    throw new Error(`六爻世爻位置无效：${shiPosition}`);
+  }
+  if (typeof shiYaoIsYang !== 'boolean') {
+    throw new Error('六爻世爻阴阳标记必须是布尔值');
+  }
+  const branch = (shiYaoIsYang ? SHI_YANG_TO_GUA_SHEN : SHI_YIN_TO_GUA_SHEN)[shiPosition];
+  if (!branch) {
+    throw new Error(`六爻月卦身资料缺失：世爻${shiPosition}，${shiYaoIsYang ? '阳' : '阴'}`);
+  }
+  return branch;
 }
 
 /**
@@ -923,7 +965,7 @@ export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOpti
       !isChanging && isDayBreakFlag && (seasonState === '旺' || seasonState === '相');
     // 回头生克冲：动爻变出之爻对动爻本身的关系（仅动爻有变爻时计算）。
     const changeRelation = changedInfo
-      ? getChangeRelation(
+      ? getLiuyaoChangeRelation(
           info.wuxing,
           changedInfo.wuxing,
           info.dizhi,
@@ -998,26 +1040,12 @@ export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOpti
   // 月卦身（按六爻传统“阳世从子月起，阴世从午月生，从初数至世方真”）：
   // 阳世：初爻子、二爻丑、三爻寅、四爻卯、五爻辰、六爻巳
   // 阴世：初爻午、二爻未、三爻申、四爻酉、五爻戌、六爻亥
-  const SHI_YANG_TO_GUA_SHEN: Record<number, string> = {
-    1: '子',
-    2: '丑',
-    3: '寅',
-    4: '卯',
-    5: '辰',
-    6: '巳',
-  };
-  const SHI_YIN_TO_GUA_SHEN: Record<number, string> = {
-    1: '午',
-    2: '未',
-    3: '申',
-    4: '酉',
-    5: '戌',
-    6: '亥',
-  };
   // 世爻的阴阳决定卦身取阳表还是阴表
-  const shiYaoIsYang = mainYaos[shiYing.shi - 1] === '阳';
-  const guaShenBranch =
-    (shiYaoIsYang ? SHI_YANG_TO_GUA_SHEN : SHI_YIN_TO_GUA_SHEN)[shiYing.shi] || '';
+  const shiYaoType = mainYaos[shiYing.shi - 1];
+  if (shiYaoType !== '阳' && shiYaoType !== '阴') {
+    throw new Error(`六爻世爻资料缺失：第${shiYing.shi}爻`);
+  }
+  const guaShenBranch = getLiuyaoGuaShenBranch(shiYing.shi, shiYaoType === '阳');
   const guaShenYao = yaosInfo.find((i) => i.dizhi === guaShenBranch);
   const guaShen = guaShenYao
     ? {

--- a/packages/core/src/divination/algorithms/xiaoliuren.ts
+++ b/packages/core/src/divination/algorithms/xiaoliuren.ts
@@ -165,6 +165,92 @@ const XIAOLIUREN_SCHOOL_LABEL_MAP: Record<XiaoliurenSchool, string> = {
   huashan: '华山派',
 };
 
+type XiaoliurenElementRelation = '比和' | '被克' | '得生' | '所生' | '所克';
+type XiaoliurenPalaceName = '大安' | '留连' | '速喜' | '赤口' | '小吉' | '空亡';
+
+const XIAOLIUREN_TIMING_PROFILES: Record<
+  XiaoliurenPalaceName,
+  {
+    rhythm: '偏快' | '平稳' | '偏缓' | '反复' | '不定';
+    trigger: string;
+  }
+> = {
+  大安: { rhythm: '平稳', trigger: '基础条件稳定、资源到位或立场明确后推进' },
+  留连: { rhythm: '反复', trigger: '旧问题、手续或牵扯事项得到清理后再推进' },
+  速喜: { rhythm: '偏快', trigger: '消息、回复、邀约或明确机会出现时及时核验' },
+  赤口: { rhythm: '反复', trigger: '沟通冲突、误解澄清或立场摊牌时出现转折' },
+  小吉: { rhythm: '平稳', trigger: '协助者、资源、中间人或小步成果出现后渐进' },
+  空亡: { rhythm: '不定', trigger: '先核实目标、信息和承诺是否真实，再重新判断时机' },
+};
+
+const START_TO_PROCESS_DESCRIPTIONS: Record<XiaoliurenElementRelation, string> = {
+  比和: '起因与过程平稳衔接',
+  得生: '过程回生起因，推进中有反哺助力',
+  所生: '起因生过程，事态自然推进',
+  被克: '起因被过程克制，起步受阻需耐心',
+  所克: '起因克过程，前段有压制，先难后易',
+};
+
+const PROCESS_TO_RESULT_DESCRIPTIONS: Record<XiaoliurenElementRelation, string> = {
+  比和: '过程与结果保持同势',
+  得生: '结果回生过程，后续仍有支撑',
+  所生: '过程生结果，越做越顺',
+  被克: '过程被结果克制，先易后难需谨慎',
+  所克: '过程克结果，后段受压，先易后难',
+};
+
+const VALID_XIAOLIUREN_WUXING = new Set(['木', '火', '土', '金', '水']);
+
+export function getXiaoliurenElementRelation(
+  sourceElement: string,
+  targetElement: string,
+): XiaoliurenElementRelation {
+  if (!VALID_XIAOLIUREN_WUXING.has(sourceElement) || !VALID_XIAOLIUREN_WUXING.has(targetElement)) {
+    throw new Error(`小六壬五行无效：${sourceElement || '空'}→${targetElement || '空'}`);
+  }
+  if (sourceElement === targetElement) return '比和';
+  const sourceRelations = liuqinRelations[sourceElement as keyof typeof liuqinRelations];
+  const relative = sourceRelations[targetElement as keyof typeof sourceRelations];
+  switch (relative) {
+    case '父母':
+      return '得生';
+    case '子孙':
+      return '所生';
+    case '官鬼':
+      return '被克';
+    case '妻财':
+      return '所克';
+    case '兄弟':
+      return '比和';
+    default:
+      throw new Error(`小六壬无法判断${sourceElement}与${targetElement}的五行关系。`);
+  }
+}
+
+function getXiaoliurenTimingProfile(name: string) {
+  if (!Object.prototype.hasOwnProperty.call(XIAOLIUREN_TIMING_PROFILES, name)) {
+    throw new Error(`小六壬结果宫应期资料缺失：${name || '空值'}`);
+  }
+  return XIAOLIUREN_TIMING_PROFILES[name as XiaoliurenPalaceName];
+}
+
+export function validateXiaoliurenReferenceData(): void {
+  const expectedNames: XiaoliurenPalaceName[] = ['大安', '留连', '速喜', '赤口', '小吉', '空亡'];
+  const actualNames = XIAOLIUREN_PALACES.map((palace) => palace.name);
+  if (
+    actualNames.length !== expectedNames.length ||
+    expectedNames.some((name, index) => actualNames[index] !== name) ||
+    XIAOLIUREN_PALACES.some(
+      (palace, index) => palace.index !== index || !VALID_XIAOLIUREN_WUXING.has(palace.element),
+    )
+  ) {
+    throw new Error('小六壬六宫资料必须按大安至空亡顺序完整登记索引与五行');
+  }
+  expectedNames.forEach(getXiaoliurenTimingProfile);
+}
+
+validateXiaoliurenReferenceData();
+
 const DAYTIME_BRANCHES = new Set(['卯', '辰', '巳', '午', '未', '申']);
 
 const STAGE_ROLE_MAP: Record<XiaoliurenStageChart['stage'], string> = {
@@ -193,19 +279,8 @@ function getRelativeToDay(dayElement: string, palaceElement: string): string {
 }
 
 function describeElementToDay(dayElement: string, palaceElement: string): string {
-  if (dayElement === palaceElement) return '比和日主';
-  const relationTables: Record<string, Record<string, string>> = {
-    木: { 木: '比和', 金: '被克', 水: '得生', 火: '所生', 土: '所克' },
-    金: { 金: '比和', 火: '被克', 土: '得生', 水: '所生', 木: '所克' },
-    火: { 火: '比和', 水: '被克', 木: '得生', 土: '所生', 金: '所克' },
-    水: { 水: '比和', 土: '被克', 金: '得生', 木: '所生', 火: '所克' },
-    土: { 土: '比和', 木: '被克', 火: '得生', 金: '所生', 水: '所克' },
-  };
-  const relation = relationTables[palaceElement]?.[dayElement];
-  if (!relation) {
-    throw new Error(`小六壬无法判断宫位${palaceElement}与日主${dayElement}的五行关系。`);
-  }
-  return relation;
+  const relation = getXiaoliurenElementRelation(palaceElement, dayElement);
+  return relation === '比和' ? '比和日主' : relation;
 }
 
 function buildStageChart(params: {
@@ -375,40 +450,14 @@ export function generateXiaoliuren(
   // 宫间五行生克分析（《小六壬金口诀》核心精要）：
   // 起因宫克过程宫→先难后易；起因生过程→顺遂；比和→平稳；
   // 过程宫生结果宫→渐入佳境；过程克结果→先易后难；比和→势头保持。
-  const elementRelations: Record<string, Record<string, string>> = {
-    木: { 木: '比和', 金: '被克', 水: '得生', 火: '所生', 土: '所克' },
-    金: { 金: '比和', 火: '被克', 土: '得生', 水: '所生', 木: '所克' },
-    火: { 火: '比和', 水: '被克', 木: '得生', 土: '所生', 金: '所克' },
-    水: { 水: '比和', 土: '被克', 金: '得生', 木: '所生', 火: '所克' },
-    土: { 土: '比和', 木: '被克', 火: '得生', 金: '所生', 水: '所克' },
-  };
-  const startToProcess = elementRelations[start.element]?.[process.element];
-  const processToResult = elementRelations[process.element]?.[result.element];
-  if (!startToProcess) {
-    throw new Error(`小六壬无法判断${start.element}与${process.element}的五行关系。`);
-  }
-  if (!processToResult) {
-    throw new Error(`小六壬无法判断${process.element}与${result.element}的五行关系。`);
-  }
-  const wuXingDesc = [
-    startToProcess === '比和' ? '起因与过程平稳衔接' : '',
-    startToProcess === '得生' ? '过程回生起因，推进中有反哺助力' : '',
-    startToProcess === '所生' ? '起因生过程，事态自然推进' : '',
-    startToProcess === '被克' ? '起因被过程克制，起步受阻需耐心' : '',
-    startToProcess === '所克' ? '起因克过程，前段有压制，先难后易' : '',
-    processToResult === '比和' ? '过程与结果保持同势' : '',
-    processToResult === '得生' ? '结果回生过程，后续仍有支撑' : '',
-    processToResult === '所生' ? '过程生结果，越做越顺' : '',
-    processToResult === '被克' ? '过程被结果克制，先易后难需谨慎' : '',
-    processToResult === '所克' ? '过程克结果，后段受压，先易后难' : '',
-  ]
-    .filter(Boolean)
-    .join('；');
+  const startToProcess = getXiaoliurenElementRelation(start.element, process.element);
+  const processToResult = getXiaoliurenElementRelation(process.element, result.element);
+  const wuXingDesc = `${START_TO_PROCESS_DESCRIPTIONS[startToProcess]}；${PROCESS_TO_RESULT_DESCRIPTIONS[processToResult]}`;
 
   const wuxingRelations = {
     startToProcess,
     processToResult,
-    description: wuXingDesc || '三宫五行无特殊生克态势',
+    description: wuXingDesc,
   };
 
   // 旺衰按月令分析（取月干支的地支）
@@ -419,24 +468,7 @@ export function generateXiaoliuren(
     result: getSeasonState(result.element, monthBranch),
   };
 
-  const timingProfiles: Record<
-    string,
-    {
-      rhythm: '偏快' | '平稳' | '偏缓' | '反复' | '不定';
-      trigger: string;
-    }
-  > = {
-    大安: { rhythm: '平稳', trigger: '基础条件稳定、资源到位或立场明确后推进' },
-    留连: { rhythm: '反复', trigger: '旧问题、手续或牵扯事项得到清理后再推进' },
-    速喜: { rhythm: '偏快', trigger: '消息、回复、邀约或明确机会出现时及时核验' },
-    赤口: { rhythm: '反复', trigger: '沟通冲突、误解澄清或立场摊牌时出现转折' },
-    小吉: { rhythm: '平稳', trigger: '协助者、资源、中间人或小步成果出现后渐进' },
-    空亡: { rhythm: '不定', trigger: '先核实目标、信息和承诺是否真实，再重新判断时机' },
-  };
-  const timingProfile = timingProfiles[result.name] ?? {
-    rhythm: '不定' as const,
-    trigger: '结合具体问题和现实进展重新判断',
-  };
+  const timingProfile = getXiaoliurenTimingProfile(result.name);
   const resultSeasonState = seasonStates.result;
   const timingEvidence = {
     rhythm: timingProfile.rhythm,

--- a/packages/core/src/divination/lenormand-evidence.ts
+++ b/packages/core/src/divination/lenormand-evidence.ts
@@ -5,7 +5,7 @@ import {
   formatLegacyRandomFacts,
   type RandomTraceFact,
 } from '../shared/random';
-import type { LenormandData } from '../types/divination';
+import type { LenormandCombinationRelation, LenormandData } from '../types/divination';
 
 export interface LenormandCardEvidence {
   key: string;
@@ -74,7 +74,7 @@ export interface LenormandSequenceFact {
   toCard: string;
   promptText: string;
   sources: string[];
-  limitation: '牌序事实只描述已声明牌位的相邻顺序与牌面衔接；不得把牌阵顺序直接写成现实事件必然按同样阶段发生';
+  limitation: '牌序事实只描述抽取或登记顺序与牌面衔接，不代表两张牌在网格中空间相邻；不得把牌阵顺序直接写成现实事件必然按同样阶段发生';
 }
 
 export interface LenormandLayoutCoverageFact {
@@ -246,7 +246,7 @@ const SPREAD_COVERAGE_LIMITATION =
 const DRAW_ORDER_FACT_LIMITATION =
   '逐张抽取事实只核对洗牌顺序记录与已确定牌面的序号、牌位、牌号、牌名、宫位和行列落点；记录一致不表示牌义可信度、预测有效性或现实结果' as const;
 const SEQUENCE_FACT_LIMITATION =
-  '牌序事实只描述已声明牌位的相邻顺序与牌面衔接；不得把牌阵顺序直接写成现实事件必然按同样阶段发生' as const;
+  '牌序事实只描述抽取或登记顺序与牌面衔接，不代表两张牌在网格中空间相邻；不得把牌阵顺序直接写成现实事件必然按同样阶段发生' as const;
 const LAYOUT_COVERAGE_LIMITATION =
   '布局覆盖只说明九宫或大桌所需的中心、路径、宫位和人物牌近身关系是否有可核验结构；旧版字符串不得反推行列、宫位、距离或缺失布局事实' as const;
 const COUNTER_FACT_LIMITATION =
@@ -445,6 +445,8 @@ export function conditionLenormandTraditionalText(
     kind?: LenormandTraditionalFact['kind'];
     cardNames?: string[];
     keywords?: string[];
+    relation?: LenormandCombinationRelation;
+    positions?: string[];
   },
 ): string {
   const kind = options?.kind ?? '单牌牌义';
@@ -452,6 +454,12 @@ export function conditionLenormandTraditionalText(
   const keywords = unique(options?.keywords ?? []);
   const targetText = keywords.length ? keywords.join('、') : '相关象征主题';
   const cardsText = cardNames.length ? cardNames.join('+') : '当前牌面';
+  const positions = unique(options?.positions ?? []);
+  const relationText = options?.relation
+    ? `${positions.length ? `${positions.join('与')}的` : ''}${options.relation}`
+    : positions.length
+      ? `${positions.join('与')}的已登记组合关系`
+      : '已登记组合关系';
   const conditionedText = text
     .replace(/感情的承诺或婚约/g, '关系承诺、契约或婚约议题')
     .replace(/订婚或喜讯/g, '订婚或喜讯线索')
@@ -493,10 +501,10 @@ export function conditionLenormandTraditionalText(
     .replace(/需要承担代价或接受现实/g, '需要核实现实责任、成本与可承受范围')
     .replace(/[。.]$/, '');
   if (kind === '固定组合') {
-    return `传统固定组合${cardsText}提示关注${conditionedText || targetText}；只可检查这些主题是否同时出现现实证据，不得直接认定婚约、生育、收益、欺骗或其他现实结果`;
+    return `传统固定组合${cardsText}通过${relationText}命中，提示关注${conditionedText || targetText}；只可检查这些主题是否同时出现现实证据，不得直接认定婚约、生育、收益、欺骗或其他现实结果`;
   }
   if (kind === '相邻合读') {
-    return `相邻牌${cardsText}按抽牌顺序形成${targetText}的合读范围；这不是传统固定组合，须逐项核实前后牌主题是否与现实进展相符`;
+    return `相邻牌${cardsText}通过${relationText}形成${targetText}的合读范围；这不是传统固定组合，须逐项核实两张牌主题是否与现实进展相符`;
   }
   return `传统单牌${cardsText}以${targetText}为解释范围；可在当前牌位检查这些主题的现实线索，但不把原始牌义直接当作已发生事实`;
 }
@@ -527,6 +535,11 @@ function buildTraditionalFacts(
     const first = cardByName.get(combo.card1);
     const second = cardByName.get(combo.card2);
     const kind = combo.source === '固定组合' ? '固定组合' : '相邻合读';
+    const relation = combo.relation;
+    const positions = unique([
+      combo.position1 ?? first?.position ?? '',
+      combo.position2 ?? second?.position ?? '',
+    ]);
     const verificationTargets = unique([...(first?.keywords ?? []), ...(second?.keywords ?? [])]);
     return {
       key: `combination:${index + 1}:${combo.card1}:${combo.card2}:${kind}`,
@@ -534,18 +547,32 @@ function buildTraditionalFacts(
       kind,
       cardFactKeys: unique([first?.key ?? '', second?.key ?? '']),
       cardNames: [combo.card1, combo.card2],
-      positions: unique([first?.position ?? '', second?.position ?? '']),
+      positions,
       originalText: combo.meaning,
       promptText: conditionLenormandTraditionalText(combo.meaning, {
         kind,
         cardNames: [combo.card1, combo.card2],
         keywords: verificationTargets,
+        relation,
+        positions,
       }),
       verificationTargets,
       sources:
         kind === '固定组合'
-          ? ['当前雷诺曼固定牌对解释资料']
-          : ['当前相邻牌位顺序与两张牌的关键词、基础牌义'],
+          ? [
+              '当前雷诺曼固定牌对解释资料',
+              relation
+                ? `当前牌阵两张牌的${relation}与具体牌位`
+                : '原始组合记录未注明空间方向，仅保留已登记牌位',
+            ]
+          : [
+              relation === '牌序相邻'
+                ? '当前牌阵的抽取或登记顺序'
+                : relation
+                  ? `当前牌阵两张牌的${relation}与具体牌位`
+                  : '原始组合记录未注明相邻关系类型',
+              '两张牌的关键词与基础牌义',
+            ],
       limitation: TRADITIONAL_FACT_LIMITATION,
     };
   });
@@ -687,8 +714,8 @@ function buildSequenceFacts(cards: LenormandCardEvidence[]): LenormandSequenceFa
       toPosition: card.position,
       fromCard: previous.name,
       toCard: card.name,
-      promptText: `${previous.position}${previous.name} → ${card.position}${card.name}`,
-      sources: ['已声明牌阵的牌位顺序', '相邻牌位的已确定牌面'],
+      promptText: `${previous.position}${previous.name} → ${card.position}${card.name}（仅表示抽取或登记顺序，不表示空间相邻）`,
+      sources: ['已声明牌阵的抽取或登记顺序', '顺序相接的已确定牌面'],
       limitation: SEQUENCE_FACT_LIMITATION,
     };
   });

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -1016,6 +1016,8 @@ export interface AlmanacData {
 export type LenormandSpreadType =
   'single' | 'three' | 'five' | 'relationship' | 'decision' | 'nine' | 'element' | 'grandTableau';
 
+export type LenormandCombinationRelation = '牌序相邻' | '横向相邻' | '纵向相邻' | '对角相邻';
+
 export interface LenormandData {
   meta?: CoreResultMeta;
   spreadType: LenormandSpreadType;
@@ -1047,6 +1049,11 @@ export interface LenormandData {
   combinations?: Array<{
     card1: string;
     card2: string;
+    position1?: string;
+    position2?: string;
+    relation?: LenormandCombinationRelation;
+    rowDistance?: number;
+    columnDistance?: number;
     meaning: string;
     source?: '固定组合' | '相邻牌义合读';
   }>;

--- a/src/lib/divination/engine/formatters.ts
+++ b/src/lib/divination/engine/formatters.ts
@@ -1010,10 +1010,12 @@ function formatLenormandInfo(data: LenormandData) {
     (card) =>
       `- ${card.position}：${card.name}；关键词：${card.keywords.join('、')}；牌义：${card.meaning}`,
   );
-  const combinationLines = (data.combinations ?? []).map(
-    (item) =>
-      `- ${item.card1}+${item.card2}：${item.meaning}${item.source ? `（${item.source}）` : ''}`,
-  );
+  const combinationLines = (data.combinations ?? []).map((item) => {
+    const positions =
+      item.position1 && item.position2 ? `${item.position1} ↔ ${item.position2}；` : '';
+    const relation = item.relation ? `${item.relation}；` : '';
+    return `- ${item.card1}+${item.card2}：${positions}${relation}${item.meaning}${item.source ? `（${item.source}）` : ''}`;
+  });
   return [
     '占法：雷诺曼',
     '时间干支：以【当前时间】为准',

--- a/tests/almanac-algorithm.test.ts
+++ b/tests/almanac-algorithm.test.ts
@@ -1,7 +1,21 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { generateAlmanacSelection } from '../packages/core/src/divination/algorithms/almanac.ts';
+import {
+  generateAlmanacSelection,
+  getAlmanacAnnualDirectionGods,
+  getAlmanacNineStarDetail,
+  getAlmanacPengZuDetails,
+  getAlmanacTwentyEightStarDetail,
+} from '../packages/core/src/divination/algorithms/almanac.ts';
+
+test('黄历基础资料缺失或输入非法时应明确报错', () => {
+  assert.throws(() => getAlmanacTwentyEightStarDetail('未知宿'), /二十八宿资料缺失/);
+  assert.throws(() => getAlmanacNineStarDetail('十白'), /九星资料缺失/);
+  assert.throws(() => getAlmanacPengZuDetails('甲', '无'), /彭祖地支百忌资料缺失/);
+  assert.throws(() => getAlmanacPengZuDetails('无', '子'), /彭祖天干百忌资料缺失/);
+  assert.throws(() => getAlmanacAnnualDirectionGods('无'), /年支无效/);
+});
 
 test('黄历择日：tyme4ts 返回九星短名时也应补出九星详情', () => {
   const result = generateAlmanacSelection({
@@ -295,6 +309,25 @@ test('黄历择日：每个候选日应给出完整时辰并排除诸事不宜�
 
   for (const day of result.days) {
     assert.equal(day.hours?.length, 13, `${day.date} 应包含早晚子时在内的 13 个时段`);
+    assert.deepEqual(
+      day.hours?.map((hour) => [hour.name, hour.branch, hour.range]),
+      [
+        ['早子时', '子', '00:00-01:00'],
+        ['丑时', '丑', '01:00-03:00'],
+        ['寅时', '寅', '03:00-05:00'],
+        ['卯时', '卯', '05:00-07:00'],
+        ['辰时', '辰', '07:00-09:00'],
+        ['巳时', '巳', '09:00-11:00'],
+        ['午时', '午', '11:00-13:00'],
+        ['未时', '未', '13:00-15:00'],
+        ['申时', '申', '15:00-17:00'],
+        ['酉时', '酉', '17:00-19:00'],
+        ['戌时', '戌', '19:00-21:00'],
+        ['亥时', '亥', '21:00-23:00'],
+        ['晚子时', '子', '23:00-24:00'],
+      ],
+    );
+    assert.equal(new Set(day.hours?.map((hour) => hour.range)).size, 13);
     assert.ok((day.bestHours?.length ?? 0) > 0, `${day.date} 应给出首选时辰`);
     for (const hour of day.bestHours ?? []) {
       assert.doesNotMatch(

--- a/tests/lenormand-algorithm.test.ts
+++ b/tests/lenormand-algorithm.test.ts
@@ -37,8 +37,17 @@ test('雷诺曼大桌牌阵应抽取完整 36 张牌', () => {
     result.draw?.order.map((item) => [item.position, item.cardId, item.cardName, item.house]),
     result.cards.map((card) => [card.position, card.id, card.name, card.house]),
   );
-  assert.equal(result.combinations?.length, 35);
-  assert.ok(result.combinations?.every((item) => item.source));
+  assert.ok((result.combinations?.length ?? 0) > 0);
+  assert.ok(
+    result.combinations?.every(
+      (item) =>
+        item.source &&
+        item.relation &&
+        item.relation !== '牌序相邻' &&
+        item.position1 &&
+        item.position2,
+    ),
+  );
   assert.ok(result.layoutEvidence?.some((item) => item.includes('男士落第')));
   assert.ok(result.layoutEvidence?.some((item) => item.includes('女士落第')));
   assert.equal(
@@ -79,7 +88,9 @@ test('雷诺曼九宫应输出横纵与对角线结构证据', () => {
     ]),
     result.cards.map((card, index) => [index + 1, card.position, card.name, card.row, card.column]),
   );
-  assert.equal(result.combinations?.length, 8);
+  assert.equal(result.combinations?.length, 20);
+  assert.ok(result.combinations?.some((item) => item.relation === '纵向相邻'));
+  assert.ok(result.combinations?.some((item) => item.relation === '对角相邻'));
   assert.ok(result.layoutEvidence?.some((item) => item.includes('横向')));
   assert.ok(result.layoutEvidence?.some((item) => item.includes('对角线')));
   const layoutItems = result.evidenceAnalysis?.evidence.items.filter((item) =>
@@ -156,6 +167,57 @@ test('雷诺曼手工录入应按牌位成盘，并将随机轨迹标为不适�
     () => drawLenormandSpread('single', { seed: '冲突参数', manualCardIds: [1] }),
     /不能同时提供随机选项/,
   );
+});
+
+test('雷诺曼九宫固定组合应按纵向空间相邻命中并保留牌位', () => {
+  const result = drawLenormandSpread('nine', {
+    manualCardIds: [24, 1, 2, 25, 3, 4, 5, 6, 7],
+  });
+  const combination = result.combinations?.find(
+    (item) => item.card1 === '心' && item.card2 === '戒指',
+  );
+
+  assert.equal(combination?.source, '固定组合');
+  assert.equal(combination?.relation, '纵向相邻');
+  assert.equal(combination?.position1, '左上');
+  assert.equal(combination?.position2, '左侧');
+  const fact = result.evidenceAnalysis?.traditionalFacts.find(
+    (item) =>
+      item.kind === '固定组合' && item.cardNames.includes('心') && item.cardNames.includes('戒指'),
+  );
+  assert.match(fact?.promptText ?? '', /左上与左侧的纵向相邻/);
+  assert.ok(fact?.sources.some((source) => source.includes('纵向相邻')));
+});
+
+test('雷诺曼大桌不应把行尾与下一行行首误判为空间相邻', () => {
+  const cardIds = Array.from({ length: 36 }, (_, index) => index + 1);
+  [cardIds[8], cardIds[23]] = [cardIds[23], cardIds[8]];
+  [cardIds[9], cardIds[24]] = [cardIds[24], cardIds[9]];
+  const result = drawLenormandSpread('grandTableau', { manualCardIds: cardIds });
+
+  assert.equal(
+    result.combinations?.some(
+      (item) =>
+        (item.card1 === '心' && item.card2 === '戒指') ||
+        (item.card1 === '戒指' && item.card2 === '心'),
+    ),
+    false,
+  );
+});
+
+test('雷诺曼大桌固定组合应按纵向空间相邻命中', () => {
+  const cardIds = Array.from({ length: 36 }, (_, index) => index + 1);
+  [cardIds[0], cardIds[23]] = [cardIds[23], cardIds[0]];
+  [cardIds[9], cardIds[24]] = [cardIds[24], cardIds[9]];
+  const result = drawLenormandSpread('grandTableau', { manualCardIds: cardIds });
+  const combination = result.combinations?.find(
+    (item) => item.card1 === '心' && item.card2 === '戒指',
+  );
+
+  assert.equal(combination?.source, '固定组合');
+  assert.equal(combination?.relation, '纵向相邻');
+  assert.equal(combination?.rowDistance, 1);
+  assert.equal(combination?.columnDistance, 0);
 });
 
 test('雷诺曼手动抽取应按样本逐张无重复翻牌并保留可重放轨迹', () => {

--- a/tests/liuyao-strength-change.test.ts
+++ b/tests/liuyao-strength-change.test.ts
@@ -3,7 +3,9 @@ import { strict as assert } from 'node:assert';
 import {
   generateLiuyao,
   getLiuyaoChangeDirection,
+  getLiuyaoChangeRelation,
   getLiuyaoFanFuRelations,
+  getLiuyaoGuaShenBranch,
   getLiuyaoHexagramRelation,
   getLiuyaoHexagramRelations,
   getLiuyaoPalaceStage,
@@ -266,6 +268,18 @@ test('六爻：月卦身应按阳世起子、阴世起午逐爻顺数', () => {
   assert.equal(yinShi.yaosDetail[5].yaoType, '阴');
   assert.equal(yinShi.guaShen?.branch, '亥');
   assert.equal(yinShi.guaShen?.position, 2);
+});
+
+test('六爻：动变关系与月卦身应拒绝非法资料', () => {
+  assert.throws(() => getLiuyaoChangeRelation('', '火', '子', '午', false), /动变五行无效/);
+  assert.throws(() => getLiuyaoChangeRelation('水', '火', '无', '午', false), /动变地支无效/);
+  assert.throws(
+    () => getLiuyaoChangeRelation('水', '火', '子', '午', undefined as never),
+    /旬空标记必须是布尔值/,
+  );
+  assert.throws(() => getLiuyaoGuaShenBranch(0, true), /世爻位置无效/);
+  assert.throws(() => getLiuyaoGuaShenBranch(7, false), /世爻位置无效/);
+  assert.throws(() => getLiuyaoGuaShenBranch(1, undefined as never), /阴阳标记必须是布尔值/);
 });
 
 test('六爻：手工三钱法爻值应严格校验长度与取值', () => {

--- a/tests/xiaoliuren-algorithm.test.ts
+++ b/tests/xiaoliuren-algorithm.test.ts
@@ -5,10 +5,37 @@ import {
   analyzeXiaoliurenEvidence,
   conditionXiaoliurenTraditionalText,
   generateXiaoliuren,
+  getXiaoliurenElementRelation,
+  validateXiaoliurenReferenceData,
 } from '../packages/core/src/divination/algorithms/xiaoliuren.ts';
 import { assertPromptIsPortableTaskText } from './prompt-assertions';
 
 const SAMPLE_DATE = new Date('2025-01-01T08:00:00+08:00');
+
+test('小六壬：五行关系表应完整覆盖 25 种组合', () => {
+  const elements = ['木', '火', '土', '金', '水'];
+  const relations = elements.flatMap((source) =>
+    elements.map((target) => getXiaoliurenElementRelation(source, target)),
+  );
+
+  assert.equal(relations.length, 25);
+  assert.deepEqual(new Set(relations), new Set(['比和', '被克', '得生', '所生', '所克']));
+  assert.doesNotThrow(() => validateXiaoliurenReferenceData());
+  assert.throws(() => getXiaoliurenElementRelation('木', ''), /五行无效/);
+});
+
+test('小六壬：六个结果宫都应使用专属应期画像', () => {
+  const results = Array.from({ length: 6 }, (_, index) =>
+    generateXiaoliuren({ method: 'number', number: index + 1, customDate: SAMPLE_DATE }),
+  );
+
+  assert.equal(new Set(results.map((result) => result.sequence.result.name)).size, 6);
+  assert.ok(results.every((result) => result.timingEvidence?.triggerConditions[0]));
+  assert.doesNotMatch(
+    results.map((result) => result.timingEvidence?.triggerConditions.join('；')).join('\n'),
+    /通用|特殊生克态势/,
+  );
+});
 
 test('小六壬：空亡宫五行应为土，类型与算法数据保持一致', () => {
   const data = generateXiaoliuren({ method: 'number', number: 5, customDate: SAMPLE_DATE });


### PR DESCRIPTION
## 目标

继续审查命理与占卜算法中的资料兜底、关系误判和空间互参问题。

## 主要修改

- 黄历对二十八宿、九星、彭祖百忌、岁支方位和 13 个时辰资料做完整校验，缺项或非法输入明确报错。
- 六爻收紧动变五行、地支、旬空与月卦身输入，不再用空值掩盖资料异常。
- 小六壬统一五行关系推导，完整覆盖 25 种组合与六宫应期画像。
- 雷诺曼九宫和大桌改按真实横向、纵向、对角邻接互参，避免行尾跨行误判；组合证据与前端明细补充牌位和关系类型。

## 验证

- pnpm test：1417 项通过
- pnpm test:e2e：36 项通过
- pnpm exec tsc -p tsconfig.app.json --noEmit：通过
- pnpm lint：通过
- Prettier：通过
- pnpm build：通过
- git diff --check：通过

## 兼容风险

雷诺曼九宫组合由抽取顺序相邻改为真实八邻域；大桌只保留固定组合和人物牌近身合读，结构更准确，但组合数量会与旧结果不同。