### PR TITLE
完成公开算法全局审查并收紧隐式输入

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -116,11 +116,11 @@
 | 查六十甲子、纳音、藏干和合冲       | `POST /foundation/ganzhi`                    | `ganZhi`，如“甲子”                                                                                                                                          | 返回统一公共地基资料，不需重复实现                                                |
 | 统计天干地支五行分布               | `POST /foundation/wuxing`                    | `items`、可选 `weightHidden`                                                                                                                                | 默认计入地支藏干权重                                                              |
 | 核验通用神煞命中                   | `POST /foundation/shensha`                   | 完整年、月、日、时四柱干支；可选 `ids`                                                                                                                      | 返回空亡、驿马、桃花的固定起法、目标地支、命中柱位、来源与限制                    |
-| 整体人生、长期事业、财运、婚恋     | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic` 按主题填写，`promptScope: "full"` 或 `"origin"`                                                                       | 有完整出生信息时优先合参；想看完整阶段时用 `full`                                 |
-| 今年、某一年、当前阶段运势         | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题填事业、财运、感情等                                                                                                           | 八字看岁运触发，紫微看流年落宫与四化                                              |
+| 整体人生、长期事业、财运、婚恋     | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic` 按主题填写；`origin` 无需行运目标，`full` 同时传 `ziweiScopeDate`、`ziweiScopeTimeIndex`                              | 有完整出生信息时优先合参；想看完整阶段时用 `full`                                 |
+| 今年、某一年、当前阶段运势         | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`、`ziweiScopeDate`、`ziweiScopeTimeIndex`，主题填事业、财运、感情等                                                                  | 八字看岁运触发，紫微看流年落宫与四化                                              |
 | 换工作、创业、合伙、投资合作       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`，按问题选择主题                                                                               | 这类问题兼具长期结构和当前触发，优先合参                                          |
 | 只看八字格局、用神、流年流月       | `POST /bazi/prompt`                          | `promptTopic`，`baziFortuneScope: "full"`、`"year"`、`"month"` 或 `"day"`                                                                                   | 明确要求八字时使用                                                                |
-| 只看紫微宫位、四化、某年某月运限   | `POST /ziwei/prompt`                         | `promptTopic`，`promptScope: "full"`、`"yearly"`、`"monthly"`、`"daily"` 或 `"hourly"`                                                                      | 明确要求紫微时使用                                                                |
+| 只看紫微宫位、四化、某年某月运限   | `POST /ziwei/prompt`                         | `promptTopic`、非本命 `promptScope`、`ziweiScopeDate`、`ziweiScopeTimeIndex`                                                                                | 明确要求紫微时使用；服务端不补当前日期或时辰                                      |
 | 当前事项能否推进、短期成败         | `POST /divination/liuyao/prompt`             | `question`，必要时传 `customDate`                                                                                                                           | 六爻适合一事一问、取用和应期                                                      |
 | 项目推进、方向选择、谈判出行、方位 | `POST /divination/qimen/prompt`              | `question`，可选 `qimenMethod: "zhuanpan"` 或 `"feipan"`，必要时传 `customDate`                                                                             | 奇门适合时空局势、路径、方位和行动窗口                                            |
 | 临时小事、快速判断                 | `POST /divination/xiaoliuren/prompt`         | `question`，可选 `xiaoliurenMethod`、`xiaoliurenSchool` 和 `xiaoliurenNumber`                                                                               | 返回三宫推进、五行、旺衰、触发条件与反证限制；华山派另含完整课象；不用于长期命运  |
@@ -141,7 +141,7 @@
 参数选择建议：
 
 - `responseMode` 默认用 `summary`；只转交提示词给 AI 时用 `prompt-only`；确实需要完整结构化排盘时再用 `full`。
-- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"` 并以 `astrolabeScopeDate: "YYYY-MM-DD"` 明确行运基准日。
+- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`；紫微和合参用 `promptScope: "full"`，并明确传入 `ziweiScopeDate: "YYYY-MM-DD"` 与 `ziweiScopeTimeIndex: 0-12`；星盘用 `astrolabeScope: "full"` 并以 `astrolabeScopeDate: "YYYY-MM-DD"` 明确行运基准日。
 - 只问某一年、某月、某日时，优先选择对应范围，避免把短期问题做成泛泛终身解读。
 - `promptMode` 默认用 `framework`，这样返回的提示词结构更完整；只有用户明确要自由问答或自己已经写好完整问题时，才用 `custom`。
 - 出生时辰未知时，不要自行补时辰；八字只能保守使用已知信息，紫微和八字紫微合参应等用户补足时辰后再调用。
@@ -237,7 +237,7 @@ curl -X POST https://aov.cc/api/v1/ziwei/compatibility/prompt \
 ```bash
 curl -X POST https://aov.cc/api/v1/ziwei/prompt \
   -H "Content-Type: application/json" \
-  -d '{"name":"测试","gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"整体人生和近期重点怎么看？","promptTopic":"life","promptScope":"full"}'
+  -d '{"name":"测试","gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"整体人生和近期重点怎么看？","promptTopic":"life","promptScope":"full","ziweiScopeDate":"2028-06-12","ziweiScopeTimeIndex":4}'
 ```
 
 八字紫微合参提示词适合“八字定主线、紫微校验宫位和运限”的深度问题，`promptScope` 同样支持 `full`：
@@ -245,7 +245,7 @@ curl -X POST https://aov.cc/api/v1/ziwei/prompt \
 ```bash
 curl -X POST https://aov.cc/api/v1/bazi-ziwei/prompt \
   -H "Content-Type: application/json" \
-  -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly"}'
+  -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly","ziweiScopeDate":"2028-06-12","ziweiScopeTimeIndex":4}'
 ```
 
 星盘提示词可用 `astrolabeScope` 指定范围。`yearly`、`monthly`、`daily` 分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`；`full` 要求 `YYYY-MM-DD` 基准日，并写入该日所属流年、流月和流日资料。服务端不会用当前日期补齐缺参：
@@ -305,7 +305,7 @@ curl -X POST https://aov.cc/api/v1/bazi/prompt \
 ```bash
 curl -X POST https://aov.cc/api/v1/ziwei/prompt \
   -H "Content-Type: application/json" \
-  -d '{"gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"2025年事业财运如何？","promptTopic":"career-wealth","promptScope":"yearly","school":"feixing"}'
+  -d '{"gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"2025年事业财运如何？","promptTopic":"career-wealth","promptScope":"yearly","ziweiScopeDate":"2025-06-12","ziweiScopeTimeIndex":4,"school":"feixing"}'
 ```
 
 奇门飞盘法排盘：
@@ -377,12 +377,12 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 - 八字 `promptTopic` 支持 `general`、`career`、`wealth`、`marriage`、`children`、`health`、`relationship-push`、`relationship-decision`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`home-move`、`settle-relocate`、`study-advance`、`exam-landing`、`reconciliation-decision`、`emotion`、`talent`、`growth`、`social`。
 - 八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围，支持 `natal`、`full`、`dayun`、`year`、`month`、`day`；除 `natal`、`full` 外必须提供所选层级需要的明确年限参数，工具不会自动选择当前时间或第一项。
 - 紫微 `promptTopic` 支持 `destiny`、`relationship`、`relationship-push`、`relationship-decision`、`children`、`career-wealth`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`family`、`home-move`、`settle-relocate`、`social`、`emotion`、`health`、`study`、`study-advance`、`exam-landing`、`reconciliation-decision`、`growth`、`talent`、`life`、`chat`。
-- 紫微 `promptScope` 支持 `origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`；`full` 会返回并写入本命、大限、流年、流月、流日、流时资料。
-- 紫微公开 API 默认只返回 `origin`（本命）范围；如果请求传入 `promptScope`，接口会返回 `origin` 加指定范围，包含分析对象、落宫与四化信息，供流年、流月、流日等分析使用。
+- 紫微 `promptScope` 支持 `origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`；除 `origin` 外必须同时提供 `ziweiScopeDate`（`YYYY-MM-DD`）和 `ziweiScopeTimeIndex`（0-12），服务端不会用当前日期或时辰补齐。`full` 会按该目标时刻返回并写入本命、大限、流年、流月、流日、流时资料。
+- 紫微公开 API 默认只返回 `origin`（本命）范围；非本命请求会返回 `origin` 加指定范围，包含明确目标时刻对应的分析对象、落宫与四化信息。
 - 紫微排盘结果以 `payloadByScope.origin.palaces` 为主结构；同时提供 `四化`、`fourMutagens`、`birthMutagens` 和 `gongList`，方便 agent 直接读取生年四化和十二宫星曜。
 - 八字提示词选择 `baziFortuneScope` 后，`data.resultSummary.fortuneSelection.promptPayload.triggerEvidence` 会返回原局、大运、流年、流月、流日逐层关系，包括同干、五合、相冲、同支、六合、六冲、刑、害、破、岁运并临与天克地冲。它只表示触发结构和时间层级，不直接表示吉凶或事件必然发生。
 - 八字出生时间必须满足接口输入约束后才会进入排盘；接口不接受模糊时间误差范围，也不会基于误差范围继续排盘。
-- 八字紫微合参接口为 `POST /bazi-ziwei/prompt`，使用同一份出生信息，同时计算八字和紫微，默认返回 `data.resultSummary.bazi`、`data.resultSummary.ziwei` 和 `data.prompt`；传 `responseMode: "full"` 可返回完整双盘。该接口使用 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope` 区分两套体系的分析范围。
+- 八字紫微合参接口为 `POST /bazi-ziwei/prompt`，使用同一份出生信息，同时计算八字和紫微，默认返回 `data.resultSummary.bazi`、`data.resultSummary.ziwei` 和 `data.prompt`；传 `responseMode: "full"` 可返回完整双盘。该接口使用 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope` 区分两套体系的分析范围；非本命紫微范围同样必须提供 `ziweiScopeDate` 和 `ziweiScopeTimeIndex`。
 - `promptMode` 支持 `framework`（完整任务书，默认）和 `custom`（只围绕用户问题自由作答）。
 - 八字 `school` 支持 `traditional`（传统派子平正法）、`mangpai`（盲派十神象法）、`xinpai`（新派调候流通）。不传则不附加流派指引。
 - 八字 `shenShaVariants` 用于请求神煞争议口径；不传时使用默认主流口径：空亡只按日柱旬空、羊刃只取阳干帝旺、童子煞只查日柱和时柱。可选值：`kongWangBasis` 为 `day` 或 `day-and-year`；`yangRenMode` 为 `yang-stems-only` 或 `include-yin-ren`；`tongZiScope` 为 `day-hour` 或 `all-pillars`。
@@ -408,7 +408,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 - 星盘本命与行运相位会输出距精确角偏差、紧密等级和归一化容许度位置；归一化位置只用于相位分层，不代表事件概率或吉凶比例。
 - 流年星盘中的太阳返照先在出生日期附近按 2 小时步长寻找太阳黄经过零区间，再用二分法细化至 1 分钟范围；提示词会同时写出当地钟表时刻、固定时区、黄经残差、迭代次数、星历来源和精度边界，不以显示到分钟宣称观测级精度。
 - 太阳返照和七政四余的计算上下文会附带统一天文时间尺度证据，包括 UTC、`JD(UTC)`、`UT1≈UTC` 假设、Espenak-Meeus 分段多项式 ΔT、近似 `JD(TT)`、模型等级和限制。只传 `timezone` 时仍视为调用方已确认的法定偏移；传 `timeZoneId` 时按运行环境 IANA 数据解析历史偏移，并报告与固定偏移的冲突。
-- 七政四余还会附带同一 UTC 时刻的月相角、照明近似和前后朔弦望证据。黄历候选日则统一附带中国标准时间正午的月相背景；该背景不参与传统候选排序，其他时区或临近相位交接时应按实际地点时间另算。
+- 七政四余必须提供真实 `latitude`、`longitude`，并在 `timezone` 与 `timeZoneId` 中至少提供一项；不会默认使用北京坐标或东八区。结果还会附带同一 UTC 时刻的月相角、照明近似和前后朔弦望证据。黄历候选日则统一附带中国标准时间正午的月相背景；该背景不参与传统候选排序，其他时区或临近相位交接时应按实际地点时间另算。
 - 七政四余相位返回实际夹角、精确角、偏差、容许度位置、紧密等级与精度分层；核心结果、公开 API、MCP 和提示词均不返回由容许度位置重复换算的百分制强度。
 - 西占和七政四余会根据真实经纬度附带太阳光照证据，包括参考时刻太阳高度、真北方位角、视太阳正午、日出日落和三类曙暮光。该数据只描述天文光照背景，不改变星体庙旺或传统吉凶；实际地形、建筑、海拔和气象折射仍需现场资料。
 - 八字节令月和奇门节令背景会附带节气交接证据：排盘边界采用 `tyme4ts` 历表，另以 Meeus/NOAA 太阳视黄经公式独立求根，并返回历表与模型差值、黄经残差及精度限制；模型核验不会静默覆盖现有排盘边界。

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,8 +82,8 @@
 | `POST /divination/astrolabe/synastry/prompt` | 西占双盘计算并生成证据提示词                                                   |
 | `POST /metaphysics/bazhai/calculate`         | 八宅命卦、宅卦、测量候选及命宅逐方结构化证据                                   |
 | `POST /metaphysics/bazhai/prompt`            | 八宅排盘并生成含测量和现实边界的 AI 解读提示词                                 |
-| `POST /metaphysics/residential/calculate`   | 住宅风水：八宅与玄空飞星分层合参结果                                           |
-| `POST /metaphysics/residential/prompt`      | 住宅风水合参并生成 AI 解读提示词                                               |
+| `POST /metaphysics/residential/calculate`    | 住宅风水：八宅与玄空飞星分层合参结果                                           |
+| `POST /metaphysics/residential/prompt`       | 住宅风水合参并生成 AI 解读提示词                                               |
 | `POST /metaphysics/zodiac/calculate`         | 生肖与流年值冲刑害破、三合六合及结构化关系证据                                 |
 | `POST /metaphysics/zodiac/prompt`            | 生肖流年关系排盘并生成含信息量限制的 AI 解读提示词                             |
 | `POST /metaphysics/taiyi/calculate`          | 太乙神数排盘                                                                   |
@@ -109,39 +109,39 @@
 
 常见问题到推荐接口：
 
-| 用户问题类型                       | 首选接口                                     | 推荐参数                                                                                                                                                    | 说明                                                                             |
-| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| 换算真太阳时                       | `POST /calendar/true-solar-time`             | `localDateTime`、`longitude`，可选 `timezone`、`applyChinaDst`                                                                                              | 默认 UTC+8，返回修正明细、跨日状态和对应时辰                                     |
-| 计算太阳光照证据                   | `POST /calendar/solar-illumination`          | `year`、`month`、`day`、`latitude`、`longitude`，并提供 `timezone` 或 `timeZoneId`；可选参考时分秒                                                          | 返回太阳高度、方位、视太阳正午、日出日落与三类曙暮光                             |
-| 查六十甲子、纳音、藏干和合冲       | `POST /foundation/ganzhi`                    | `ganZhi`，如“甲子”                                                                                                                                          | 返回统一公共地基资料，不需重复实现                                               |
-| 统计天干地支五行分布               | `POST /foundation/wuxing`                    | `items`、可选 `weightHidden`                                                                                                                                | 默认计入地支藏干权重                                                             |
-| 核验通用神煞命中                   | `POST /foundation/shensha`                   | 完整年、月、日、时四柱干支；可选 `ids`                                                                                                                      | 返回空亡、驿马、桃花的固定起法、目标地支、命中柱位、来源与限制                   |
-| 整体人生、长期事业、财运、婚恋     | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic` 按主题填写，`promptScope: "full"` 或 `"origin"`                                                                       | 有完整出生信息时优先合参；想看完整阶段时用 `full`                                |
-| 今年、某一年、当前阶段运势         | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题填事业、财运、感情等                                                                                                           | 八字看岁运触发，紫微看流年落宫与四化                                             |
-| 换工作、创业、合伙、投资合作       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`，按问题选择主题                                                                               | 这类问题兼具长期结构和当前触发，优先合参                                         |
-| 只看八字格局、用神、流年流月       | `POST /bazi/prompt`                          | `promptTopic`，`baziFortuneScope: "full"`、`"year"`、`"month"` 或 `"day"`                                                                                   | 明确要求八字时使用                                                               |
-| 只看紫微宫位、四化、某年某月运限   | `POST /ziwei/prompt`                         | `promptTopic`，`promptScope: "full"`、`"yearly"`、`"monthly"`、`"daily"` 或 `"hourly"`                                                                      | 明确要求紫微时使用                                                               |
-| 当前事项能否推进、短期成败         | `POST /divination/liuyao/prompt`             | `question`，必要时传 `customDate`                                                                                                                           | 六爻适合一事一问、取用和应期                                                     |
-| 项目推进、方向选择、谈判出行、方位 | `POST /divination/qimen/prompt`              | `question`，可选 `qimenMethod: "zhuanpan"` 或 `"feipan"`，必要时传 `customDate`                                                                             | 奇门适合时空局势、路径、方位和行动窗口                                           |
-| 临时小事、快速判断                 | `POST /divination/xiaoliuren/prompt`         | `question`，可选 `xiaoliurenMethod`、`xiaoliurenSchool` 和 `xiaoliurenNumber`                                                                                | 返回三宫推进、五行、旺衰、触发条件与反证限制；华山派另含完整课象；不用于长期命运 |
-| 以数字或时间起卦的象意判断         | `POST /divination/meihua/prompt`             | `question`，可选 `method`、`number` 或 `customDate`                                                                                                         | 梅花适合象意、触发点和过程结果                                                   |
-| 更传统复杂的一事一课               | `POST /divination/liuren/prompt`             | `question`，可选 `liurenTemplate` 和 `customDate`                                                                                                           | 大六壬适合较严肃的事项推演                                                       |
-| 结婚、搬家、开业、签约、出行、安葬 | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`                                                                                    | 只在候选日期范围内择优，不应让 AI 推荐范围外日期                                 |
-| 星盘本命、行运、流年流月           | `POST /divination/astrolabe/prompt`          | 出生时间地点，经纬度，`astrolabeTopic`，`astrolabeScope: "full"` 或指定范围                                                                                 | 需要经纬度和时区，资料不足时应先补齐                                             |
-| 西占双方关系、合作或婚恋互动       | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                                                                                                     | 返回跨盘相位、容许度、落宫和解释边界，不给虚假匹配分                             |
-| 牌面灵感、关系牌阵、选择牌阵       | `POST /divination/tarot/prompt` 或雷诺曼     | `spreadType`、`question`                                                                                                                                    | 适合轻量启发，不作为长期命盘判断                                                 |
-| 求签                               | `POST /divination/ssgw/prompt`               | `question`                                                                                                                                                  | 有三连阴杯等拒签情况时，应如实返回，不强行解释                                   |
-| 住宅风水（八宅+玄空）             | `POST /metaphysics/residential/prompt`       | 山向或居住人至少一项：`birthYear`+`gender`/`mingGua`，`sitMountain`/`facingDegree`/`doorToInteriorDegree`，可选 `year` 建造/起运年                         | 统一入口；可只做人宅、只做宅运或两者合参；不给综合吉凶总分                        |
-| 仅八宅命卦、坐山吉凶               | `POST /metaphysics/bazhai/prompt`            | `birthYear`、`gender`、可选 `sitMountain`；实测可传 `doorToInteriorDegree`、`northReference`、`magneticDeclinationDegrees`、`measurementUncertaintyDegrees` | 返回磁北/真北换算、候选坐向与边界稳定性                                          |
-| 生肖犯太岁、流年贵人               | `POST /metaphysics/zodiac/prompt`            | `zodiac`、`year` 或 `yearGanZhi`                                                                                                                            | 生肖可传“鼠”或“子”                                                               |
-| 太乙神数                           | `POST /metaphysics/taiyi/prompt`             | `scope` 可选年、月、日、时、分；年计传 `year`，其余计式传完整年月日时分                                                                                     | 五计各用独立积数，时计与分计按规则定阴阳遁；结果含 `evidenceAnalysis` 结构化证据 |
-| 七政四余                           | `POST /metaphysics/qizheng/prompt`           | 出生年月日时分、经纬度、时区；可选 `useTrueSolarTime`                                                                                                      | 返回逐星来源、UTC计算上下文、坐标链路、精度分层和证据边界；真太阳时仅校正传统宫位 |
-| 玄空飞星                           | `POST /metaphysics/xuankong/prompt`          | `year`、`sitMountain`/`facingMountain` 或度数；可选 `guaType`、测量误差                                                                                    | 返回三元九运、三盘飞星、到山到向与结构化证据                                      |
+| 用户问题类型                       | 首选接口                                     | 推荐参数                                                                                                                                                    | 说明                                                                              |
+| ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| 换算真太阳时                       | `POST /calendar/true-solar-time`             | `localDateTime`、`longitude`，可选 `timezone`、`applyChinaDst`                                                                                              | 默认 UTC+8，返回修正明细、跨日状态和对应时辰                                      |
+| 计算太阳光照证据                   | `POST /calendar/solar-illumination`          | `year`、`month`、`day`、`latitude`、`longitude`，并提供 `timezone` 或 `timeZoneId`；可选参考时分秒                                                          | 返回太阳高度、方位、视太阳正午、日出日落与三类曙暮光                              |
+| 查六十甲子、纳音、藏干和合冲       | `POST /foundation/ganzhi`                    | `ganZhi`，如“甲子”                                                                                                                                          | 返回统一公共地基资料，不需重复实现                                                |
+| 统计天干地支五行分布               | `POST /foundation/wuxing`                    | `items`、可选 `weightHidden`                                                                                                                                | 默认计入地支藏干权重                                                              |
+| 核验通用神煞命中                   | `POST /foundation/shensha`                   | 完整年、月、日、时四柱干支；可选 `ids`                                                                                                                      | 返回空亡、驿马、桃花的固定起法、目标地支、命中柱位、来源与限制                    |
+| 整体人生、长期事业、财运、婚恋     | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic` 按主题填写，`promptScope: "full"` 或 `"origin"`                                                                       | 有完整出生信息时优先合参；想看完整阶段时用 `full`                                 |
+| 今年、某一年、当前阶段运势         | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题填事业、财运、感情等                                                                                                           | 八字看岁运触发，紫微看流年落宫与四化                                              |
+| 换工作、创业、合伙、投资合作       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`，按问题选择主题                                                                               | 这类问题兼具长期结构和当前触发，优先合参                                          |
+| 只看八字格局、用神、流年流月       | `POST /bazi/prompt`                          | `promptTopic`，`baziFortuneScope: "full"`、`"year"`、`"month"` 或 `"day"`                                                                                   | 明确要求八字时使用                                                                |
+| 只看紫微宫位、四化、某年某月运限   | `POST /ziwei/prompt`                         | `promptTopic`，`promptScope: "full"`、`"yearly"`、`"monthly"`、`"daily"` 或 `"hourly"`                                                                      | 明确要求紫微时使用                                                                |
+| 当前事项能否推进、短期成败         | `POST /divination/liuyao/prompt`             | `question`，必要时传 `customDate`                                                                                                                           | 六爻适合一事一问、取用和应期                                                      |
+| 项目推进、方向选择、谈判出行、方位 | `POST /divination/qimen/prompt`              | `question`，可选 `qimenMethod: "zhuanpan"` 或 `"feipan"`，必要时传 `customDate`                                                                             | 奇门适合时空局势、路径、方位和行动窗口                                            |
+| 临时小事、快速判断                 | `POST /divination/xiaoliuren/prompt`         | `question`，可选 `xiaoliurenMethod`、`xiaoliurenSchool` 和 `xiaoliurenNumber`                                                                               | 返回三宫推进、五行、旺衰、触发条件与反证限制；华山派另含完整课象；不用于长期命运  |
+| 以数字或时间起卦的象意判断         | `POST /divination/meihua/prompt`             | `question`，可选 `method`、`number` 或 `customDate`                                                                                                         | 梅花适合象意、触发点和过程结果                                                    |
+| 更传统复杂的一事一课               | `POST /divination/liuren/prompt`             | `question`，可选 `liurenTemplate` 和 `customDate`                                                                                                           | 大六壬适合较严肃的事项推演                                                        |
+| 结婚、搬家、开业、签约、出行、安葬 | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`                                                                                    | 只在候选日期范围内择优，不应让 AI 推荐范围外日期                                  |
+| 星盘本命、行运、流年流月           | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、时区、`astrolabeTopic`、`astrolabeScope`；行运范围同时传 `astrolabeScopeDate`                                                         | 需要明确行运日期；不会自动套用服务器当前日期                                      |
+| 西占双方关系、合作或婚恋互动       | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                                                                                                     | 返回跨盘相位、容许度、落宫和解释边界，不给虚假匹配分                              |
+| 牌面灵感、关系牌阵、选择牌阵       | `POST /divination/tarot/prompt` 或雷诺曼     | `spreadType`、`question`                                                                                                                                    | 适合轻量启发，不作为长期命盘判断                                                  |
+| 求签                               | `POST /divination/ssgw/prompt`               | `question`                                                                                                                                                  | 有三连阴杯等拒签情况时，应如实返回，不强行解释                                    |
+| 住宅风水（八宅+玄空）              | `POST /metaphysics/residential/prompt`       | 山向或居住人至少一项：`birthYear`+`gender`/`mingGua`，`sitMountain`/`facingDegree`/`doorToInteriorDegree`，可选 `year` 建造/起运年                          | 统一入口；可只做人宅、只做宅运或两者合参；不给综合吉凶总分                        |
+| 仅八宅命卦、坐山吉凶               | `POST /metaphysics/bazhai/prompt`            | `birthYear`、`gender`、可选 `sitMountain`；实测可传 `doorToInteriorDegree`、`northReference`、`magneticDeclinationDegrees`、`measurementUncertaintyDegrees` | 返回磁北/真北换算、候选坐向与边界稳定性                                           |
+| 生肖犯太岁、流年贵人               | `POST /metaphysics/zodiac/prompt`            | `zodiac`、`year` 或 `yearGanZhi`                                                                                                                            | 生肖可传“鼠”或“子”                                                                |
+| 太乙神数                           | `POST /metaphysics/taiyi/prompt`             | `scope` 可选年、月、日、时、分；年计传 `year`，其余计式传完整年月日时分                                                                                     | 五计各用独立积数，时计与分计按规则定阴阳遁；结果含 `evidenceAnalysis` 结构化证据  |
+| 七政四余                           | `POST /metaphysics/qizheng/prompt`           | 出生年月日时分、经纬度、时区；可选 `useTrueSolarTime`                                                                                                       | 返回逐星来源、UTC计算上下文、坐标链路、精度分层和证据边界；真太阳时仅校正传统宫位 |
+| 玄空飞星                           | `POST /metaphysics/xuankong/prompt`          | `year`、`sitMountain`/`facingMountain` 或度数；可选 `guaType`、测量误差                                                                                     | 返回三元九运、三盘飞星、到山到向与结构化证据                                      |
 
 参数选择建议：
 
 - `responseMode` 默认用 `summary`；只转交提示词给 AI 时用 `prompt-only`；确实需要完整结构化排盘时再用 `full`。
-- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"`。
+- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"` 并以 `astrolabeScopeDate: "YYYY-MM-DD"` 明确行运基准日。
 - 只问某一年、某月、某日时，优先选择对应范围，避免把短期问题做成泛泛终身解读。
 - `promptMode` 默认用 `framework`，这样返回的提示词结构更完整；只有用户明确要自由问答或自己已经写好完整问题时，才用 `custom`。
 - 出生时辰未知时，不要自行补时辰；八字只能保守使用已知信息，紫微和八字紫微合参应等用户补足时辰后再调用。
@@ -206,7 +206,7 @@ curl -X POST https://aov.cc/api/v1/bazi/calculate \
   -d '{"gender":"male","year":1990,"month":5,"day":15,"timeIndex":1,"dateType":"solar","shenShaVariants":{"kongWangBasis":"day-and-year","yangRenMode":"include-yin-ren","tongZiScope":"all-pillars"}}'
 ```
 
-八字提示词可指定命限范围。`baziFortuneScope` 支持 `natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）；配套参数为 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
+八字提示词可指定命限范围。`baziFortuneScope` 支持 `natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`dayun` 必须传 `baziFortuneCycleIndex`；`year`、`month`、`day` 必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`，交运年份可同时传 `baziFortuneCycleIndex` 消除重叠歧义。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
 
 ```bash
 curl -X POST https://aov.cc/api/v1/bazi/prompt \
@@ -248,12 +248,12 @@ curl -X POST https://aov.cc/api/v1/bazi-ziwei/prompt \
   -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly"}'
 ```
 
-星盘提示词可用 `astrolabeScope` 指定范围，`full` 会写入本命、当前流年、当前流月、当前流日行运资料：
+星盘提示词可用 `astrolabeScope` 指定范围。`yearly`、`monthly`、`daily` 分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`；`full` 要求 `YYYY-MM-DD` 基准日，并写入该日所属流年、流月和流日资料。服务端不会用当前日期补齐缺参：
 
 ```bash
 curl -X POST https://aov.cc/api/v1/divination/astrolabe/prompt \
   -H "Content-Type: application/json" \
-  -d '{"name":"本人","gender":"女","year":1995,"month":5,"day":20,"hour":12,"minute":30,"latitude":39.9042,"longitude":116.4074,"timezone":8,"locationName":"北京","question":"整体人生和近期重点怎么看？","astrolabeTopic":"life","astrolabeScope":"full"}'
+  -d '{"name":"本人","gender":"女","year":1995,"month":5,"day":20,"hour":12,"minute":30,"latitude":39.9042,"longitude":116.4074,"timezone":8,"locationName":"北京","question":"整体人生和近期重点怎么看？","astrolabeTopic":"life","astrolabeScope":"full","astrolabeScopeDate":"2028-06-12"}'
 ```
 
 西占双盘接口要求 `person1`、`person2` 分别提供一份完整星盘出生资料，提示词会写入双方本命盘、跨盘相位的实际夹角与容许度、双方落宫和证据边界：
@@ -375,7 +375,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 - `/prompt` 支持 `responseMode`：`summary` 默认只返回提示词和轻量摘要；`full` 返回完整排盘和提示词；`prompt-only` 只返回提示词。
 - 八字、紫微、奇门和黄历择日排盘接口支持 `detailMode`：`full` 返回完整结构；`compact` 返回轻量结构，适合自动化或多次分页请求。
 - 八字 `promptTopic` 支持 `general`、`career`、`wealth`、`marriage`、`children`、`health`、`relationship-push`、`relationship-decision`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`home-move`、`settle-relocate`、`study-advance`、`exam-landing`、`reconciliation-decision`、`emotion`、`talent`、`growth`、`social`。
-- 八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围，支持 `natal`、`full`、`dayun`、`year`、`month`、`day`；选择 `dayun`、`year`、`month`、`day` 时可配合 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+- 八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围，支持 `natal`、`full`、`dayun`、`year`、`month`、`day`；除 `natal`、`full` 外必须提供所选层级需要的明确年限参数，工具不会自动选择当前时间或第一项。
 - 紫微 `promptTopic` 支持 `destiny`、`relationship`、`relationship-push`、`relationship-decision`、`children`、`career-wealth`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`family`、`home-move`、`settle-relocate`、`social`、`emotion`、`health`、`study`、`study-advance`、`exam-landing`、`reconciliation-decision`、`growth`、`talent`、`life`、`chat`。
 - 紫微 `promptScope` 支持 `origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`；`full` 会返回并写入本命、大限、流年、流月、流日、流时资料。
 - 紫微公开 API 默认只返回 `origin`（本命）范围；如果请求传入 `promptScope`，接口会返回 `origin` 加指定范围，包含分析对象、落宫与四化信息，供流年、流月、流日等分析使用。

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -75,24 +75,24 @@
 
 常见问题到工具：
 
-| 用户问题类型                     | 首选工具                    | 推荐参数                                                                 |
-| -------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
-| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `origin` |
-| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`，主题按事业、财运、感情等选择                    |
-| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`            |
-| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                        |
-| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、`promptScope`                                             |
-| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                            |
-| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                             |
+| 用户问题类型                     | 首选工具                    | 推荐参数                                                                    |
+| -------------------------------- | --------------------------- | --------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `origin`    |
+| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
+| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`               |
+| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                           |
+| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、`promptScope`                                                |
+| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                               |
+| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
 | 临时小事快速判断                 | `xiaoliuren_prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
-| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                        |
-| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                          |
-| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize` |
-| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                 |
-| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                  |
-| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                 |
-| 雷诺曼关系或选择牌阵             | `lenormand_prompt`          | `spreadType`、`question`                                                 |
-| 求签                             | `ssgw_prompt`               | `question`                                                               |
+| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
+| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
+| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
+| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
+| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
+| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                    |
+| 雷诺曼关系或选择牌阵             | `lenormand_prompt`          | `spreadType`、`question`                                                    |
+| 求签                             | `ssgw_prompt`               | `question`                                                                  |
 
 出生时辰未知时，不要自行补时辰。八字可以保守分析；紫微和八字紫微合参需要时辰，优先请用户补足后再调用。
 
@@ -169,7 +169,11 @@ npm run mcp
 
 `bazi_prompt` 可通过 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
 
-选择 `dayun`、`year`、`month`、`day` 时，可配套传入 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+选择 `dayun` 时必须传 `baziFortuneCycleIndex`。选择 `year`、`month`、`day` 时必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`；交运年份可同时传 `baziFortuneCycleIndex` 消除前后两步大运重叠歧义。工具不会自动选择当前年或第一项。
+
+### 星盘行运提示词参数
+
+`astrolabe_prompt` 的 `yearly`、`monthly`、`daily` 范围分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`。`full` 也必须传 `YYYY-MM-DD` 基准日，用于生成同一基准下的本命、流年、流月和流日资料；工具不会读取系统当前日期补齐缺参。
 
 ### 起卦与排盘时间参数
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -54,7 +54,7 @@
 | `metaphysics_taiyi`          | 太乙五计     | 按年、月、日、时、分五计的积数和阴阳遁返回七十二局式盘                         |
 | `taiyi_prompt`               | 太乙提示词   | 太乙排盘并返回可直接用于 AI 解读的提示词                                       |
 | `metaphysics_qizheng`        | 七政四余     | 返回逐星来源、UTC上下文、坐标换算、宿度、紫炁模型、十二宫和精度分层            |
-| `qizheng_prompt`             | 七政提示词   | 返回含主证、辅证、模型差异和输入缺省限制的七政四余提示词                       |
+| `qizheng_prompt`             | 七政提示词   | 返回含主证、辅证、模型差异和时空输入边界的七政四余提示词                       |
 
 七政四余相位保留实际夹角、精确角、偏差、容许度位置、紧密等级与精度分层，不返回由容许度位置重复换算的百分制强度。
 
@@ -66,7 +66,7 @@
 
 1. 用户提供完整出生信息，并询问人生、事业、财运、婚恋、亲子、健康、迁居、学习、考试、合作、近期趋势或某一年某阶段走势时，优先调用 `bazi_ziwei_prompt`。这是深度解读首选工具，用八字定主线，用紫微校验宫位、四化、三方四正和运限。
 2. 用户明确只看单人八字时调用 `bazi_prompt`；询问两人婚恋、合作或亲属互动时调用 `bazi_compatibility_prompt`；长期或完整阶段分析优先传 `baziFortuneScope: "full"`。出生时间由输入约束保证符合排盘要求，不基于模糊时间范围继续排盘。
-3. 用户明确只看紫微时，调用 `ziwei_prompt`；长期或完整阶段分析优先传 `promptScope: "full"`。
+3. 用户明确只看紫微时，调用 `ziwei_prompt`；长期或完整阶段分析优先传 `promptScope: "full"`。除本命外还必须明确传入 `ziweiScopeDate` 和 `ziweiScopeTimeIndex`。
 4. 用户问单件事情当前能否推进、对方态度、短期成败或应期，优先调用 `liuyao_prompt`；涉及项目路径、方位、谈判、出行和时空窗口时，优先调用 `qimen_prompt`。
 5. 用户要从日期范围里选日子，调用 `almanac_prompt`；日期范围或参与人较多时使用分页参数。
 6. 用户提供一人的西方占星资料时调用 `astrolabe_prompt`；提供双方完整资料并询问关系时调用 `astrolabe_synastry_prompt`。
@@ -75,24 +75,24 @@
 
 常见问题到工具：
 
-| 用户问题类型                     | 首选工具                    | 推荐参数                                                                    |
-| -------------------------------- | --------------------------- | --------------------------------------------------------------------------- |
-| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `origin`    |
-| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
-| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`               |
-| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                           |
-| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、`promptScope`                                                |
-| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                               |
-| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
-| 临时小事快速判断                 | `xiaoliuren_prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
-| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
-| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
-| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
-| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
-| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
-| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                    |
-| 雷诺曼关系或选择牌阵             | `lenormand_prompt`          | `spreadType`、`question`                                                    |
-| 求签                             | `ssgw_prompt`               | `question`                                                                  |
+| 用户问题类型                     | 首选工具                    | 推荐参数                                                                     |
+| -------------------------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `origin` 无需行运目标；`full` 同时传 `ziweiScopeDate`、`ziweiScopeTimeIndex` |
+| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`、`ziweiScopeDate`、`ziweiScopeTimeIndex`             |
+| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`                |
+| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                            |
+| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、非本命 `promptScope`、`ziweiScopeDate`、`ziweiScopeTimeIndex` |
+| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                                |
+| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                                 |
+| 临时小事快速判断                 | `xiaoliuren_prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber`  |
+| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                            |
+| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                              |
+| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`     |
+| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                     |
+| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                      |
+| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                     |
+| 雷诺曼关系或选择牌阵             | `lenormand_prompt`          | `spreadType`、`question`                                                     |
+| 求签                             | `ssgw_prompt`               | `question`                                                                   |
 
 出生时辰未知时，不要自行补时辰。八字可以保守分析；紫微和八字紫微合参需要时辰，优先请用户补足后再调用。
 
@@ -200,13 +200,19 @@ npm run mcp
 
 `ziwei_prompt` 工具支持 `school` 参数：`sanhe`（三合派三方四正）、`feixing`（飞星派四化飞星链路）、`sihua`（四化派生年四化主线）。不传则不附加流派指引。
 
-`bazi_ziwei_prompt` 工具使用同一份出生信息，同时计算八字和紫微斗数。它支持 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope`、`promptMode`、`baziSchool`、`ziweiSchool`，适合需要先用八字判断命局主线，再用紫微校验宫位、四化和运限的深度问题。
+`bazi_ziwei_prompt` 工具使用同一份出生信息，同时计算八字和紫微斗数。它支持 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope`、`ziweiScopeDate`、`ziweiScopeTimeIndex`、`promptMode`、`baziSchool`、`ziweiSchool`，适合需要先用八字判断命局主线，再用紫微校验宫位、四化和运限的深度问题。
 
 ### 紫微 promptScope 参数
 
-`ziwei_calculate` 和 `ziwei_prompt` 默认只返回 `origin`（本命）范围。传入 `promptScope` 时会返回 `origin` 加指定范围。支持的值：`origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`。`full` 会返回并写入本命、大限、流年、流月、流日、流时资料。
+`ziwei_calculate` 和 `ziwei_prompt` 默认只返回 `origin`（本命）范围。支持的 `promptScope` 值为 `origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`。除 `origin` 外必须同时提供 `ziweiScopeDate`（`YYYY-MM-DD`）和 `ziweiScopeTimeIndex`（0-12），工具不会读取系统当前日期或时辰补齐。`full` 会按该目标时刻返回并写入本命、大限、流年、流月、流日、流时资料。
 
 `ziwei_compatibility` 和 `ziwei_compatibility_prompt` 只计算双方静态本命盘的宫位叠盘与生年四化跨盘落点。它们不会伪造具体年份应期，也不会输出缺乏统一依据的匹配总分。
+
+### 生肖与七政时空参数
+
+`metaphysics_zodiac` 和 `zodiac_prompt` 必须在 `year` 与 `yearGanZhi` 中至少提供一项，不会默认使用系统当前年份。
+
+`metaphysics_qizheng` 和 `qizheng_prompt` 必须提供真实 `latitude`、`longitude`，并在 `timezone` 与 `timeZoneId` 中至少提供一项；不会默认使用北京坐标或东八区。
 
 ### 雷诺曼牌阵参数
 

--- a/mcp/src/tools/astrolabe.ts
+++ b/mcp/src/tools/astrolabe.ts
@@ -4,7 +4,10 @@ import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
 import { analyzeAstrolabeSynastry } from 'mingyu-core/divination/astrolabe-synastry';
 import type { AstrolabeBirthInput } from 'mingyu-core/types';
 import { ASTROLABE_PROMPT_TOPICS } from '../../../src/lib/astrolabe-prompts.js';
-import { buildAstrolabeScopeContext } from '../../../src/lib/astrolabe-scope.js';
+import {
+  buildAstrolabeFullScopeContexts,
+  buildAstrolabeScopeContext,
+} from '../../../src/lib/astrolabe-scope.js';
 import { buildAstrolabeSynastryPrompt } from '../../../src/lib/astrolabe-synastry-prompt.js';
 import type { AstrolabeData } from '../../../src/types/divination.js';
 import { resultOutputSchema } from '../schemas.js';
@@ -55,7 +58,9 @@ const astrolabePromptSchema = extendPromptSchema(
     astrolabeScopeDate: z
       .string()
       .optional()
-      .describe('星盘行运日期；yearly 用年份，monthly 用 年-月，daily 用 年-月-日'),
+      .describe(
+        '星盘行运日期；full 和 daily 用 YYYY-MM-DD，yearly 用 YYYY，monthly 用 YYYY-MM；除 natal 外必填',
+      ),
     astrolabeScopeText: z
       .string()
       .optional()
@@ -123,12 +128,13 @@ function buildAstrolabeSynastryResult(args: z.infer<typeof astrolabeSynastrySche
   };
 }
 
-function buildAstrolabeFullScopePromptText(data: AstrolabeData) {
+function buildAstrolabeFullScopePromptText(data: AstrolabeData, referenceDateStr: string) {
+  const fullContexts = buildAstrolabeFullScopeContexts(data, referenceDateStr);
   const contexts = [
-    buildAstrolabeScopeContext(data, 'natal', ''),
-    buildAstrolabeScopeContext(data, 'yearly', ''),
-    buildAstrolabeScopeContext(data, 'monthly', ''),
-    buildAstrolabeScopeContext(data, 'daily', ''),
+    fullContexts.natal,
+    fullContexts.yearly,
+    fullContexts.monthly,
+    fullContexts.daily,
   ];
   const lines = contexts
     .map((context) => context.promptText)
@@ -146,11 +152,19 @@ function buildAstrolabePromptScopeText(
   if (customText) return customText;
 
   const scope = args.astrolabeScope ?? 'natal';
+  const dateStr = scope === 'natal' ? '' : requireAstrolabeScopeDate(args.astrolabeScopeDate);
   if (scope === 'full') {
-    return buildAstrolabeFullScopePromptText(result);
+    return buildAstrolabeFullScopePromptText(result, dateStr);
   }
 
-  return buildAstrolabeScopeContext(result, scope, args.astrolabeScopeDate ?? '').promptText;
+  return buildAstrolabeScopeContext(result, scope, dateStr).promptText;
+}
+
+function requireAstrolabeScopeDate(dateStr: string | undefined) {
+  if (!dateStr?.trim()) {
+    throw new Error('除 natal 外必须提供 astrolabeScopeDate。');
+  }
+  return dateStr;
 }
 
 function buildAstrolabeScopeEvidence(
@@ -161,19 +175,16 @@ function buildAstrolabeScopeEvidence(
   if (customText) return { scope: 'custom' as const, promptText: customText };
 
   const scope = args.astrolabeScope ?? 'natal';
+  const dateStr = scope === 'natal' ? '' : requireAstrolabeScopeDate(args.astrolabeScopeDate);
   if (scope === 'full') {
     return {
       scope: 'full' as const,
-      contexts: {
-        natal: buildAstrolabeScopeContext(result, 'natal', ''),
-        yearly: buildAstrolabeScopeContext(result, 'yearly', ''),
-        monthly: buildAstrolabeScopeContext(result, 'monthly', ''),
-        daily: buildAstrolabeScopeContext(result, 'daily', ''),
-      },
+      referenceDate: dateStr,
+      contexts: buildAstrolabeFullScopeContexts(result, dateStr),
     };
   }
 
-  return buildAstrolabeScopeContext(result, scope, args.astrolabeScopeDate ?? '');
+  return buildAstrolabeScopeContext(result, scope, dateStr);
 }
 
 export function registerAstrolabeTool(server: McpServer) {

--- a/mcp/src/tools/bazi-ziwei.ts
+++ b/mcp/src/tools/bazi-ziwei.ts
@@ -27,7 +27,7 @@ import {
   getErrorMessage,
 } from '../tool-results.js';
 import { buildBaziPerson } from './bazi.js';
-import { buildMcpZiweiChartInput } from './ziwei.js';
+import { buildMcpZiweiChartInput, buildMcpZiweiHoroscopeContext } from './ziwei.js';
 
 const baziZiweiPromptSchema = z.object({
   name: z.string().optional().describe('姓名（可选）'),
@@ -61,6 +61,17 @@ const baziZiweiPromptSchema = z.object({
     .describe(
       '紫微运限范围：origin=本命, full=完整输出版, decadal=大限, yearly=流年, monthly=流月等',
     ),
+  ziweiScopeDate: z
+    .string()
+    .optional()
+    .describe('紫微行运目标公历日期 YYYY-MM-DD；选择非本命范围时必填'),
+  ziweiScopeTimeIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(12)
+    .optional()
+    .describe('紫微行运目标时辰索引 0-12；选择非本命范围时必填'),
   promptMode: z
     .enum(PROMPT_MODES)
     .optional()
@@ -112,6 +123,8 @@ export function registerBaziZiweiTool(server: McpServer) {
         const ziweiResult = await calculateZiweiChartForScopes(
           buildCombinedZiweiInput(args),
           scopes,
+          undefined,
+          buildMcpZiweiHoroscopeContext(args, scope),
         );
         const serializableZiweiResult = buildSerializableZiweiResult(ziweiResult);
 

--- a/mcp/src/tools/bazi.ts
+++ b/mcp/src/tools/bazi.ts
@@ -98,10 +98,13 @@ const baziPromptSchema = baziSchema.extend({
     .describe(
       '八字命限范围：natal=本命, full=完整输出版, dayun=大运, year=流年, month=流月, day=流日',
     ),
-  baziFortuneCycleIndex: z.number().optional().describe('大运序号，从 0 开始'),
-  baziFortuneYear: z.number().optional().describe('指定流年年份'),
-  baziFortuneMonth: z.number().optional().describe('指定流月序号'),
-  baziFortuneDay: z.number().optional().describe('指定流日序号'),
+  baziFortuneCycleIndex: z
+    .number()
+    .optional()
+    .describe('大运序号，从 0 开始；选择大运时必填，交运年建议同时传入'),
+  baziFortuneYear: z.number().optional().describe('指定流年年份；选择流年及以下范围时必填'),
+  baziFortuneMonth: z.number().optional().describe('指定流月序号；选择流月及以下范围时必填'),
+  baziFortuneDay: z.number().optional().describe('指定流日序号；选择流日时必填'),
 });
 
 export function buildBaziPerson(args: z.infer<typeof baziSchema>): Person {
@@ -202,14 +205,29 @@ export function registerBaziTool(server: McpServer) {
       try {
         const person = buildBaziPerson(args);
         const result = baziCalculator.calculateBazi(person);
+        const fortuneScope = args.baziFortuneScope ?? 'natal';
+        const requiresCycle = fortuneScope === 'dayun';
+        const requiresYear = ['year', 'month', 'day'].includes(fortuneScope);
+        const requiresMonth = fortuneScope === 'month' || fortuneScope === 'day';
+        const requiresDay = fortuneScope === 'day';
+        if (requiresCycle && args.baziFortuneCycleIndex === undefined) {
+          throw new Error('选择大运时必须提供 baziFortuneCycleIndex。');
+        }
+        if (requiresYear && args.baziFortuneYear === undefined) {
+          throw new Error('选择流年、流月或流日时必须提供 baziFortuneYear。');
+        }
+        if (requiresMonth && args.baziFortuneMonth === undefined) {
+          throw new Error('选择流月或流日时必须提供 baziFortuneMonth。');
+        }
+        if (requiresDay && args.baziFortuneDay === undefined) {
+          throw new Error('选择流日时必须提供 baziFortuneDay。');
+        }
         const fortuneSelectionContext = buildFortuneSelectionContext(result, {
-          scope: args.baziFortuneScope ?? 'natal',
+          scope: fortuneScope,
           cycleIndex:
-            args.baziFortuneScope &&
-            args.baziFortuneScope !== 'natal' &&
-            args.baziFortuneScope !== 'full'
+            args.baziFortuneCycleIndex !== undefined
               ? readMcpIntegerLikeInRange(
-                  args.baziFortuneCycleIndex ?? 0,
+                  args.baziFortuneCycleIndex,
                   'baziFortuneCycleIndex',
                   0,
                   99,

--- a/mcp/src/tools/qi_zheng.ts
+++ b/mcp/src/tools/qi_zheng.ts
@@ -15,16 +15,27 @@ const qiZhengSchema = z.object({
   day: z.number().int().min(1).max(31).describe('日'),
   hour: z.number().int().min(0).max(23).describe('时'),
   minute: z.number().int().min(0).max(59).optional().describe('分'),
-  latitude: z.number().min(-90).max(90).optional().describe('纬度（默认北京）'),
-  longitude: z.number().min(-180).max(180).optional().describe('经度（默认北京）'),
+  latitude: z.number().min(-90).max(90).describe('出生地纬度'),
+  longitude: z.number().min(-180).max(180).describe('出生地经度'),
   useTrueSolarTime: z.boolean().optional().describe('是否启用真太阳时仅校正传统命身十二宫'),
-  timezone: z.number().min(-12).max(14).optional().describe('时区偏移（默认 +8）'),
+  timezone: z
+    .number()
+    .min(-12)
+    .max(14)
+    .optional()
+    .describe('固定时区偏移；与 timeZoneId 至少提供一项'),
   timeZoneId: z
     .string()
     .optional()
     .describe('IANA 历史时区，例如 Asia/Shanghai；提供后会自动解析当年的夏令时'),
   question: z.string().optional().describe('希望 AI 重点解读的问题'),
 });
+
+function assertQizhengTimezone(input: z.infer<typeof qiZhengSchema>) {
+  if (input.timezone === undefined && !input.timeZoneId?.trim()) {
+    throw new Error('timezone 与 timeZoneId 至少需要提供一项。');
+  }
+}
 
 export function registerQizhengTool(server: McpServer) {
   server.registerTool(
@@ -37,14 +48,15 @@ export function registerQizhengTool(server: McpServer) {
     },
     async (args) => {
       try {
+        assertQizhengTimezone(args);
         const result = qizheng.generateQizheng({
           year: args.year,
           month: args.month,
           day: args.day,
           hour: args.hour,
           minute: args.minute ?? 0,
-          ...(args.latitude !== undefined ? { latitude: args.latitude } : {}),
-          ...(args.longitude !== undefined ? { longitude: args.longitude } : {}),
+          latitude: args.latitude,
+          longitude: args.longitude,
           ...(args.timezone !== undefined ? { timezone: args.timezone } : {}),
           ...(args.timeZoneId ? { timeZoneId: args.timeZoneId } : {}),
           ...(args.useTrueSolarTime !== undefined
@@ -67,14 +79,15 @@ export function registerQizhengTool(server: McpServer) {
     },
     async (args) => {
       try {
+        assertQizhengTimezone(args);
         const result = qizheng.generateQizheng({
           year: args.year,
           month: args.month,
           day: args.day,
           hour: args.hour,
           minute: args.minute ?? 0,
-          ...(args.latitude !== undefined ? { latitude: args.latitude } : {}),
-          ...(args.longitude !== undefined ? { longitude: args.longitude } : {}),
+          latitude: args.latitude,
+          longitude: args.longitude,
           ...(args.timezone !== undefined ? { timezone: args.timezone } : {}),
           ...(args.timeZoneId ? { timeZoneId: args.timeZoneId } : {}),
           ...(args.useTrueSolarTime !== undefined

--- a/mcp/src/tools/ziwei.ts
+++ b/mcp/src/tools/ziwei.ts
@@ -32,6 +32,11 @@ import {
   readMcpNumberLikeInRange,
 } from './input-helpers.js';
 
+type ZiweiScopeInput = {
+  ziweiScopeDate?: string;
+  ziweiScopeTimeIndex?: number;
+};
+
 export const ziweiSchema = z.object({
   name: z.string().optional().describe('姓名（可选）'),
   gender: z.enum(['male', 'female']).describe('性别：male 为男，female 为女'),
@@ -52,6 +57,17 @@ export const ziweiSchema = z.object({
     .describe(
       '运限范围：origin=本命（默认）, full=完整输出版, decadal=大限, yearly=流年, monthly=流月, daily=流日, hourly=流时, age=年龄。默认只返回 origin 范围；full 会返回本命、大限、流年、流月、流日、流时。',
     ),
+  ziweiScopeDate: z
+    .string()
+    .optional()
+    .describe('行运目标公历日期，格式 YYYY-MM-DD；选择非本命范围时必填'),
+  ziweiScopeTimeIndex: z
+    .number()
+    .int()
+    .min(0)
+    .max(12)
+    .optional()
+    .describe('行运目标时辰索引 0-12；选择非本命范围时必填'),
   isLeapMonth: z.boolean().optional().describe('是否为闰月（仅农历有效）'),
   useTrueSolarTime: z.boolean().optional().describe('是否启用真太阳时校正'),
   birthHour: z.string().optional().describe('精准出生小时，启用真太阳时时必填，如 1'),
@@ -80,8 +96,16 @@ const ziweiPromptSchema = ziweiSchema.extend({
 });
 
 const ziweiCompatibilitySchema = z.object({
-  person1: ziweiSchema.omit({ promptScope: true }),
-  person2: ziweiSchema.omit({ promptScope: true }),
+  person1: ziweiSchema.omit({
+    promptScope: true,
+    ziweiScopeDate: true,
+    ziweiScopeTimeIndex: true,
+  }),
+  person2: ziweiSchema.omit({
+    promptScope: true,
+    ziweiScopeDate: true,
+    ziweiScopeTimeIndex: true,
+  }),
 });
 
 const ziweiCompatibilityPromptSchema = ziweiCompatibilitySchema.extend({
@@ -133,6 +157,20 @@ export function buildMcpZiweiChartInput(args: z.infer<typeof ziweiSchema>) {
   });
 }
 
+export function buildMcpZiweiHoroscopeContext(args: ZiweiScopeInput, scope: ZiweiPromptScope) {
+  if (scope === 'origin') return undefined;
+  if (!args.ziweiScopeDate?.trim()) {
+    throw new Error('选择紫微非本命范围时必须提供 ziweiScopeDate。');
+  }
+  if (args.ziweiScopeTimeIndex === undefined) {
+    throw new Error('选择紫微非本命范围时必须提供 ziweiScopeTimeIndex。');
+  }
+  return {
+    dateStr: args.ziweiScopeDate.trim(),
+    hourIndex: args.ziweiScopeTimeIndex,
+  };
+}
+
 export function registerZiweiTool(server: McpServer) {
   server.registerTool(
     'ziwei_calculate',
@@ -149,7 +187,12 @@ export function registerZiweiTool(server: McpServer) {
         const scopes: ScopeType[] = Array.from(
           new Set(['origin' as ScopeType, ...getZiweiPromptCalculationScopes(scope)]),
         );
-        const result = await calculateZiweiChartForScopes(input, scopes);
+        const result = await calculateZiweiChartForScopes(
+          input,
+          scopes,
+          undefined,
+          buildMcpZiweiHoroscopeContext(args, scope),
+        );
         return createStructuredToolResult(buildSerializableZiweiResult(result));
       } catch (error) {
         return createErrorToolResult(getErrorMessage(error, '排盘失败'));
@@ -175,7 +218,12 @@ export function registerZiweiTool(server: McpServer) {
         const scopes: ScopeType[] = Array.from(
           new Set(['origin' as ScopeType, ...getZiweiPromptCalculationScopes(scope)]),
         );
-        const result = await calculateZiweiChartForScopes(input, scopes);
+        const result = await calculateZiweiChartForScopes(
+          input,
+          scopes,
+          undefined,
+          buildMcpZiweiHoroscopeContext(args, scope),
+        );
         return createStructuredToolResult({
           result: buildSerializableZiweiResult(result),
           prompt: buildZiweiPromptForRuntime({

--- a/mcp/src/tools/zodiac.ts
+++ b/mcp/src/tools/zodiac.ts
@@ -12,7 +12,13 @@ import { buildMetaphysicsPrompt } from '../metaphysics-prompt.js';
 
 const zodiacSchema = z.object({
   zodiac: z.string().describe('生肖或地支，如「鼠」或「子」'),
-  year: z.number().int().min(1900).max(2200).optional().describe('公元年（默认今年）'),
+  year: z
+    .number()
+    .int()
+    .min(1900)
+    .max(2200)
+    .optional()
+    .describe('公元年；与 yearGanZhi 至少提供一项'),
   yearGanZhi: z
     .string()
     .refine(isValidGanZhi, 'yearGanZhi 必须是有效的六十甲子')
@@ -20,6 +26,12 @@ const zodiacSchema = z.object({
     .describe('直接给定流年干支，如「甲辰」'),
   question: z.string().optional().describe('希望 AI 重点解读的问题'),
 });
+
+function assertZodiacYear(input: z.infer<typeof zodiacSchema>) {
+  if (input.year === undefined && !input.yearGanZhi) {
+    throw new Error('year 与 yearGanZhi 至少需要提供一项。');
+  }
+}
 
 function resolveZodiacBranch(z: string): string {
   if ((EARTHLY_BRANCHES as readonly string[]).includes(z)) return z;
@@ -39,10 +51,9 @@ export function registerZodiacTool(server: McpServer) {
     },
     async (args) => {
       try {
+        assertZodiacYear(args);
         const branch = resolveZodiacBranch(args.zodiac);
-        const yearGanZhi =
-          args.yearGanZhi ||
-          getGanZhiFromDate(new Date(args.year ?? new Date().getFullYear(), 1, 10)).year;
+        const yearGanZhi = args.yearGanZhi || getGanZhiFromDate(new Date(args.year!, 1, 10)).year;
         const result = zodiac.getZodiacYearFortune(branch, yearGanZhi);
         return createStructuredToolResult({ result });
       } catch (error) {
@@ -60,10 +71,9 @@ export function registerZodiacTool(server: McpServer) {
     },
     async (args) => {
       try {
+        assertZodiacYear(args);
         const branch = resolveZodiacBranch(args.zodiac);
-        const yearGanZhi =
-          args.yearGanZhi ||
-          getGanZhiFromDate(new Date(args.year ?? new Date().getFullYear(), 1, 10)).year;
+        const yearGanZhi = args.yearGanZhi || getGanZhiFromDate(new Date(args.year!, 1, 10)).year;
         const result = zodiac.getZodiacYearFortune(branch, yearGanZhi);
         return createStructuredToolResult({
           result,

--- a/packages/core/src/bazi/baziAnalysisFormatter.ts
+++ b/packages/core/src/bazi/baziAnalysisFormatter.ts
@@ -1,6 +1,4 @@
 import type { BaziChartResult } from './baziTypes';
-import { getCurrentTimeDescription } from './calendarTool';
-import { getLuckCycleForDate } from './luckTiming';
 import { WUXING } from '../wuxing';
 
 interface FormatBaziOptions {
@@ -8,10 +6,8 @@ interface FormatBaziOptions {
   includeShensha?: boolean;
   includeShenShaAnalysis?: boolean;
   includeWuxing?: boolean;
-  includeCurrentTiming?: boolean;
   includeSpecialPillars?: boolean;
   includeLuckOverview?: boolean;
-  includeCurrentLiunian?: boolean;
 }
 
 export type PromptChartScene =
@@ -69,10 +65,6 @@ function formatPromptLuckOverview(baziResult: BaziChartResult): string {
   }
 
   const cycles = baziResult.luckInfo.cycles;
-  const now = new Date();
-  const currentYear = now.getFullYear();
-  const currentLuck = getLuckCycleForDate(cycles, now);
-
   const lines = [`起运: ${baziResult.luckInfo.startInfo}`];
   const cycleOverview = cycles.slice(0, 13).map((cycle, index) => {
     const years = cycle.years ?? [];
@@ -88,43 +80,6 @@ function formatPromptLuckOverview(baziResult: BaziChartResult): string {
     lines.push(...cycleOverview);
   }
 
-  if (!currentLuck) {
-    lines.push('当前阶段: 未匹配到当前大运，只能参考大运总览作长期阶段背景。');
-    return lines.join('\n');
-  }
-
-  if (currentLuck.isXiaoyun) {
-    lines.push('当前阶段: 未起运（行童运）');
-    const preview = currentLuck.years
-      .slice(0, 3)
-      .map((year) => `${year.year}年${year.ganZhi}`)
-      .join(' -> ');
-    if (preview) {
-      lines.push(`近期流年: ${preview}`);
-    }
-    return lines.join('\n');
-  }
-
-  const currentIndex = cycles.findIndex(
-    (cycle) => cycle.ganZhi === currentLuck.ganZhi && cycle.age === currentLuck.age,
-  );
-  const relatedCycles = [
-    currentIndex > 0
-      ? `前运: ${cycles[currentIndex - 1].ganZhi}(${cycles[currentIndex - 1].age}岁)`
-      : '',
-    `当前大运: ${currentLuck.ganZhi}(${currentLuck.age}岁)`,
-    currentIndex >= 0 && currentIndex < cycles.length - 1
-      ? `后运: ${cycles[currentIndex + 1].ganZhi}(${cycles[currentIndex + 1].age}岁)`
-      : '',
-  ].filter(Boolean);
-
-  lines.push(...relatedCycles);
-  const nearYears = currentLuck.years
-    .filter((year) => Math.abs(year.year - currentYear) <= 2)
-    .map((year) => `${year.year}年${year.ganZhi}(${year.age}岁，${year.tenGod}/${year.tenGodZhi})`);
-  if (nearYears.length) {
-    lines.push(`近年流年: ${nearYears.join(' -> ')}`);
-  }
   return lines.join('\n');
 }
 
@@ -149,10 +104,8 @@ function buildBaziText(baziResult: BaziChartResult, options: FormatBaziOptions):
     includeShensha = true,
     includeShenShaAnalysis = false,
     includeWuxing = true,
-    includeCurrentTiming = true,
     includeSpecialPillars = true,
     includeLuckOverview = true,
-    includeCurrentLiunian = true,
   } = options;
 
   let result = '【命盘】\n';
@@ -311,34 +264,6 @@ function buildBaziText(baziResult: BaziChartResult, options: FormatBaziOptions):
     result += `${formatPromptLuckOverview(baziResult)}\n`;
   }
 
-  if (includeCurrentLiunian && baziResult.liunian?.length) {
-    const now = new Date();
-    const currentYear = now.getFullYear();
-    let currentLuckStr = '';
-    let currentLiunian = baziResult.liunian.find((year) => year.year === currentYear);
-
-    if (baziResult.luckInfo?.cycles) {
-      const currentLuck = getLuckCycleForDate(baziResult.luckInfo.cycles, now);
-      if (currentLuck?.isXiaoyun) {
-        currentLuckStr = ' | 【当前大运】 未起运(行童运)';
-        currentLiunian =
-          currentLuck.years.find((year) => year.year === currentYear) || currentLiunian;
-      } else if (currentLuck) {
-        currentLuckStr = ` | 【当前大运】 ${currentLuck.ganZhi}运`;
-        currentLiunian =
-          currentLuck.years.find((year) => year.year === currentYear) || currentLiunian;
-      }
-    }
-
-    if (currentLiunian) {
-      result += `\n【当前流年】 ${currentYear}年 ${currentLiunian.ganZhi}${currentLuckStr}\n`;
-      result += `十神: ${currentLiunian.tenGod}/${currentLiunian.tenGodZhi}\n`;
-    }
-  }
-
-  if (includeCurrentTiming) {
-    result += `\n${getCurrentTimeDescription()}`;
-  }
   return result;
 }
 
@@ -349,10 +274,8 @@ function getPromptSceneOptions(scene: PromptChartScene): FormatBaziOptions {
       includeShensha: false,
       includeShenShaAnalysis: true,
       includeWuxing: true,
-      includeCurrentTiming: false,
       includeSpecialPillars: true,
       includeLuckOverview: true,
-      includeCurrentLiunian: true,
     };
   }
 
@@ -362,10 +285,8 @@ function getPromptSceneOptions(scene: PromptChartScene): FormatBaziOptions {
       includeShensha: false,
       includeShenShaAnalysis: true,
       includeWuxing: true,
-      includeCurrentTiming: false,
       includeSpecialPillars: true,
       includeLuckOverview: true,
-      includeCurrentLiunian: true,
     };
   }
 
@@ -375,10 +296,8 @@ function getPromptSceneOptions(scene: PromptChartScene): FormatBaziOptions {
       includeShensha: false,
       includeShenShaAnalysis: false,
       includeWuxing: false,
-      includeCurrentTiming: false,
       includeSpecialPillars: false,
       includeLuckOverview: false,
-      includeCurrentLiunian: false,
     };
   }
 
@@ -388,10 +307,8 @@ function getPromptSceneOptions(scene: PromptChartScene): FormatBaziOptions {
       includeShensha: false,
       includeShenShaAnalysis: false,
       includeWuxing: false,
-      includeCurrentTiming: false,
       includeSpecialPillars: false,
       includeLuckOverview: false,
-      includeCurrentLiunian: false,
     };
   }
 
@@ -400,10 +317,8 @@ function getPromptSceneOptions(scene: PromptChartScene): FormatBaziOptions {
     includeShensha: false,
     includeShenShaAnalysis: true,
     includeWuxing: true,
-    includeCurrentTiming: false,
     includeSpecialPillars: true,
     includeLuckOverview: true,
-    includeCurrentLiunian: true,
   };
 }
 

--- a/packages/core/src/bazi/fortuneSelection/helpers/resolvers.ts
+++ b/packages/core/src/bazi/fortuneSelection/helpers/resolvers.ts
@@ -1,10 +1,5 @@
 import type { BaziChartResult, LiunianInfo, LuckCycle } from '../../baziTypes';
-import {
-  getBaziDayIndexByDate,
-  getBaziMonthIndexByDate,
-  getMonthDaysInfo,
-  getYearInfo,
-} from '../../calendarTool';
+import { getMonthDaysInfo, getYearInfo } from '../../calendarTool';
 import type { BaziFortuneSelectionValue } from './types';
 
 export function formatCycleLabel(cycle: LuckCycle) {
@@ -22,12 +17,12 @@ export function formatYearLabel(yearInfo: LiunianInfo) {
 export function resolveCycleIndex(result: BaziChartResult, selection: BaziFortuneSelectionValue) {
   if (!result.luckInfo.cycles.length) return -1;
 
-  if (
-    typeof selection.cycleIndex === 'number' &&
-    selection.cycleIndex >= 0 &&
-    selection.cycleIndex < result.luckInfo.cycles.length
-  ) {
-    return selection.cycleIndex;
+  if (selection.cycleIndex !== undefined) {
+    return Number.isInteger(selection.cycleIndex) &&
+      selection.cycleIndex >= 0 &&
+      selection.cycleIndex < result.luckInfo.cycles.length
+      ? selection.cycleIndex
+      : -1;
   }
 
   if (typeof selection.year === 'number') {
@@ -43,15 +38,7 @@ export function resolveCycleIndex(result: BaziChartResult, selection: BaziFortun
     }
   }
 
-  const currentYear = new Date().getFullYear();
-  let currentCycleIndex = -1;
-  for (let i = result.luckInfo.cycles.length - 1; i >= 0; i -= 1) {
-    if (result.luckInfo.cycles[i].years.some((item) => item.year === currentYear)) {
-      currentCycleIndex = i;
-      break;
-    }
-  }
-  return currentCycleIndex >= 0 ? currentCycleIndex : 0;
+  return -1;
 }
 
 export function resolveSelectedYear(
@@ -67,9 +54,7 @@ export function resolveSelectedYear(
     return selection.year;
   }
 
-  const currentYear = new Date().getFullYear();
-  const currentItem = cycle.years.find((item) => item.year === currentYear);
-  return currentItem?.year ?? cycle.years[0]?.year;
+  return undefined;
 }
 
 export function resolveSelectedMonth(selection: BaziFortuneSelectionValue) {
@@ -84,7 +69,7 @@ export function resolveSelectedMonth(selection: BaziFortuneSelectionValue) {
     return selection.month;
   }
 
-  return getBaziMonthIndexByDate(selection.year, new Date()) ?? 1;
+  return undefined;
 }
 
 export function resolveSelectedDay(
@@ -103,5 +88,5 @@ export function resolveSelectedDay(
     return selection.day;
   }
 
-  return getBaziDayIndexByDate(year, month, new Date()) ?? 1;
+  return undefined;
 }

--- a/packages/core/src/bazi/fortuneSelection/index.ts
+++ b/packages/core/src/bazi/fortuneSelection/index.ts
@@ -235,38 +235,37 @@ export function normalizeFortuneSelection(
   const cycle = result.luckInfo.cycles[cycleIndex];
 
   if (!cycle) {
-    return { scope: 'natal' };
+    throw new Error(
+      selection.scope === 'dayun'
+        ? '选择大运时必须提供有效的大运序号。'
+        : '选择流年、流月或流日时必须提供有效的大运序号，或提供可定位大运的流年年份。',
+    );
   }
-
-  const year = resolveSelectedYear(cycle, selection);
 
   if (selection.scope === 'dayun') {
     return {
       scope: 'dayun',
       cycleIndex,
-      year,
     };
   }
 
+  const year = resolveSelectedYear(cycle, selection);
   if (!year) {
-    return {
-      scope: 'dayun',
-      cycleIndex,
-    };
+    throw new Error('所选范围必须提供属于该大运的有效流年年份。');
   }
-
-  const month = resolveSelectedMonth(selection);
 
   if (selection.scope === 'year') {
     return {
       scope: 'year',
       cycleIndex,
       year,
-      month,
     };
   }
 
-  const day = resolveSelectedDay(year, month, selection);
+  const month = resolveSelectedMonth(selection);
+  if (!month) {
+    throw new Error('选择流月或流日时必须提供有效的流月序号。');
+  }
 
   if (selection.scope === 'month') {
     return {
@@ -274,8 +273,12 @@ export function normalizeFortuneSelection(
       cycleIndex,
       year,
       month,
-      day,
     };
+  }
+
+  const day = resolveSelectedDay(year, month, selection);
+  if (!day) {
+    throw new Error('选择流日时必须提供该节令月内的有效流日序号。');
   }
 
   return {

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -229,7 +229,23 @@ const systems: SystemCapability[] = [
     id: 'ziwei',
     name: '紫微斗数',
     category: 'chart',
-    inputs: [birthProfileInput],
+    inputs: [
+      birthProfileInput,
+      {
+        id: 'ziweiScopeDate',
+        label: '行运目标日期',
+        type: 'date',
+        required: false,
+        description: '选择非本命范围时必填，格式 YYYY-MM-DD。',
+      },
+      {
+        id: 'ziweiScopeTimeIndex',
+        label: '行运目标时辰',
+        type: 'number',
+        required: false,
+        description: '选择非本命范围时必填，取值 0-12。',
+      },
+    ],
     outputs: [
       '十二宫',
       '星曜',
@@ -250,6 +266,7 @@ const systems: SystemCapability[] = [
       batch: false,
     },
     optionalDependencies: ['iztro'],
+    notes: ['本命范围不读取系统当前时间；非本命范围必须明确提供目标日期和时辰。'],
   },
   {
     id: 'astrolabe',
@@ -632,8 +649,20 @@ const systems: SystemCapability[] = [
     category: 'chart',
     inputs: [
       { id: 'zodiac', label: '生肖或年支', type: 'text', required: true },
-      { id: 'year', label: '流年年份', type: 'number', required: false },
-      { id: 'yearGanZhi', label: '流年干支', type: 'text', required: false },
+      {
+        id: 'year',
+        label: '流年年份',
+        type: 'number',
+        required: false,
+        description: '与流年干支至少提供一项。',
+      },
+      {
+        id: 'yearGanZhi',
+        label: '流年干支',
+        type: 'text',
+        required: false,
+        description: '与流年年份至少提供一项。',
+      },
     ],
     outputs: [
       '值冲刑害破关系',
@@ -651,7 +680,10 @@ const systems: SystemCapability[] = [
       birthTimeRequired: false,
       batch: false,
     },
-    notes: ['生肖流年是只使用出生年支的轻量关系模型，不替代完整八字或现实资料。'],
+    notes: [
+      'year 与 yearGanZhi 至少提供一项，不使用系统当前年份补齐。',
+      '生肖流年是只使用出生年支的轻量关系模型，不替代完整八字或现实资料。',
+    ],
   },
   {
     id: 'taiyi',
@@ -708,7 +740,25 @@ const systems: SystemCapability[] = [
     id: 'qizheng',
     name: '七政四余',
     category: 'chart',
-    inputs: [birthProfileInput],
+    inputs: [
+      birthProfileInput,
+      { id: 'latitude', label: '出生地纬度', type: 'number', required: true },
+      { id: 'longitude', label: '出生地经度', type: 'number', required: true },
+      {
+        id: 'timezone',
+        label: '固定时区偏移',
+        type: 'number',
+        required: false,
+        description: '与 IANA 时区至少提供一项。',
+      },
+      {
+        id: 'timeZoneId',
+        label: 'IANA 时区',
+        type: 'text',
+        required: false,
+        description: '与固定时区偏移至少提供一项。',
+      },
+    ],
     outputs: [
       '七政',
       '四余',
@@ -737,6 +787,7 @@ const systems: SystemCapability[] = [
     },
     optionalDependencies: ['celestine'],
     notes: [
+      '必须提供真实经纬度，并在 timezone 与 timeZoneId 中至少提供一项；不会默认使用北京坐标或东八区。',
       'useTrueSolarTime 可选；启用后仅传统命身十二宫按真太阳时排布，七政四余位置仍用现代星历，属于混合精度口径。',
     ],
   },

--- a/packages/core/src/divination/algorithms/astrolabe.ts
+++ b/packages/core/src/divination/algorithms/astrolabe.ts
@@ -360,6 +360,8 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
         locationName.length > 0
           ? `${locationName}（${latitude.toFixed(4)}, ${longitude.toFixed(4)}）`
           : `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`,
+      latitude,
+      longitude,
       timezone,
       timeZoneId: input.timeZoneId,
       timezoneStatus: timezoneEvidence?.status,

--- a/packages/core/src/divination/astrolabe-scope.ts
+++ b/packages/core/src/divination/astrolabe-scope.ts
@@ -28,6 +28,13 @@ export type AstrolabeScopeContext = {
   solarArcEvidence?: SolarArcEvidence;
 };
 
+export type AstrolabeFullScopeContexts = {
+  natal: AstrolabeScopeContext;
+  yearly: AstrolabeScopeContext;
+  monthly: AstrolabeScopeContext;
+  daily: AstrolabeScopeContext;
+};
+
 export type AstrolabeAdvancedTechnique = '太阳返照' | '次限推进' | '太阳弧';
 
 export interface AstrolabeAdvancedCalculationStep {
@@ -302,19 +309,6 @@ function parseDateParts(dateStr: string) {
   return { year, month, day };
 }
 
-function getCurrentLocalDate() {
-  const now = new Date();
-  return {
-    year: now.getFullYear(),
-    month: now.getMonth() + 1,
-    day: now.getDate(),
-  };
-}
-
-function daysInMonth(year: number, month: number) {
-  return daysInAstrolabeScopeMonth(year, month);
-}
-
 function daysInAstrolabeScopeMonth(year: number, month: number) {
   if (!Number.isInteger(year) || year < 1900 || year > 2200) {
     throw new Error('年份需在 1900-2200 之间。');
@@ -327,17 +321,21 @@ function daysInAstrolabeScopeMonth(year: number, month: number) {
 }
 
 function normalizeTargetDate(scope: AstrolabeScopeMode, dateStr: string) {
-  const current = getCurrentLocalDate();
+  const pattern =
+    scope === 'yearly' ? /^\d{4}$/ : scope === 'monthly' ? /^\d{4}-\d{2}$/ : /^\d{4}-\d{2}-\d{2}$/;
+  const expected = scope === 'yearly' ? 'YYYY' : scope === 'monthly' ? 'YYYY-MM' : 'YYYY-MM-DD';
+  if (!pattern.test(dateStr.trim())) {
+    throw new Error(`${SCOPE_LABEL_MAP[scope]}必须提供 ${expected} 格式的明确日期。`);
+  }
+
   const parsed = parseDateParts(dateStr);
-  const year = parsed?.year ?? current.year;
-  const month = scope === 'yearly' ? 7 : Math.min(Math.max(parsed?.month ?? current.month, 1), 12);
-  const maxDay = daysInMonth(year, month);
-  const day =
-    scope === 'yearly'
-      ? Math.min(1, maxDay)
-      : scope === 'monthly'
-        ? Math.min(15, maxDay)
-        : Math.min(Math.max(parsed?.day ?? current.day, 1), maxDay);
+  if (!parsed) {
+    throw new Error(`${SCOPE_LABEL_MAP[scope]}日期无效或超出 1900-2200 年范围。`);
+  }
+
+  const year = parsed.year;
+  const month = scope === 'yearly' ? 7 : parsed.month!;
+  const day = scope === 'yearly' ? 1 : scope === 'monthly' ? 15 : parsed.day!;
 
   return { year, month, day };
 }
@@ -484,19 +482,30 @@ function parseBirthDateTime(data: AstrolabeData) {
   };
 }
 
+function resolveScopeTimezone(
+  data: AstrolabeData,
+  date: { year: number; month: number; day: number; hour: number; minute: number },
+) {
+  if (data.birth.timeZoneId) {
+    return resolveHistoricalTimezone({
+      ...date,
+      second: 0,
+      timeZoneId: data.birth.timeZoneId,
+      fixedOffsetHours: data.birth.timezone,
+    }).resolvedOffsetHours;
+  }
+  if (!Number.isFinite(data.birth.timezone)) {
+    throw new Error('星盘缺少有效时区，无法计算行运。');
+  }
+  return data.birth.timezone;
+}
+
 function calculateScopePlanets(
   data: AstrolabeData,
   date: { year: number; month: number; day: number; hour: number; minute: number },
 ) {
   const coordinates = parseBirthCoordinates(data);
-  const timezone = data.birth.timeZoneId
-    ? resolveHistoricalTimezone({
-        ...date,
-        second: 0,
-        timeZoneId: data.birth.timeZoneId,
-        fixedOffsetHours: data.birth.timezone,
-      }).resolvedOffsetHours
-    : data.birth.timezone;
+  const timezone = resolveScopeTimezone(data, date);
   return calculatePlanets(
     {
       ...date,
@@ -1258,10 +1267,19 @@ export function calculateSolarReturnEvidence(
   const techniqueKey = advancedTechniqueKey(technique);
   const birth = parseBirthDateTime(data);
   const natalSun = data.planets.find((planet) => planet.name === 'Sun');
+  const targetTimezone = birth
+    ? resolveScopeTimezone(data, {
+        year: targetYear,
+        month: birth.month,
+        day: Math.min(birth.day, daysInAstrolabeScopeMonth(targetYear, birth.month)),
+        hour: birth.hour,
+        minute: birth.minute,
+      })
+    : data.birth.timezone;
   const baseEvidence = {
     key: `${techniqueKey}:${targetYear}`,
     targetYear,
-    timezone: data.birth.timezone,
+    timezone: targetTimezone,
     searchWindowHours: 48,
     coarseStepHours: 2,
     refinementToleranceMinutes: 1,
@@ -1618,15 +1636,31 @@ function buildHouseRulerChainEvidence(data: AstrolabeData) {
 }
 
 function parseBirthCoordinates(data: AstrolabeData) {
-  const matched = /(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/.exec(data.birth.location);
-  if (!matched) {
-    return { latitude: 0, longitude: 0 };
+  if (
+    typeof data.birth.latitude === 'number' &&
+    Number.isFinite(data.birth.latitude) &&
+    data.birth.latitude >= -90 &&
+    data.birth.latitude <= 90 &&
+    typeof data.birth.longitude === 'number' &&
+    Number.isFinite(data.birth.longitude) &&
+    data.birth.longitude >= -180 &&
+    data.birth.longitude <= 180
+  ) {
+    return { latitude: data.birth.latitude, longitude: data.birth.longitude };
   }
 
-  return {
-    latitude: Number(matched[1]),
-    longitude: Number(matched[2]),
-  };
+  const matched = /(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/.exec(data.birth.location);
+  if (!matched) {
+    throw new Error('星盘缺少有效出生地经纬度，无法计算行运。');
+  }
+
+  const latitude = Number(matched[1]);
+  const longitude = Number(matched[2]);
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    throw new Error('星盘出生地经纬度超出有效范围，无法计算行运。');
+  }
+
+  return { latitude, longitude };
 }
 
 function getTransitBodiesForScope(scope: AstrolabeScopeMode) {
@@ -1643,100 +1677,78 @@ function buildTransitHouseEvidence(
   data: AstrolabeData,
   scope: AstrolabeScopeMode,
   target: { year: number; month: number; day: number },
+  timezone: number,
 ) {
   const cusps = getNatalHouseCusps(data);
   if (!cusps) {
     return '行运落宫：本命宫头资料不足。';
   }
 
-  try {
-    const coordinates = parseBirthCoordinates(data);
-    const planets = calculatePlanets(
-      {
-        year: target.year,
-        month: target.month,
-        day: target.day,
-        hour: 12,
-        minute: 0,
-        second: 0,
-        timezone: 8,
-        latitude: coordinates.latitude,
-        longitude: coordinates.longitude,
-      },
-      {
-        houseSystem: 'placidus',
-        includeAsteroids: false,
-        includeChiron: false,
-        includeLilith: false,
-        includeNodes: false,
-        includeLots: false,
-      },
-    );
-    const allowedBodies = getTransitBodiesForScope(scope);
-    const lines = planets
-      .filter((planet) => allowedBodies.has(planet.name))
-      .map((planet) => {
-        const natalHouse = getNatalHouseByLongitude(planet.longitude, cusps);
-        const label = CELESTIAL_BODY_LABELS[planet.name] ?? planet.name;
-        const position = formatAstrolabePlanetPosition(planet);
-        const retrograde = planet.isRetrograde ? '，逆行' : '';
-        return natalHouse
-          ? `${label}${position}${retrograde}落本命第${natalHouse}宫`
-          : `${label}${position}${retrograde}未能定位本命落宫`;
-      });
+  const planets = calculateScopePlanets(data, {
+    ...target,
+    hour: 12,
+    minute: 0,
+  });
+  const allowedBodies = getTransitBodiesForScope(scope);
+  const lines = planets
+    .filter((planet) => allowedBodies.has(planet.name))
+    .map((planet) => {
+      const natalHouse = getNatalHouseByLongitude(planet.longitude, cusps);
+      const label = CELESTIAL_BODY_LABELS[planet.name] ?? planet.name;
+      const position = formatAstrolabePlanetPosition(planet);
+      const retrograde = planet.isRetrograde ? '，逆行' : '';
+      return natalHouse
+        ? `${label}${position}${retrograde}落本命第${natalHouse}宫`
+        : `${label}${position}${retrograde}未能定位本命落宫`;
+    });
 
-    return lines.length ? `行运落宫：${lines.join('；')}。` : '行运落宫：未取得可用行运行星位置。';
-  } catch {
-    return '行运落宫：计算失败。';
+  if (!lines.length) {
+    throw new Error('未取得可用行运行星位置，无法计算行运落宫。');
   }
+  return `行运落宫：取样时区UTC${timezone >= 0 ? '+' : ''}${timezone}；${lines.join('；')}。`;
 }
 
 function buildTransitEvidence(
   data: AstrolabeData,
   target: { year: number; month: number; day: number },
+  timezone: number,
 ) {
   const natalPoints = buildNatalPoints(data);
   if (natalPoints.length < 3) {
     return '主要行运相位：本命点经度资料不足。';
   }
 
-  try {
-    const julianDate = time.toJulianDate({
-      year: target.year,
-      month: target.month,
-      day: target.day,
-      hour: 12,
-      minute: 0,
-      second: 0,
-      timezone: 8,
-    });
-    const result = calculateTransits(natalPoints, julianDate, {
-      aspectTypes: [
-        AspectType.Conjunction,
-        AspectType.Sextile,
-        AspectType.Square,
-        AspectType.Trine,
-        AspectType.Opposition,
-      ],
-      transitingBodies: TRANSITING_BODIES,
-      minimumStrength: 35,
-      includeOutOfSign: true,
-    });
-    const transitLines = result.transits
-      .sort(
-        (first, second) => second.strength - first.strength || first.deviation - second.deviation,
-      )
-      .slice(0, 10)
-      .map(formatTransitLine);
+  const julianDate = time.toJulianDate({
+    year: target.year,
+    month: target.month,
+    day: target.day,
+    hour: 12,
+    minute: 0,
+    second: 0,
+    timezone,
+  });
+  const result = calculateTransits(natalPoints, julianDate, {
+    aspectTypes: [
+      AspectType.Conjunction,
+      AspectType.Sextile,
+      AspectType.Square,
+      AspectType.Trine,
+      AspectType.Opposition,
+    ],
+    transitingBodies: TRANSITING_BODIES,
+    minimumStrength: 35,
+    includeOutOfSign: true,
+  });
+  const transitLines = result.transits
+    .sort((first, second) => second.strength - first.strength || first.deviation - second.deviation)
+    .slice(0, 10)
+    .map(formatTransitLine);
 
-    if (transitLines.length === 0) {
-      return '主要行运相位：所选日期未见当前容许度内的主要相位。';
-    }
-
-    return `主要行运相位：${transitLines.join('；')}。`;
-  } catch {
-    return '主要行运相位：计算失败。';
+  if (transitLines.length === 0) {
+    return '主要行运相位：所选日期未见当前容许度内的主要相位。';
   }
+
+  return `主要行运相位：${transitLines.join('；')}。`;
 }
 
 function formatAdvancedScopeFacts(params: {
@@ -1784,14 +1796,26 @@ export function buildAstrolabeScopeContext(
   }
 
   const houseRulerChain = buildHouseRulerChainEvidence(data);
-  if (scope === 'natal' || scope === 'full') {
+  if (scope === 'natal') {
     return {
       scope,
       dateStr: '',
-      displayText: scope === 'full' ? '本命盘与完整行运资料' : '仅使用本命信息',
-      displayLabel: scope === 'full' ? '完整输出版' : '本命盘',
+      displayText: '仅使用本命信息',
+      displayLabel: '本命盘',
+      promptText: ['分析对象：本命盘。', houseRulerChain].join('\n'),
+    };
+  }
+
+  if (scope === 'full') {
+    const reference = normalizeTargetDate('full', dateStr);
+    const normalizedReferenceDate = formatDateStr('daily', reference);
+    return {
+      scope,
+      dateStr: normalizedReferenceDate,
+      displayText: `本命盘与完整行运资料 · ${normalizedReferenceDate}`,
+      displayLabel: `完整输出版${normalizedReferenceDate}`,
       promptText: [
-        scope === 'full' ? '分析对象：本命盘与完整行运资料。' : '分析对象：本命盘。',
+        `分析对象：本命盘与以${normalizedReferenceDate}为基准的完整行运资料。`,
         houseRulerChain,
       ].join('\n'),
     };
@@ -1802,8 +1826,12 @@ export function buildAstrolabeScopeContext(
   const scopeLabel = SCOPE_LABEL_MAP[scope];
   const displayText = `${scopeLabel} · ${normalizedDateStr}`;
   const anchorDate = formatAnchorDate(target);
-  const transitEvidence = buildTransitEvidence(data, target);
-  const transitHouseEvidence = buildTransitHouseEvidence(data, scope, target);
+  const targetTimezone = resolveScopeTimezone(data, { ...target, hour: 12, minute: 0 });
+  const timezoneLabel = data.birth.timeZoneId
+    ? `${data.birth.timeZoneId}（UTC${targetTimezone >= 0 ? '+' : ''}${targetTimezone}）`
+    : `UTC${targetTimezone >= 0 ? '+' : ''}${targetTimezone}`;
+  const transitEvidence = buildTransitEvidence(data, target, targetTimezone);
+  const transitHouseEvidence = buildTransitHouseEvidence(data, scope, target, targetTimezone);
   const solarReturnEvidence =
     scope === 'yearly' ? calculateSolarReturnEvidence(data, target.year) : undefined;
   const secondaryProgressionEvidence =
@@ -1823,7 +1851,7 @@ export function buildAstrolabeScopeContext(
     displayLabel: `${scopeLabel}${normalizedDateStr}`,
     promptText: [
       `分析对象：${scopeLabel}${normalizedDateStr}。`,
-      `取样时间：${anchorDate}（按北京时间中午取样，用于计算行运行星触发）。`,
+      `取样时间：${anchorDate}（按出生地时区${timezoneLabel}的中午取样，用于计算行运行星触发）。`,
       houseRulerChain,
       transitEvidence,
       transitHouseEvidence,
@@ -1832,6 +1860,23 @@ export function buildAstrolabeScopeContext(
     solarReturnEvidence,
     secondaryProgressionEvidence,
     solarArcEvidence,
+  };
+}
+
+export function buildAstrolabeFullScopeContexts(
+  data: AstrolabeData,
+  referenceDateStr: string,
+): AstrolabeFullScopeContexts {
+  const reference = normalizeTargetDate('full', referenceDateStr);
+  const dailyDate = formatDateStr('daily', reference);
+  const monthlyDate = formatDateStr('monthly', reference);
+  const yearlyDate = formatDateStr('yearly', reference);
+
+  return {
+    natal: buildAstrolabeScopeContext(data, 'natal', ''),
+    yearly: buildAstrolabeScopeContext(data, 'yearly', yearlyDate),
+    monthly: buildAstrolabeScopeContext(data, 'monthly', monthlyDate),
+    daily: buildAstrolabeScopeContext(data, 'daily', dailyDate),
   };
 }
 

--- a/packages/core/src/qi_zheng/index.ts
+++ b/packages/core/src/qi_zheng/index.ts
@@ -147,8 +147,8 @@ export interface QizhengCalculationContext {
   timezone: number;
   latitude: number;
   longitude: number;
-  locationSource: '用户提供' | '默认北京坐标' | '部分坐标使用默认值';
-  timezoneSource: 'IANA历史时区' | '用户提供' | '默认东八区';
+  locationSource: '用户提供';
+  timezoneSource: 'IANA历史时区' | '用户提供';
   astronomicalTime: AstronomicalTimeEvidence;
   moonPhase: MoonPhaseEvidence;
   solarIllumination: SolarIlluminationEvidence;
@@ -350,16 +350,19 @@ function conditionQizhengPortableText(text: string): string {
     .replace(/这是项目明确采用/g, '这是当前计算明确采用');
 }
 
-export interface QizhengInput {
+export interface QizhengTimeInput {
   year: number;
   month: number;
   day: number;
   hour: number;
   minute?: number;
-  latitude?: number;
-  longitude?: number;
   timezone?: number;
   timeZoneId?: string;
+}
+
+export interface QizhengInput extends QizhengTimeInput {
+  latitude: number;
+  longitude: number;
   /**
    * 可选：启用后仅用真太阳时校正传统命身十二宫排布；
    * 七政四余天体位置仍按现代星历与天文时间尺度计算。
@@ -610,7 +613,7 @@ function assertNumberRange(value: number, label: string, min: number, max: numbe
   }
 }
 
-function validateQizhengInput(input: QizhengInput, includeLocation: boolean): void {
+function validateQizhengTimeInput(input: QizhengTimeInput): void {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     throw new Error('七政四余参数必须是对象。');
   }
@@ -626,18 +629,25 @@ function validateQizhengInput(input: QizhengInput, includeLocation: boolean): vo
   if (input.timeZoneId !== undefined && !input.timeZoneId.trim()) {
     throw new Error('IANA 时区名不能为空。');
   }
-  if (includeLocation) {
-    assertNumberRange(input.latitude ?? 39.9, '纬度', -90, 90);
-    assertNumberRange(input.longitude ?? 116.4, '经度', -180, 180);
+  if (input.timezone === undefined && !input.timeZoneId) {
+    throw new Error('七政四余必须提供 timezone 或 timeZoneId。');
   }
 }
 
-function getTargetUtcMs(input: QizhengInput): number {
-  validateQizhengInput(input, false);
+function validateQizhengInput(input: QizhengInput): void {
+  validateQizhengTimeInput(input);
+  if (input.latitude === undefined) throw new Error('七政四余必须提供出生地纬度。');
+  if (input.longitude === undefined) throw new Error('七政四余必须提供出生地经度。');
+  assertNumberRange(input.latitude, '纬度', -90, 90);
+  assertNumberRange(input.longitude, '经度', -180, 180);
+}
+
+function getTargetUtcMs(input: QizhengTimeInput): number {
+  validateQizhengTimeInput(input);
   return buildQizhengAstronomicalTime(input).unixMilliseconds;
 }
 
-function buildQizhengAstronomicalTime(input: QizhengInput): AstronomicalTimeEvidence {
+function buildQizhengAstronomicalTime(input: QizhengTimeInput): AstronomicalTimeEvidence {
   return buildAstronomicalTimeEvidence({
     year: input.year,
     month: input.month,
@@ -645,7 +655,7 @@ function buildQizhengAstronomicalTime(input: QizhengInput): AstronomicalTimeEvid
     hour: input.hour,
     minute: input.minute ?? 0,
     second: 0,
-    timezone: input.timezone ?? (input.timeZoneId ? undefined : 8),
+    timezone: input.timezone,
     timeZoneId: input.timeZoneId,
   });
 }
@@ -659,7 +669,7 @@ function getDecimalYear(utcMs: number): number {
 }
 
 /** 依《七政算内篇》单一古法模型计算紫炁回归黄经。 */
-export function calculateZiqiTropicalLongitude(input: QizhengInput): number {
+export function calculateZiqiTropicalLongitude(input: QizhengTimeInput): number {
   const targetUtcMs = getTargetUtcMs(input);
   const elapsedDays = (targetUtcMs - ZIQI_MODERN_EPOCH_UTC_MS) / 86_400_000;
   return normalizeLongitude(ZIQI_MODERN_EPOCH_LONGITUDE + elapsedDays * ZIQI_DAILY_MOTION);
@@ -683,7 +693,7 @@ function toSidereal(tropical: number, year: number): number {
 }
 
 /** 返回紫炁的完整可审计位置数据；项目中不存在第二套紫炁计算模型。 */
-export function calculateZiqiPosition(input: QizhengInput): ZiqiPosition {
+export function calculateZiqiPosition(input: QizhengTimeInput): ZiqiPosition {
   const targetUtcMs = getTargetUtcMs(input);
   const tropicalLongitude = calculateZiqiTropicalLongitude(input);
   const siderealLongitude = toSidereal(tropicalLongitude, getDecimalYear(targetUtcMs));
@@ -807,8 +817,6 @@ function buildCalculationContext(
   longitude: number,
   astronomicalTime: AstronomicalTimeEvidence,
 ): QizhengCalculationContext {
-  const hasLatitude = input.latitude !== undefined;
-  const hasLongitude = input.longitude !== undefined;
   const moonPhase = calculateMoonPhaseEvidence(astronomicalTime.unixMilliseconds);
   const solarIllumination = calculateSolarIlluminationEvidence({
     year: input.year,
@@ -828,17 +836,8 @@ function buildCalculationContext(
     timezone: astronomicalTime.timezone,
     latitude,
     longitude,
-    locationSource:
-      hasLatitude && hasLongitude
-        ? '用户提供'
-        : !hasLatitude && !hasLongitude
-          ? '默认北京坐标'
-          : '部分坐标使用默认值',
-    timezoneSource: input.timeZoneId
-      ? 'IANA历史时区'
-      : input.timezone === undefined
-        ? '默认东八区'
-        : '用户提供',
+    locationSource: '用户提供',
+    timezoneSource: input.timeZoneId ? 'IANA历史时区' : '用户提供',
     astronomicalTime,
     moonPhase,
     solarIllumination,
@@ -1438,12 +1437,12 @@ function buildQizhengEvidence(
 
 /** 生成七政四余盘 */
 export function generateQizheng(input: QizhengInput): QizhengResult {
-  validateQizhengInput(input, true);
+  validateQizhengInput(input);
   if (input.useTrueSolarTime !== undefined && typeof input.useTrueSolarTime !== 'boolean') {
     throw new Error('useTrueSolarTime 必须是布尔值。');
   }
-  const lat = input.latitude ?? 39.9;
-  const lon = input.longitude ?? 116.4;
+  const lat = input.latitude;
+  const lon = input.longitude;
   const astronomicalTime = buildQizhengAstronomicalTime(input);
   const tz = astronomicalTime.timezone;
   const calculationContext = buildCalculationContext(input, lat, lon, astronomicalTime);

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -1118,6 +1118,8 @@ export interface AstrolabeData {
     gender: AlmanacParticipantGender;
     dateTime: string;
     location: string;
+    latitude?: number;
+    longitude?: number;
     timezone: number;
     timeZoneId?: string;
     timezoneStatus?: 'unique' | 'ambiguous';

--- a/public/skills/aov-mingyu-api/SKILL.md
+++ b/public/skills/aov-mingyu-api/SKILL.md
@@ -52,7 +52,7 @@ description: 通过 aov.cc 公开 API 调用真太阳时换算、命理、占卜
 
 - 有完整出生信息，且用户问人生、事业、财运、婚恋、亲子、健康、迁居、学习、考试、合作、近期趋势、某年某阶段走势：优先调用 `POST /bazi-ziwei/prompt`。这是深度解读的首选方案，用八字定主线，用紫微校验宫位、四化和运限。
 - 用户明确只要八字：调用 `POST /bazi/prompt`。长期或完整阶段分析用 `baziFortuneScope: "full"`；指定年份、月份、日期时用对应范围。
-- 用户明确只要紫微：调用 `POST /ziwei/prompt`。长期或完整阶段分析用 `promptScope: "full"`；指定年份、月份、日期时用 `yearly`、`monthly`、`daily` 或 `hourly`。
+- 用户明确只要紫微：调用 `POST /ziwei/prompt`。长期或完整阶段分析用 `promptScope: "full"`；指定年份、月份、日期时用 `yearly`、`monthly`、`daily` 或 `hourly`。除本命外必须同时提供 `ziweiScopeDate` 和 `ziweiScopeTimeIndex`。
 - 用户要求紫微合盘或双方宫位、四化互动证据：调用 `POST /ziwei/compatibility/prompt`；只要结构化数据时调用 `POST /ziwei/compatibility`。
 - 用户问一件事现在能不能成、要不要推进、对方态度、短期应期：优先用六爻 `POST /divination/liuyao/prompt`；涉及方位、项目路径、谈判、出行和时空窗口时优先用奇门 `POST /divination/qimen/prompt`。
 - 用户要从日期范围里挑日子：调用 `POST /divination/almanac/prompt`，日期多或参与人多时分页。
@@ -62,24 +62,24 @@ description: 通过 aov.cc 公开 API 调用真太阳时换算、命理、占卜
 
 问题到接口速查：
 
-| 问题类型                       | 首选接口                                     | 关键参数                                                                    |
-| ------------------------------ | -------------------------------------------- | --------------------------------------------------------------------------- |
-| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `"origin"`  |
-| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
-| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`               |
-| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                           |
-| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、`promptScope`                                                |
-| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                               |
-| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
-| 临时小事快速判断               | `POST /divination/xiaoliuren/prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
-| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
-| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
-| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
-| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
-| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
-| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                    |
-| 雷诺曼关系或选择牌阵           | `POST /divination/lenormand/prompt`          | `spreadType`、`question`                                                    |
-| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                  |
+| 问题类型                       | 首选接口                                     | 关键参数                                                                     |
+| ------------------------------ | -------------------------------------------- | ---------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `origin` 无需行运目标；`full` 同时传 `ziweiScopeDate`、`ziweiScopeTimeIndex` |
+| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`、`ziweiScopeDate`、`ziweiScopeTimeIndex`             |
+| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`                |
+| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                            |
+| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、非本命 `promptScope`、`ziweiScopeDate`、`ziweiScopeTimeIndex` |
+| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                                |
+| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                                 |
+| 临时小事快速判断               | `POST /divination/xiaoliuren/prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber`  |
+| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                            |
+| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                              |
+| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`     |
+| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                     |
+| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                      |
+| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                     |
+| 雷诺曼关系或选择牌阵           | `POST /divination/lenormand/prompt`          | `spreadType`、`question`                                                     |
+| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                   |
 
 参数默认建议：
 
@@ -133,7 +133,7 @@ description: 通过 aov.cc 公开 API 调用真太阳时换算、命理、占卜
 - `POST /divination/astrolabe/synastry/prompt`：西占双盘计算并生成结构化证据提示词。
 - `POST /metaphysics/bazhai/calculate`、`POST /metaphysics/bazhai/prompt`：八宅排盘与提示词。
 - `POST /metaphysics/zodiac/calculate`、`POST /metaphysics/zodiac/prompt`：生肖犯太岁与流年提示词。
-- `POST /metaphysics/taiyi/calculate`、`POST /metaphysics/taiyi/prompt`：年家太乙七十二局排盘与提示词；当前不提供未完整复原的月、日、时家。
+- `POST /metaphysics/taiyi/calculate`、`POST /metaphysics/taiyi/prompt`：太乙年、月、日、时、分五计七十二局排盘与提示词。
 - `POST /metaphysics/qizheng/calculate`、`POST /metaphysics/qizheng/prompt`：七政四余排盘与提示词，紫炁采用《七政算内篇》古法均速模型。
 - `POST /ai/analyze`：AI 解读，返回 SSE 流式响应。
 - `POST /ai/models`：获取当前 AI 配置可用的模型列表。
@@ -177,7 +177,7 @@ curl -X POST https://aov.cc/api/v1/ziwei/prompt \
 ```bash
 curl -X POST https://aov.cc/api/v1/bazi-ziwei/prompt \
   -H "Content-Type: application/json" \
-  -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly"}'
+  -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly","ziweiScopeDate":"2028-06-12","ziweiScopeTimeIndex":4}'
 ```
 
 塔罗抽牌：
@@ -217,7 +217,7 @@ curl -X POST https://aov.cc/api/v1/bazi/prompt \
 ```bash
 curl -X POST https://aov.cc/api/v1/ziwei/prompt \
   -H "Content-Type: application/json" \
-  -d '{"gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"2025年事业财运如何？","promptTopic":"career-wealth","promptScope":"yearly","school":"feixing"}'
+  -d '{"gender":"female","dateType":"solar","year":"1992","month":"8","day":"21","timeIndex":4,"question":"2025年事业财运如何？","promptTopic":"career-wealth","promptScope":"yearly","ziweiScopeDate":"2025-06-12","ziweiScopeTimeIndex":4,"school":"feixing"}'
 ```
 
 奇门飞盘法排盘：
@@ -323,11 +323,13 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 紫微 `promptTopic` 支持以下主题：
 `destiny`（命局）、`relationship`（感情）、`relationship-push`（感情推进）、`relationship-decision`（关系去留）、`career-wealth`（事业财运）、`job-change`（工作变动）、`startup-partnership`（创业合作）、`investment-partnership`（投资合作）、`recent`（近期趋势）、`family`（六亲家庭）、`home-move`（搬家置业）、`settle-relocate`（定居换城）、`social`（人际合作）、`emotion`（情绪心理）、`health`（健康养护）、`study`（学业成长）、`study-advance`（考证进修）、`exam-landing`（考试上岸）、`growth`（成长方向）、`talent`（天赋特质）、`reconciliation-decision`（复合判断）、`life`（人生解析）、`chat`（自由聊天）。
 
-紫微 `promptScope` 支持：`origin`（本命）、`full`（完整输出版）、`decadal`（大限）、`yearly`（流年）、`monthly`（流月）、`daily`（流日）、`hourly`（流时）、`age`（年龄）。公开 API 默认只返回 `origin`；请求传入 `promptScope` 时，会返回 `origin` 加指定范围，包含分析对象、落宫与四化信息；`full` 会返回并写入本命、大限、流年、流月、流日、流时资料。
+紫微 `promptScope` 支持：`origin`（本命）、`full`（完整输出版）、`decadal`（大限）、`yearly`（流年）、`monthly`（流月）、`daily`（流日）、`hourly`（流时）、`age`（年龄）。公开 API 默认只返回 `origin`；除 `origin` 外必须同时提供 `ziweiScopeDate`（`YYYY-MM-DD`）和 `ziweiScopeTimeIndex`（0-12），不会读取系统当前日期或时辰补齐。`full` 会按该目标时刻返回并写入本命、大限、流年、流月、流日、流时资料。
 
 紫微排盘结果以 `payloadByScope.origin.palaces` 为主结构；接口同时提供 `四化`、`fourMutagens`、`birthMutagens` 和 `gongList`，方便 agent 直接读取生年四化和十二宫星曜。
 
-八字紫微合参 `/bazi-ziwei/prompt` 使用同一份出生信息，支持 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope`、`promptMode`、`baziSchool`、`ziweiSchool`、`responseMode`。默认返回 `data.resultSummary.bazi`、`data.resultSummary.ziwei` 和 `data.prompt`；需要完整双盘时传 `responseMode: "full"`。
+八字紫微合参 `/bazi-ziwei/prompt` 使用同一份出生信息，支持 `baziPromptTopic`、`ziweiPromptTopic`、`promptScope`、`ziweiScopeDate`、`ziweiScopeTimeIndex`、`promptMode`、`baziSchool`、`ziweiSchool`、`responseMode`。默认返回 `data.resultSummary.bazi`、`data.resultSummary.ziwei` 和 `data.prompt`；需要完整双盘时传 `responseMode: "full"`。非本命紫微范围同样必须提供明确目标日期和时辰。
+
+生肖流年接口必须在 `year` 与 `yearGanZhi` 中至少提供一项，不会默认使用系统当前年份。七政四余接口必须提供真实 `latitude`、`longitude`，并在 `timezone` 与 `timeZoneId` 中至少提供一项；不会默认使用北京坐标或东八区。
 
 `promptMode` 支持：`framework`（内置完整框架，默认）、`custom`（只围绕用户问题自由作答，不塞框架）。
 

--- a/public/skills/aov-mingyu-api/SKILL.md
+++ b/public/skills/aov-mingyu-api/SKILL.md
@@ -62,24 +62,24 @@ description: 通过 aov.cc 公开 API 调用真太阳时换算、命理、占卜
 
 问题到接口速查：
 
-| 问题类型                       | 首选接口                                     | 关键参数                                                                   |
-| ------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------- |
-| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `"origin"` |
-| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题按事业、财运、感情等选择                      |
-| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`              |
-| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                          |
-| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、`promptScope`                                               |
-| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                              |
-| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                               |
+| 问题类型                       | 首选接口                                     | 关键参数                                                                    |
+| ------------------------------ | -------------------------------------------- | --------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `"origin"`  |
+| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
+| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`               |
+| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                           |
+| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、`promptScope`                                                |
+| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                               |
+| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
 | 临时小事快速判断               | `POST /divination/xiaoliuren/prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
-| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                          |
-| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                            |
-| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`   |
-| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                   |
-| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                    |
-| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                   |
-| 雷诺曼关系或选择牌阵           | `POST /divination/lenormand/prompt`          | `spreadType`、`question`                                                   |
-| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                 |
+| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
+| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
+| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
+| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
+| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
+| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                    |
+| 雷诺曼关系或选择牌阵           | `POST /divination/lenormand/prompt`          | `spreadType`、`question`                                                    |
+| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                  |
 
 参数默认建议：
 
@@ -318,7 +318,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 八字 `promptTopic` 支持以下主题：
 `general`（综合）、`recent`（近期）、`career`（事业）、`job-change`（跳槽）、`startup-partnership`（创业合作）、`investment-partnership`（投资合作）、`wealth`（财运）、`marriage`（婚恋）、`relationship-push`（感情推进）、`relationship-decision`（关系去留）、`reconciliation-decision`（复合判断）、`children`（子女）、`family`（家庭）、`home-move`（搬家置业）、`settle-relocate`（定居换城）、`social`（人际合作）、`emotion`（情绪心理）、`health`（健康）、`parents`（父母）、`study`（学业）、`study-advance`（考证进修）、`exam-landing`（考试上岸）、`growth`（成长方向）、`talent`（天赋特质）。
 
-八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。选择 `dayun`、`year`、`month`、`day` 时，可配套传入 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。选择 `dayun` 时必须传 `baziFortuneCycleIndex`；选择 `year`、`month`、`day` 时必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`，交运年份可同时传 `baziFortuneCycleIndex` 消除重叠歧义。工具不会自动选择当前时间或第一项。
 
 紫微 `promptTopic` 支持以下主题：
 `destiny`（命局）、`relationship`（感情）、`relationship-push`（感情推进）、`relationship-decision`（关系去留）、`career-wealth`（事业财运）、`job-change`（工作变动）、`startup-partnership`（创业合作）、`investment-partnership`（投资合作）、`recent`（近期趋势）、`family`（六亲家庭）、`home-move`（搬家置业）、`settle-relocate`（定居换城）、`social`（人际合作）、`emotion`（情绪心理）、`health`（健康养护）、`study`（学业成长）、`study-advance`（考证进修）、`exam-landing`（考试上岸）、`growth`（成长方向）、`talent`（天赋特质）、`reconciliation-decision`（复合判断）、`life`（人生解析）、`chat`（自由聊天）。
@@ -360,7 +360,7 @@ Python `urllib` 默认 `User-Agent` 可能被 Cloudflare 拦截；Python 调用�
 - 黄历择日 `startDate`、`endDate`：日期范围字符串，一次最多 31 天。`participants`：参与者数组，每人包含 `id`、`name`、`gender`、`year`、`month`、`day`、`timeIndex`、`dateType`、`isLeapMonth`，一次最多 30 位；更多日期或参与人请拆成多次请求。
 - 黄历择日 `page`、`pageSize`：分页参数，`pageSize` 最大 31。不传分页时返回全部日期；传分页后只返回当前页并带 `pagination`。`page` 超过总页数会返回 400，请按 `pagination.totalPages` 继续请求。
 - 雷诺曼 `spreadType`：`single`（单牌）、`three`（三牌）、`five`（五牌十字阵）、`relationship`（关系）、`decision`（选择）、`nine`（九宫）、`element`（元素牌阵）、`grandTableau`（大桌牌阵）。
-- 星盘 `year`、`month`、`day`、`hour`、`minute`：出生时间。`latitude`、`longitude`：经纬度。`timezone`：时区偏移。`locationName`：地点名称。可传 `useTrueSolarTime` 启用真太阳时校正；提示词接口可传 `astrolabeTopic`、`astrolabeScope`、`astrolabeScopeDate` 和 `astrolabeScopeText`。`astrolabeScope` 支持 `natal`、`full`、`yearly`、`monthly`、`daily`；`full` 会写入本命、当前流年、当前流月、当前流日行运资料；传入 `astrolabeScopeText` 时以自定义文本为准。
+- 星盘 `year`、`month`、`day`、`hour`、`minute`：出生时间。`latitude`、`longitude`：经纬度。`timezone`：时区偏移。`locationName`：地点名称。可传 `useTrueSolarTime` 启用真太阳时校正；提示词接口可传 `astrolabeTopic`、`astrolabeScope`、`astrolabeScopeDate` 和 `astrolabeScopeText`。`astrolabeScope` 支持 `natal`、`full`、`yearly`、`monthly`、`daily`；`yearly`、`monthly`、`daily` 分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`，`full` 也必须提供 `YYYY-MM-DD` 基准日并写入该日所属的本命、流年、流月、流日资料；传入 `astrolabeScopeText` 时以自定义文本为准。
 
 AI 接口参数：
 

--- a/scripts/generate-prompt-audit.ts
+++ b/scripts/generate-prompt-audit.ts
@@ -43,6 +43,7 @@ type RequiredSampleFields = {
 
 const AUDIT_DATE = new Date('2026-05-19T10:30:00+08:00');
 const AUDIT_DATE_TEXT = '2026年5月19日 10时30分（北京时间）';
+const AUDIT_ZIWEI_CONTEXT = { dateStr: '2026-05-19', hourIndex: 5 };
 const CUSTOM_DATE = '2026-05-19T10:30:00+08:00';
 const CONTEST_SOURCE = 'docs/2025第十六届全球算命师比赛/00_原题目.md；本脚本未读取“正确答案.md”。';
 const COMMON_PROJECT_QUESTION = '我现在应该继续推进这个项目，还是先调整策略再行动？';
@@ -72,15 +73,28 @@ const REQUIRED_SAMPLE_FIELDS: RequiredSampleFields[] = [
   },
   {
     sampleName: '六爻',
-    requiredFields: withCommonProjectSupplementRequired(['【传统判断规则】', '【传统依据】', '应期']),
+    requiredFields: withCommonProjectSupplementRequired([
+      '【传统判断规则】',
+      '【传统依据】',
+      '应期',
+    ]),
   },
   {
     sampleName: '梅花易数',
-    requiredFields: withCommonProjectSupplementRequired(['【传统判断规则】', '【传统依据】', '体用关系']),
+    requiredFields: withCommonProjectSupplementRequired([
+      '【传统判断规则】',
+      '【传统依据】',
+      '体用关系',
+    ]),
   },
   {
     sampleName: '奇门遁甲',
-    requiredFields: withCommonProjectSupplementRequired(['【传统判断规则】', '【传统依据】', '发用', '值符']),
+    requiredFields: withCommonProjectSupplementRequired([
+      '【传统判断规则】',
+      '【传统依据】',
+      '发用',
+      '值符',
+    ]),
   },
   {
     sampleName: '大六壬',
@@ -146,63 +160,39 @@ const REQUIRED_SAMPLE_FIELDS: RequiredSampleFields[] = [
   },
   {
     sampleName: '八宅风水',
-    requiredFields: [
-      '【当前时间】',
-      '【传统判断规则】',
-      '【传统依据】',
-      '命卦八宫明细',
-      '宅卦八宫明细',
-    ],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '命卦八宫明细', '宅卦八宫明细'],
   },
   {
     sampleName: '住宅风水',
-    requiredFields: [
-      '【当前时间】',
-      '【传统判断规则】',
-      '【传统依据】',
-      '合参要点',
-      '结构化证据',
-    ],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '合参要点', '结构化证据'],
   },
   {
     sampleName: '玄空飞星',
-    requiredFields: [
-      '【当前时间】',
-      '【传统判断规则】',
-      '【传统依据】',
-      '运盘',
-      '山盘',
-      '向盘',
-      '结构化证据',
-    ],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '运盘', '山盘', '向盘', '结构化证据'],
   },
   {
     sampleName: '生肖流年',
-    requiredFields: ['【当前时间】', '【传统判断规则】', '【传统依据】', '太岁'],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '太岁'],
   },
   {
     sampleName: '太乙神数',
-    requiredFields: [
-      '【当前时间】',
-      '【传统判断规则】',
-      '【传统依据】',
-      '核心宫位',
-      '主客定算',
-      '将参',
-      '十六神',
-    ],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '核心宫位', '主客定算', '将参', '十六神'],
   },
   {
     sampleName: '七政四余',
-    requiredFields: [
-      '【当前时间】',
-      '【传统判断规则】',
-      '【传统依据】',
-      '出生时空',
-      '十二宫映射',
-      '计算上下文',
-    ],
+    requiredFields: ['【传统判断规则】', '【传统依据】', '出生时空', '十二宫映射', '计算上下文'],
   },
+];
+
+const SAMPLES_WITHOUT_CURRENT_TIME = [
+  '八字排盘',
+  '紫微斗数',
+  '八宅风水',
+  '住宅风水',
+  '玄空飞星',
+  '生肖流年',
+  '太乙神数',
+  '七政四余',
 ];
 
 function withSeed<T>(seed: number, callback: () => T): T {
@@ -276,7 +266,7 @@ function buildPromptMarkdown(samples: PromptSample[]) {
     '',
     '使用场景：以下提示词会由用户直接复制到外部在线 AI 中解读，外部 AI 不知道本仓库、页面、接口、内部实现或生成过程。',
     '',
-    '硬性要求：每份提示词必须像用户手动写成的完整任务书，独立包含当前时间、盘面资料、问题、任务、证据要求、输出要求和必要边界；提示词正文不得出现本项目、算法返回、本模块、接口、代码、调试、系统提示词等工程语境。',
+    '硬性要求：每份提示词必须像用户手动写成的完整任务书，独立包含盘面资料、问题、任务、证据要求、输出要求和必要边界；即时占卜应包含明确起盘时间，命盘、行运和环境类任务不得用系统当前时间补齐分析目标；提示词正文不得出现本项目、算法返回、本模块、接口、代码、调试、系统提示词等工程语境。',
     '',
     '理由：工程语境会让外部 AI 误以为需要理解或评价软件实现，也可能使它依赖并不存在的上下文，导致偏离盘面和用户问题。改用“本盘”“上方资料”“推算口径”“资料边界”等自然表达，能让解读只围绕已提供事实展开。',
     '',
@@ -328,6 +318,13 @@ function assertRequiredSampleFields(samples: PromptSample[]) {
         missingMessages.push(`${sampleName} 缺少字段：${field}`);
       }
     });
+  });
+
+  SAMPLES_WITHOUT_CURRENT_TIME.forEach((sampleName) => {
+    const sample = samples.find((item) => item.name === sampleName);
+    if (sample?.prompt.includes('【当前时间】')) {
+      missingMessages.push(`${sampleName} 不应包含字段：【当前时间】`);
+    }
   });
 
   if (missingMessages.length > 0) {
@@ -431,6 +428,7 @@ async function buildSamples(): Promise<PromptSample[]> {
         birthMinute: '34',
         birthLongitude: '103.8198',
       }),
+      AUDIT_ZIWEI_CONTEXT,
     );
     const ziweiPrompt = buildZiweiPromptForRuntime({
       result: ziweiRuntime,
@@ -606,7 +604,6 @@ async function buildSamples(): Promise<PromptSample[]> {
       '请分析命主的核心结构、优势、限制和适合的发展方向。',
       { method: 'qizheng', currentTime: fixedNow },
     );
-
 
     const residentialData = generateResidentialFengshui({
       birthYear: 1990,
@@ -791,4 +788,3 @@ async function main() {
 }
 
 await main();
-

--- a/src/lib/astrolabe-synastry-prompt.ts
+++ b/src/lib/astrolabe-synastry-prompt.ts
@@ -1,6 +1,5 @@
 import type { AstrolabeData, AstrolabeSynastryData } from 'mingyu-core/types';
 import { formatAstrolabeInfo } from './divination/engine/formatters';
-import { formatPromptCurrentTime } from './prompt-time';
 import { buildPromptGuidanceSections } from './prompt-guidance';
 
 export type AstrolabeSynastryPromptMode = 'framework' | 'custom';
@@ -30,14 +29,10 @@ export function buildAstrolabeSynastryPrompt(params: {
   synastry: AstrolabeSynastryData;
   question?: string;
   promptMode?: AstrolabeSynastryPromptMode;
-  currentTime?: Date;
 }) {
   const question = params.question?.trim() || '请先整体判断双方关系中的互动主轴。';
   const baseSections = [
     buildPromptGuidanceSections('astrolabe-synastry'),
-    '',
-    '【当前时间】',
-    formatPromptCurrentTime(params.currentTime),
     '',
     '【第一人本命盘】',
     formatAstrolabeInfo(params.chart1),

--- a/src/lib/full-chart-engine/index.ts
+++ b/src/lib/full-chart-engine/index.ts
@@ -1,4 +1,4 @@
-export type { ZiweiRuntime } from './ziwei';
+export type { ZiweiHoroscopeContext, ZiweiRuntime } from './ziwei';
 export { buildPersonFromInput, calculateFullBaziChart } from './bazi';
 export {
   buildZiweiPayloadByScope,

--- a/src/lib/full-chart-engine/ziwei.ts
+++ b/src/lib/full-chart-engine/ziwei.ts
@@ -14,7 +14,6 @@ import {
   buildPatternAnalysis,
   detectPatterns,
   getCurrentScopeItem,
-  getDefaultHoroscopeContext,
   mapStarFact,
   analyzeZiweiCompatibility,
 } from '@core/ziwei/iztro';
@@ -23,7 +22,6 @@ import {
   getZiweiDefaultQuestion,
 } from '../prompt-default-questions';
 import { buildPortablePromptPack, type PromptContext } from '../ziwei-prompts';
-import { formatPromptCurrentTime } from '../prompt-time';
 import { buildPromptGuidanceSections } from '../prompt-guidance';
 
 export type ZiweiRuntime = {
@@ -32,6 +30,11 @@ export type ZiweiRuntime = {
   payloadByScope: Record<ScopeType, AnalysisPayloadV1>;
   trueSolarEvidence?: ChartInput['trueSolarEvidence'];
 };
+
+export interface ZiweiHoroscopeContext {
+  dateStr: string;
+  hourIndex: number;
+}
 
 type ZiweiTrueSolarEvidence = NonNullable<ZiweiRuntime['trueSolarEvidence']>;
 
@@ -113,23 +116,51 @@ export function buildZiweiPayloadByScope(params: {
 
 export async function calculateFullZiweiChart(
   input: ChartInput,
+  horoscopeContext: ZiweiHoroscopeContext,
   skipAnalysis?: boolean,
 ): Promise<ZiweiRuntime> {
-  return calculateZiweiChartForScopes(input, undefined, skipAnalysis);
+  return calculateZiweiChartForScopes(input, undefined, skipAnalysis, horoscopeContext);
+}
+
+function resolveZiweiHoroscopeContext(
+  astrolabe: IztroAstrolabe,
+  input: ChartInput,
+  scopes: ScopeType[],
+  horoscopeContext: ZiweiHoroscopeContext | undefined,
+): ZiweiHoroscopeContext {
+  if (horoscopeContext) return horoscopeContext;
+
+  if (scopes.some((scope) => scope !== 'origin')) {
+    throw new Error('紫微非本命计算必须明确提供目标日期和时辰。');
+  }
+
+  return {
+    dateStr: buildBasicInfo(astrolabe).solar_date,
+    hourIndex: input.birthTimeIndex,
+  };
 }
 
 export async function calculateZiweiChartForScopes(
   input: ChartInput,
   scopes?: ScopeType[],
   skipAnalysis?: boolean,
+  horoscopeContext?: ZiweiHoroscopeContext,
 ): Promise<ZiweiRuntime> {
   const astrolabe = await buildAstrolabeFromInput(input);
-  const { dateStr, hourIndex } = getDefaultHoroscopeContext();
+  const requestedScopes = scopes?.length
+    ? scopes
+    : (['origin', 'decadal', 'yearly', 'monthly', 'daily', 'hourly', 'age'] as ScopeType[]);
+  const { dateStr, hourIndex } = resolveZiweiHoroscopeContext(
+    astrolabe,
+    input,
+    requestedScopes,
+    horoscopeContext,
+  );
   const horoscope = buildHoroscope(astrolabe, dateStr, hourIndex);
   const payloadByScope = buildZiweiPayloadByScope({
     astrolabe,
     horoscope,
-    scopes,
+    scopes: requestedScopes,
     skipAnalysis,
   });
 
@@ -232,11 +263,17 @@ function buildLightweightPublicPayload(params: {
 export async function calculatePublicZiweiChartForScopes(
   input: ChartInput,
   scopes?: ScopeType[],
+  horoscopeContext?: ZiweiHoroscopeContext,
 ): Promise<ZiweiRuntime> {
   const astrolabe = await buildAstrolabeFromInput(input);
-  const { dateStr, hourIndex } = getDefaultHoroscopeContext();
-  const horoscope = buildHoroscope(astrolabe, dateStr, hourIndex);
   const requestedScopes = Array.from(new Set(['origin' as const, ...(scopes ?? [])]));
+  const { dateStr, hourIndex } = resolveZiweiHoroscopeContext(
+    astrolabe,
+    input,
+    requestedScopes,
+    horoscopeContext,
+  );
+  const horoscope = buildHoroscope(astrolabe, dateStr, hourIndex);
   const basicInfo = buildBasicInfo(astrolabe);
   const palaces = buildLightweightPublicPalaces(astrolabe);
   const payloadByScope: Partial<Record<ScopeType, AnalysisPayloadV1>> = {};
@@ -259,9 +296,12 @@ export async function calculatePublicZiweiChartForScopes(
   };
 }
 
-export async function calculateZiweiPayloadByScope(input: ChartInput) {
+export async function calculateZiweiPayloadByScope(
+  input: ChartInput,
+  horoscopeContext: ZiweiHoroscopeContext,
+) {
   const astrolabe = await buildAstrolabeFromInput(input);
-  const { dateStr, hourIndex } = getDefaultHoroscopeContext();
+  const { dateStr, hourIndex } = horoscopeContext;
   const horoscope = buildHoroscope(astrolabe, dateStr, hourIndex);
 
   return buildZiweiPayloadByScope({
@@ -570,8 +610,6 @@ export function buildCombinedZiweiPrompt(
 
   return [
     buildPromptGuidanceSections('ziwei'),
-    `【当前时间】\n${formatPromptCurrentTime()}`,
-    '',
     packWithPriority,
     ...(trueSolarEvidenceText ? ['', `【出生时间校正】\n${trueSolarEvidenceText}`] : []),
     '',
@@ -637,7 +675,6 @@ export function buildCombinedZiweiCompatibilityPrompt(params: {
 
   return [
     buildPromptGuidanceSections('ziwei-compatibility'),
-    `【当前时间】\n${formatPromptCurrentTime()}`,
     `【${primaryName}盘面】`,
     primaryEmbeddedPack,
     ...(primaryTrueSolarEvidenceText

--- a/src/lib/metaphysics-prompt.ts
+++ b/src/lib/metaphysics-prompt.ts
@@ -1,11 +1,9 @@
-import { formatPromptCurrentTime } from './prompt-time';
 import { appendTraditionalResearchNotice } from 'mingyu-core/prompt-evidence';
 import { buildPromptGuidanceSections, type MetaphysicsPromptMethod } from './prompt-guidance';
 
 export interface MetaphysicsPromptOptions {
   method: MetaphysicsPromptMethod;
   measurement?: string;
-  currentTime?: Date;
   context?: PromptRealWorldContext;
 }
 
@@ -55,9 +53,6 @@ export function buildMetaphysicsPrompt(
   return appendTraditionalResearchNotice(
     [
       buildPromptGuidanceSections(options.method),
-      '',
-      '【当前时间】',
-      formatPromptCurrentTime(options.currentTime),
       '',
       basePrompt,
       ...(options.measurement ? ['', '【测量换算】', options.measurement] : []),

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -50,7 +50,7 @@ import {
 } from 'mingyu-core/foundation';
 import { buildDivinationPrompt } from '../divination/engine';
 import { getDivinationSummaryBlocks } from '../divination/summary';
-import { buildAstrolabeScopeContext } from '../astrolabe-scope';
+import { buildAstrolabeFullScopeContexts, buildAstrolabeScopeContext } from '../astrolabe-scope';
 import { buildAstrolabeSynastryPrompt } from '../astrolabe-synastry-prompt';
 import { getCompatibilityPrompt, type CompatType } from '../../utils/ai/aiPrompts';
 import {
@@ -343,7 +343,8 @@ const DIVINATION_REQUEST_PROPERTIES = {
   },
   astrolabeScopeDate: {
     type: 'string',
-    description: '星盘行运日期；yearly 用年份，monthly 用 年-月，daily 用 年-月-日。',
+    description:
+      '星盘行运日期；full 和 daily 用 YYYY-MM-DD，yearly 用 YYYY，monthly 用 YYYY-MM。除 natal 外均必填。',
   },
   astrolabeScopeText: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
   promptMode: { enum: [...PROMPT_MODES] },
@@ -1186,20 +1187,24 @@ export function getPublicApiOpenApiDocument(
                 baziFortuneCycleIndex: {
                   type: 'integer',
                   minimum: 0,
-                  description: '大运序号，从 0 开始；选择大运、流年、流月或流日时可传。',
+                  description:
+                    '大运序号，从 0 开始；选择大运时必填，选择流年、流月或流日时可与年份一起传入以消除交运年歧义。',
                 },
-                baziFortuneYear: { type: 'integer', description: '指定流年年份。' },
+                baziFortuneYear: {
+                  type: 'integer',
+                  description: '指定流年年份；选择流年、流月或流日时必填。',
+                },
                 baziFortuneMonth: {
                   type: 'integer',
                   minimum: 1,
                   maximum: 12,
-                  description: '指定流月序号。',
+                  description: '指定流月序号；选择流月或流日时必填。',
                 },
                 baziFortuneDay: {
                   type: 'integer',
                   minimum: 1,
                   maximum: 31,
-                  description: '指定流日序号。',
+                  description: '指定流日序号；选择流日时必填。',
                 },
                 responseMode: DIVINATION_REQUEST_PROPERTIES.responseMode,
                 school: {
@@ -2212,26 +2217,34 @@ function readShenShaVariants(input: JsonRecord): Partial<ShenShaVariantConfig> |
 
 function buildBaziFortuneContextFromInput(result: BaziChartResult, input: JsonRecord) {
   const scope = readEnum(input, 'baziFortuneScope', BAZI_FORTUNE_SCOPES, 'natal');
-  const readOptionalInteger = (key: string, min: number, max: number) =>
-    input[key] === undefined ? undefined : readInteger(input, key, min, max);
   const selection: BaziFortuneSelectionValue = {
     scope,
     cycleIndex:
       scope === 'natal' || scope === 'full'
         ? undefined
-        : readInteger(input, 'baziFortuneCycleIndex', 0, 99, 0),
+        : scope === 'dayun' || input.baziFortuneCycleIndex !== undefined
+          ? readInteger(input, 'baziFortuneCycleIndex', 0, 99)
+          : undefined,
     year:
       scope === 'year' || scope === 'month' || scope === 'day'
-        ? readOptionalInteger('baziFortuneYear', 1900, 2200)
+        ? readInteger(input, 'baziFortuneYear', 1900, 2200)
         : undefined,
     month:
       scope === 'month' || scope === 'day'
-        ? readOptionalInteger('baziFortuneMonth', 1, 12)
+        ? readInteger(input, 'baziFortuneMonth', 1, 12)
         : undefined,
-    day: scope === 'day' ? readOptionalInteger('baziFortuneDay', 1, 31) : undefined,
+    day: scope === 'day' ? readInteger(input, 'baziFortuneDay', 1, 31) : undefined,
   };
 
-  return buildFortuneSelectionContext(result, selection);
+  try {
+    return buildFortuneSelectionContext(result, selection);
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '八字年限参数无效。',
+    );
+  }
 }
 
 function buildBaziPrompt(input: JsonRecord) {
@@ -2788,12 +2801,13 @@ function buildAstrolabeSynastryPromptApi(input: JsonRecord) {
   });
 }
 
-function buildAstrolabeFullScopePromptText(data: AstrolabeData) {
+function buildAstrolabeFullScopePromptText(data: AstrolabeData, referenceDateStr: string) {
+  const fullContexts = buildAstrolabeFullScopeContexts(data, referenceDateStr);
   const contexts = [
-    buildAstrolabeScopeContext(data, 'natal', ''),
-    buildAstrolabeScopeContext(data, 'yearly', ''),
-    buildAstrolabeScopeContext(data, 'monthly', ''),
-    buildAstrolabeScopeContext(data, 'daily', ''),
+    fullContexts.natal,
+    fullContexts.yearly,
+    fullContexts.monthly,
+    fullContexts.daily,
   ];
   const lines = contexts
     .map((context) => context.promptText)
@@ -2813,13 +2827,21 @@ function buildAstrolabePromptScopeText(input: JsonRecord, data: AstrolabeData) {
     ASTROLABE_PROMPT_SCOPES,
     'natal',
   ) as (typeof ASTROLABE_PROMPT_SCOPES)[number];
+  const dateStr = scope === 'natal' ? '' : readRequiredString(input, 'astrolabeScopeDate');
 
-  if (scope === 'full') {
-    return buildAstrolabeFullScopePromptText(data);
+  try {
+    if (scope === 'full') {
+      return buildAstrolabeFullScopePromptText(data, dateStr);
+    }
+
+    return buildAstrolabeScopeContext(data, scope, dateStr).promptText;
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '星盘行运日期无效。',
+    );
   }
-
-  const dateStr = readString(input, 'astrolabeScopeDate', '');
-  return buildAstrolabeScopeContext(data, scope, dateStr).promptText;
 }
 
 function buildAstrolabeScopeEvidence(input: JsonRecord, data: AstrolabeData) {
@@ -2834,19 +2856,24 @@ function buildAstrolabeScopeEvidence(input: JsonRecord, data: AstrolabeData) {
     ASTROLABE_PROMPT_SCOPES,
     'natal',
   ) as (typeof ASTROLABE_PROMPT_SCOPES)[number];
-  if (scope === 'full') {
-    return {
-      scope: 'full' as const,
-      contexts: {
-        natal: buildAstrolabeScopeContext(data, 'natal', ''),
-        yearly: buildAstrolabeScopeContext(data, 'yearly', ''),
-        monthly: buildAstrolabeScopeContext(data, 'monthly', ''),
-        daily: buildAstrolabeScopeContext(data, 'daily', ''),
-      },
-    };
-  }
+  const dateStr = scope === 'natal' ? '' : readRequiredString(input, 'astrolabeScopeDate');
+  try {
+    if (scope === 'full') {
+      return {
+        scope: 'full' as const,
+        referenceDate: dateStr,
+        contexts: buildAstrolabeFullScopeContexts(data, dateStr),
+      };
+    }
 
-  return buildAstrolabeScopeContext(data, scope, readString(input, 'astrolabeScopeDate', ''));
+    return buildAstrolabeScopeContext(data, scope, dateStr);
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '星盘行运日期无效。',
+    );
+  }
 }
 
 function buildDivinationPromptResult(

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -1131,9 +1131,12 @@ export function getPublicApiOpenApiDocument(
               type: 'integer',
               minimum: 1900,
               maximum: 2200,
-              description: '公元年（默认今年）',
+              description: '公元年；生肖流年中与 yearGanZhi 至少提供一项。',
             },
-            yearGanZhi: { type: 'string', description: '直接给定流年干支，如「甲辰」（生肖运程）' },
+            yearGanZhi: {
+              type: 'string',
+              description: '直接给定流年干支，如「甲辰」；与 year 至少提供一项（生肖运程）。',
+            },
             scope: {
               enum: ['year', 'month', 'day', 'hour', 'minute'],
               description: '太乙计式：年计、月计、日计、时计或分计',
@@ -1147,19 +1150,23 @@ export function getPublicApiOpenApiDocument(
               type: 'number',
               minimum: -90,
               maximum: 90,
-              description: '纬度（七政四余）',
+              description: '出生地纬度；七政四余必填。',
             },
             longitude: {
               type: 'number',
               minimum: -180,
               maximum: 180,
-              description: '经度（七政四余）',
+              description: '出生地经度；七政四余必填。',
             },
             timezone: {
               type: 'number',
               minimum: -12,
               maximum: 14,
-              description: '时区偏移（七政四余）',
+              description: '固定时区偏移；七政四余中与 timeZoneId 至少提供一项。',
+            },
+            timeZoneId: {
+              type: 'string',
+              description: 'IANA 时区名；七政四余中与 timezone 至少提供一项。',
             },
             question: { type: 'string', description: '解读问题（prompt 端点）' },
             promptMode: { type: 'string', description: '提示词模式（prompt 端点）' },
@@ -1249,6 +1256,17 @@ export function getPublicApiOpenApiDocument(
               description:
                 '可选。默认只返回本命范围；传入后会额外返回指定分析范围；full 会返回本命、大限、流年、流月、流日、流时。',
             },
+            ziweiScopeDate: {
+              type: 'string',
+              pattern: '^\\d{4}-\\d{2}-\\d{2}$',
+              description: '行运目标公历日期；选择非本命范围时必填，格式 YYYY-MM-DD。',
+            },
+            ziweiScopeTimeIndex: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 12,
+              description: '行运目标时辰索引；选择非本命范围时必填。',
+            },
             isLeapMonth: { type: 'boolean' },
             useTrueSolarTime: { type: 'boolean' },
             birthHour: { type: 'string' },
@@ -1269,7 +1287,11 @@ export function getPublicApiOpenApiDocument(
                   maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH,
                 },
                 promptTopic: { enum: [...ZIWEI_PROMPT_TOPICS] },
-                promptScope: { enum: [...ZIWEI_PROMPT_SCOPES] },
+                promptScope: {
+                  enum: [...ZIWEI_PROMPT_SCOPES],
+                  description:
+                    '选择非本命范围时必须同时提供 ziweiScopeDate 和 ziweiScopeTimeIndex。',
+                },
                 promptMode: { enum: [...PROMPT_MODES] },
                 responseMode: DIVINATION_REQUEST_PROPERTIES.responseMode,
                 school: {
@@ -1324,7 +1346,22 @@ export function getPublicApiOpenApiDocument(
                   enum: [...ZIWEI_PROMPT_TOPICS],
                   description: '紫微侧分析主题；不传时使用 life。',
                 },
-                promptScope: { enum: [...ZIWEI_PROMPT_SCOPES] },
+                promptScope: {
+                  enum: [...ZIWEI_PROMPT_SCOPES],
+                  description:
+                    '选择非本命范围时必须同时提供 ziweiScopeDate 和 ziweiScopeTimeIndex。',
+                },
+                ziweiScopeDate: {
+                  type: 'string',
+                  pattern: '^\\d{4}-\\d{2}-\\d{2}$',
+                  description: '紫微行运目标公历日期；选择非本命范围时必填。',
+                },
+                ziweiScopeTimeIndex: {
+                  type: 'integer',
+                  minimum: 0,
+                  maximum: 12,
+                  description: '紫微行运目标时辰索引；选择非本命范围时必填。',
+                },
                 promptMode: { enum: [...PROMPT_MODES] },
                 responseMode: DIVINATION_REQUEST_PROPERTIES.responseMode,
                 baziSchool: {
@@ -1910,9 +1947,12 @@ function calculateZodiacApi(input: JsonRecord) {
   if (yearGanZhi && !isValidGanZhi(yearGanZhi)) {
     throw new ApiError(400, 'BAD_REQUEST', `yearGanZhi 不是有效的六十甲子：${yearGanZhi}。`);
   }
-  const year = readInteger(input, 'year', 1900, 2200, new Date().getFullYear());
+  if (!yearGanZhi && input.year === undefined) {
+    throw new ApiError(400, 'BAD_REQUEST', 'year 与 yearGanZhi 至少需要提供一项。');
+  }
+  const year = yearGanZhi ? undefined : readInteger(input, 'year', 1900, 2200);
   // 以"立春"为年界：取 2 月 10 日（必在立春之后）推算流年干支，避免 2/4 凌晨尚属上一干支年的误差
-  const gz = yearGanZhi || getGanZhiFromDate(new Date(year, 1, 10)).year;
+  const gz = yearGanZhi || getGanZhiFromDate(new Date(year!, 1, 10)).year;
   return zodiac.getZodiacYearFortune(zodiacBranch, gz);
 }
 
@@ -1976,11 +2016,14 @@ function calculateQizhengApi(input: JsonRecord) {
   const hour = readInteger(input, 'hour', 0, 23);
   const minute = optInt(input, 'minute', 0, 59) ?? 0;
   buildSolarDate(year, month, day, hour, minute);
-  const latitude = optNumber(input, 'latitude', -90, 90);
-  const longitude = optNumber(input, 'longitude', -180, 180);
+  const latitude = readNumber(input, 'latitude', -90, 90);
+  const longitude = readNumber(input, 'longitude', -180, 180);
   const timezone = optNumber(input, 'timezone', -12, 14);
   const timeZoneId =
     input.timeZoneId === undefined ? undefined : readString(input, 'timeZoneId', '');
+  if (timezone === undefined && !timeZoneId) {
+    throw new ApiError(400, 'BAD_REQUEST', 'timezone 与 timeZoneId 至少需要提供一项。');
+  }
   const useTrueSolarTime = readBoolean(input, 'useTrueSolarTime', false);
   return qizheng.generateQizheng({
     year,
@@ -1988,8 +2031,8 @@ function calculateQizhengApi(input: JsonRecord) {
     day,
     hour,
     minute,
-    ...(latitude !== undefined ? { latitude } : {}),
-    ...(longitude !== undefined ? { longitude } : {}),
+    latitude,
+    longitude,
     ...(timezone !== undefined ? { timezone } : {}),
     ...(timeZoneId ? { timeZoneId } : {}),
     ...(useTrueSolarTime ? { useTrueSolarTime: true } : {}),
@@ -2353,6 +2396,13 @@ async function calculateZiweiRuntime(input: JsonRecord, scopes: ScopeType[] = ['
         birthMinute: readString(input, 'birthMinute', ''),
         birthLongitude: readString(input, 'birthLongitude', ''),
       };
+  const needsHoroscopeContext = scopes.some((scope) => scope !== 'origin');
+  const horoscopeContext = needsHoroscopeContext
+    ? {
+        dateStr: readRequiredString(input, 'ziweiScopeDate'),
+        hourIndex: readInteger(input, 'ziweiScopeTimeIndex', 0, 12),
+      }
+    : undefined;
   return calculatePublicZiweiChartForScopes(
     buildZiweiChartInput({
       name: readString(input, 'name', ''),
@@ -2369,6 +2419,7 @@ async function calculateZiweiRuntime(input: JsonRecord, scopes: ScopeType[] = ['
       birthLongitude: timeInput.birthLongitude,
     }),
     Array.from(new Set(['origin' as ScopeType, ...scopes])),
+    horoscopeContext,
   );
 }
 
@@ -3022,9 +3073,6 @@ function buildPromptApiResult(params: {
 }
 
 function buildCompactBaziResult(result: BaziChartResult) {
-  const currentYear = new Date().getFullYear();
-  const currentLiunian = result.liunian?.find((item) => item.year === currentYear);
-
   return {
     gender: result.gender,
     solarDate: result.solarDate,
@@ -3068,7 +3116,6 @@ function buildCompactBaziResult(result: BaziChartResult) {
         endSolarTime: cycle.endSolarTime,
       })),
     },
-    currentLiunian,
     warnings: result.warnings,
     warningFacts: result.warningFacts,
     warningSummaryFact: result.warningSummaryFact,

--- a/src/lib/public-api/prompt-builders.ts
+++ b/src/lib/public-api/prompt-builders.ts
@@ -14,7 +14,6 @@ import {
   type ZiweiRuntime,
 } from '../full-chart-engine/ziwei';
 import { mapScopeLabel, mapTopicLabel } from '../ziwei-prompts/labels';
-import { formatPromptCurrentTime } from '../prompt-time';
 import { buildPromptGuidanceSections, insertPromptSectionBeforeHeading } from '../prompt-guidance';
 
 export const BAZI_PROMPT_TOPICS = [
@@ -646,7 +645,6 @@ export function buildBaziZiweiPromptForResults(params: {
   const baseSections = [
     buildPromptGuidanceSections('bazi-ziwei'),
     guidance.length ? `【流派】\n${guidance.join('\n')}` : '',
-    `【当前时间】\n${formatPromptCurrentTime()}`,
     `【分析对象】\n八字主题：${BAZI_TOPIC_LABELS[baziTopic]}\n紫微主题：${mapTopicLabel(ziweiTopic)}\n紫微范围：${mapZiweiPromptScopeLabel(ziweiScope)}`,
     `【八字排盘信息】\n${baziText}`,
     `【紫微盘面信息】\n${ziweiText}`,

--- a/src/lib/query-state.ts
+++ b/src/lib/query-state.ts
@@ -645,8 +645,12 @@ function normalizeZiweiScopeDate(scope: ZiweiScopeMode, dateStr: string) {
 }
 
 function normalizeAstrolabeScopeDate(scope: AstrolabeScopeMode, dateStr: string) {
-  if (scope === 'natal' || scope === 'full' || !dateStr) {
+  if (scope === 'natal' || !dateStr) {
     return '';
+  }
+
+  if (scope === 'full') {
+    return parseScopeDateParts(dateStr) ? dateStr : '';
   }
 
   if (scope === 'yearly') {
@@ -679,6 +683,9 @@ function normalizePromptState(prompt: QueryPromptState): QueryPromptState {
     normalized.astrolabeScope,
     normalized.astrolabeScopeDate,
   );
+  if (normalized.astrolabeScope !== 'natal' && !normalized.astrolabeScopeDate) {
+    normalized.astrolabeScope = 'natal';
+  }
 
   if (normalized.baziFortuneScope === 'natal' || normalized.baziFortuneScope === 'full') {
     normalized.baziFortuneCycleIndex = '';

--- a/src/pages/ResultPage/ResultPage.helpers.ts
+++ b/src/pages/ResultPage/ResultPage.helpers.ts
@@ -1,5 +1,4 @@
 import type { DecadalTimelineOption } from '@core/ziwei/iztro';
-import { formatPromptCurrentTime } from '@/lib/prompt-time';
 import type { AstrolabeScopeMode, QueryPromptState, ZiweiScopeMode } from '@/lib/query-state';
 import type { AstrolabePromptTopic } from '@/lib/astrolabe-prompts';
 import { buildPortablePromptPack, type PromptContext } from '@/lib/ziwei-prompts';
@@ -214,7 +213,6 @@ export function buildBaziZiweiEnhancedPrompt(params: {
 
   return [
     buildPromptGuidanceSections('bazi-ziwei'),
-    `【当前时间】\n${formatPromptCurrentTime()}`,
     sourceLabels.length > 0 ? `【分析对象】\n${sourceLabels.join('\n')}` : '',
     questionScopeLabel && questionScopeLabel !== '通用'
       ? `【问题范围】\n${questionScopeLabel}`

--- a/src/pages/ResultPage/components/AstrolabeScopeModal.tsx
+++ b/src/pages/ResultPage/components/AstrolabeScopeModal.tsx
@@ -350,7 +350,11 @@ export function AstrolabeScopeModal(props: {
               onClick={() => {
                 onApply(
                   draftScope,
-                  draftScope === 'natal' || draftScope === 'full' ? '' : draftScopeDateStr,
+                  draftScope === 'natal'
+                    ? ''
+                    : draftScope === 'full'
+                      ? formatDateByScope('daily', draftYear, draftMonth, normalizedDraftDay)
+                      : draftScopeDateStr,
                 );
                 onClose();
               }}

--- a/src/pages/ResultPage/hooks/useZiweiCalculations.ts
+++ b/src/pages/ResultPage/hooks/useZiweiCalculations.ts
@@ -16,7 +16,7 @@ async function runZiweiMainThread(
 ): Promise<void> {
   try {
     // skipAnalysis=true：不在主线程计算证据池和格局检测，仅生成展示所需的基础数据
-    const runtime = await calculateFullZiweiChart(input, true);
+    const runtime = await calculateFullZiweiChart(input, getDefaultHoroscopeContext(), true);
     onSuccess(runtime);
   } catch (error) {
     onError(error instanceof Error ? error.message : '紫微排盘失败。');
@@ -129,6 +129,7 @@ export function useZiweiCalculations(
 
     return createPayloadWorker(
       primaryZiweiInput,
+      getDefaultHoroscopeContext(),
       `${Date.now()}-primary`,
       (payloadByScope) => {
         setZiweiPayloadByScope(payloadByScope);
@@ -160,6 +161,7 @@ export function useZiweiCalculations(
 
     return createPayloadWorker(
       partnerZiweiInput,
+      getDefaultHoroscopeContext(),
       `${Date.now()}-partner`,
       (payloadByScope) => {
         setPartnerZiweiPayloadByScope(payloadByScope);
@@ -206,6 +208,7 @@ export function useZiweiCalculations(
           // 异步后台 worker 计算完整版（含证据池和格局检测），不阻塞主线程
           cleanupBackgroundWorker = createPayloadWorker(
             primaryZiweiInput,
+            getDefaultHoroscopeContext(),
             `${Date.now()}-bg-primary`,
             (fullPayloadByScope) => {
               if (!cancelled) {
@@ -258,6 +261,7 @@ export function useZiweiCalculations(
 
           cleanupBackgroundWorker = createPayloadWorker(
             partnerZiweiInput,
+            getDefaultHoroscopeContext(),
             `${Date.now()}-bg-partner`,
             (fullPayloadByScope) => {
               if (!cancelled) {

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -676,6 +676,9 @@ export function ResultPage() {
     (mountedTabs.qizheng || (promptState.tab === 'prompt' && isQizhengPromptSource));
   const qizhengCalculation = useMemo<{ data: QizhengResult | null; error: string }>(() => {
     if (!shouldCalculateQizheng || !sharedBirthData) return { data: null, error: '' };
+    if (sharedBirthData.latitude === undefined || sharedBirthData.longitude === undefined) {
+      return { data: null, error: '七政四余排盘需要完整的出生地经纬度。' };
+    }
     try {
       return {
         data: generateQizheng({

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -14,7 +14,7 @@ import {
   type QueryPromptState,
   type ResultTabKey,
 } from '@/lib/query-state';
-import { buildAstrolabeScopeContext } from '@/lib/astrolabe-scope';
+import { buildAstrolabeFullScopeContexts, buildAstrolabeScopeContext } from '@/lib/astrolabe-scope';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
 import { shouldUsePhoneLayout } from '@/lib/responsive-layout';
 import { PageTopbar } from '@/components/PageTopbar';
@@ -503,7 +503,11 @@ export function ResultPage() {
       return { scope: 'natal' as const };
     }
 
-    return baziFortuneSelectionModule.normalizeFortuneSelection(baziResult, baziFortuneSelection);
+    try {
+      return baziFortuneSelectionModule.normalizeFortuneSelection(baziResult, baziFortuneSelection);
+    } catch {
+      return { scope: 'natal' as const };
+    }
   }, [baziFortuneSelection, baziFortuneSelectionModule, baziResult]);
   const baziFortuneContext = useMemo(() => {
     if (!baziResult || !baziFortuneSelectionModule) {
@@ -522,9 +526,9 @@ export function ResultPage() {
     [baziResult, currentScopeDate],
   );
   const baziFortunePreset: FortuneScopePreset =
-    promptState.baziFortuneScope === 'natal'
+    normalizedBaziFortuneSelection.scope === 'natal'
       ? 'default'
-      : promptState.baziFortuneScope === 'full'
+      : normalizedBaziFortuneSelection.scope === 'full'
         ? 'all'
         : recentBaziFortuneSelection &&
             isSameBaziFortuneSelection(normalizedBaziFortuneSelection, recentBaziFortuneSelection)
@@ -601,7 +605,7 @@ export function ResultPage() {
     }
     updatePromptState({
       astrolabeScope: value === 'all' ? 'full' : value === 'recent' ? 'monthly' : 'natal',
-      astrolabeScopeDate: value === 'recent' ? currentDateStr : '',
+      astrolabeScopeDate: value === 'recent' || value === 'all' ? currentDateStr : '',
     });
   }
 
@@ -707,13 +711,10 @@ export function ResultPage() {
       return null;
     }
 
-    return buildAstrolabeFullScopePromptText({
-      natal: buildAstrolabeScopeContext(astrolabeCalculation.data, 'natal', ''),
-      yearly: buildAstrolabeScopeContext(astrolabeCalculation.data, 'yearly', ''),
-      monthly: buildAstrolabeScopeContext(astrolabeCalculation.data, 'monthly', ''),
-      daily: buildAstrolabeScopeContext(astrolabeCalculation.data, 'daily', ''),
-    });
-  }, [astrolabeCalculation.data, promptState.astrolabeScope]);
+    return buildAstrolabeFullScopePromptText(
+      buildAstrolabeFullScopeContexts(astrolabeCalculation.data, promptState.astrolabeScopeDate),
+    );
+  }, [astrolabeCalculation.data, promptState.astrolabeScope, promptState.astrolabeScopeDate]);
 
   const activeBaziQuestionScopeLabel = useMemo(() => {
     if (activeBaziShortcutMode === '自定义' || activeBaziShortcutMode === '问题灵感') {
@@ -1944,7 +1945,7 @@ export function ResultPage() {
         <Suspense fallback={<BaziFortuneLoadingModal />}>
           <LazyBaziFortuneModal
             result={baziResult}
-            selection={baziFortuneSelection}
+            selection={normalizedBaziFortuneSelection}
             onClose={() => setIsBaziFortuneModalOpen(false)}
             onApply={applyBaziFortuneSelection}
           />

--- a/src/pages/ResultPage/utils/createPayloadWorker.ts
+++ b/src/pages/ResultPage/utils/createPayloadWorker.ts
@@ -1,9 +1,11 @@
 import { attachWorkerSafety } from '@/hooks/useWorkerRequest';
+import type { ZiweiHoroscopeContext } from '@/lib/full-chart-engine';
 import type { AnalysisPayloadV1, ScopeType } from '@/types/analysis';
 import type { ChartInput } from '@/types/chart';
 
 export function createPayloadWorker(
   input: ChartInput,
+  horoscopeContext: ZiweiHoroscopeContext,
   requestId: string,
   onSuccess: (payloadByScope: Record<ScopeType, AnalysisPayloadV1>) => void,
   onError: (message: string) => void,
@@ -35,7 +37,7 @@ export function createPayloadWorker(
     worker.terminate();
   };
 
-  worker.postMessage({ id: requestId, input });
+  worker.postMessage({ id: requestId, input, horoscopeContext });
 
   return () => {
     disarm();

--- a/src/utils/ai/aiPrompts.ts
+++ b/src/utils/ai/aiPrompts.ts
@@ -5,7 +5,6 @@ import {
   getBaziCompatibilityDefaultQuestion,
   getBaziDefaultQuestion,
 } from '../../lib/prompt-default-questions';
-import { formatPromptCurrentTime } from '../../lib/prompt-time';
 import { generateEnhancedAnalysisSection } from '@core/bazi/baziPromptEnhancement';
 import { analyzeBaziCompatibility } from '@core/bazi/compatibilityEvidence';
 import { buildPromptGuidanceSections } from '../../lib/prompt-guidance';
@@ -314,7 +313,6 @@ export function buildPromptFromConfig(
       user: appendTraditionalResearchNotice(
         joinPromptSections([
           buildPromptGuidanceSections('bazi'),
-          buildPromptSection('当前时间', formatPromptCurrentTime()),
           buildPromptSection('排盘信息', [chartData, enhancedSection].filter(Boolean).join('\n')),
           hasFullFortuneOutput
             ? buildPromptSection('分析对象', buildBaziFullAnalysisObjectSection())
@@ -347,7 +345,6 @@ export function buildPromptFromConfig(
     user: appendTraditionalResearchNotice(
       joinPromptSections([
         buildPromptGuidanceSections('bazi'),
-        buildPromptSection('当前时间', formatPromptCurrentTime()),
         buildPromptSection('排盘信息', chartData),
         hasFullFortuneOutput
           ? buildPromptSection('分析对象', buildBaziFullAnalysisObjectSection())
@@ -433,7 +430,6 @@ export function getCompatibilityPrompt(
     user: appendTraditionalResearchNotice(
       joinPromptSections([
         buildPromptGuidanceSections('bazi-compatibility'),
-        buildPromptSection('当前时间', formatPromptCurrentTime()),
         buildPromptSection('第一人排盘信息', data1),
         buildPromptSection('第二人排盘信息', data2),
         buildPromptSection('双盘关系资料', compatibilityEvidence),

--- a/src/workers/ziwei-payload.worker.ts
+++ b/src/workers/ziwei-payload.worker.ts
@@ -1,9 +1,10 @@
-import { calculateZiweiPayloadByScope } from '@/lib/full-chart-engine';
+import { calculateZiweiPayloadByScope, type ZiweiHoroscopeContext } from '@/lib/full-chart-engine';
 import type { ChartInput } from '@/types/chart';
 
 type ZiweiPayloadWorkerRequest = {
   id: string;
   input: ChartInput;
+  horoscopeContext: ZiweiHoroscopeContext;
 };
 
 type ZiweiPayloadWorkerResponse =
@@ -20,7 +21,10 @@ type ZiweiPayloadWorkerResponse =
 
 self.onmessage = async (event: MessageEvent<ZiweiPayloadWorkerRequest>) => {
   try {
-    const payloadByScope = await calculateZiweiPayloadByScope(event.data.input);
+    const payloadByScope = await calculateZiweiPayloadByScope(
+      event.data.input,
+      event.data.horoscopeContext,
+    );
     const response: ZiweiPayloadWorkerResponse = {
       id: event.data.id,
       ok: true,

--- a/tests/astrolabe-scope.test.ts
+++ b/tests/astrolabe-scope.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildAstrolabeFullScopeContexts,
   buildAstrolabeScopeContext,
   calculateSecondaryProgressionEvidence,
   calculateSolarArcEvidence,
@@ -89,10 +90,15 @@ test('星盘完整输出版显示完整行运资料摘要', () => {
   const context = buildAstrolabeScopeContext(astrolabeData, 'full', '2028-06-01');
 
   assert.equal(context.scope, 'full');
-  assert.equal(context.displayText, '本命盘与完整行运资料');
-  assert.equal(context.dateStr, '');
-  assert.match(context.promptText, /分析对象：本命盘与完整行运资料。/);
+  assert.equal(context.displayText, '本命盘与完整行运资料 · 2028-06-01');
+  assert.equal(context.dateStr, '2028-06-01');
+  assert.match(context.promptText, /以2028-06-01为基准的完整行运资料/);
   assert.match(context.promptText, /本命宫主星：第1宫/);
+
+  const contexts = buildAstrolabeFullScopeContexts(astrolabeData, '2028-06-01');
+  assert.equal(contexts.yearly.dateStr, '2028');
+  assert.equal(contexts.monthly.dateStr, '2028-06');
+  assert.equal(contexts.daily.dateStr, '2028-06-01');
 });
 
 test('星盘流年分析对象会生成行运证据和展示文本', () => {
@@ -236,12 +242,24 @@ test('星盘流月与流日沿用同一选择器语义并写入对应行运资�
   assert.doesNotMatch(`${monthContext.promptText}\n${dayContext.promptText}`, /不得|时间边界|证据/);
 });
 
-test('星盘范围日期不存在时不应夹到另一天', () => {
-  const invalidDayContext = buildAstrolabeScopeContext(astrolabeData, 'daily', '2028-02-31');
-  const invalidMonthContext = buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-13');
-
-  assert.notEqual(invalidDayContext.dateStr, '2028-02-29');
-  assert.notEqual(invalidMonthContext.dateStr, '2028-12');
+test('星盘行运范围应拒绝缺失、错格式和不存在的日期', () => {
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'daily', '2028-02-31'),
+    /流日日期无效/,
+  );
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-13'),
+    /流月日期无效/,
+  );
+  assert.throws(() => buildAstrolabeScopeContext(astrolabeData, 'yearly', ''), /流年必须提供 YYYY/);
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-6'),
+    /流月必须提供 YYYY-MM/,
+  );
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'full', ''),
+    /完整输出必须提供 YYYY-MM-DD/,
+  );
 });
 
 test('星盘行运范围应支持 2100 年以后的有效年份', () => {
@@ -287,4 +305,37 @@ test('星盘资料缺少宫头经度时应禁止行运落宫证据', () => {
 
   assert.match(context.promptText, /行运落宫：本命宫头资料不足/);
   assert.doesNotThrow(() => buildAstrolabeScopeContext(incompleteData, 'daily', '2028-06-12'));
+});
+
+test('星盘行运应使用目标日期的出生地时区而不是固定北京时间', () => {
+  const newYorkData = generateAstrolabe({
+    name: '本人',
+    gender: '女',
+    year: '1995',
+    month: '5',
+    day: '20',
+    hour: '12',
+    minute: '30',
+    latitude: '40.7128',
+    longitude: '-74.0060',
+    timeZoneId: 'America/New_York',
+    locationName: '纽约',
+  });
+  const context = buildAstrolabeScopeContext(newYorkData, 'daily', '2028-07-12');
+
+  assert.match(context.promptText, /America\/New_York（UTC-4）/);
+  assert.match(context.promptText, /行运落宫：取样时区UTC-4/);
+  assert.doesNotMatch(context.promptText, /按北京时间|取样时区UTC\+8/);
+});
+
+test('星盘行运缺少真实经纬度时不得静默使用零度坐标', () => {
+  const incompleteData = structuredClone(astrolabeData) as AstrolabeData;
+  delete incompleteData.birth.latitude;
+  delete incompleteData.birth.longitude;
+  incompleteData.birth.location = '未知地点';
+
+  assert.throws(
+    () => buildAstrolabeScopeContext(incompleteData, 'daily', '2028-06-12'),
+    /缺少有效出生地经纬度/,
+  );
 });

--- a/tests/bazi-ai-prompt.test.ts
+++ b/tests/bazi-ai-prompt.test.ts
@@ -229,8 +229,8 @@ test('八字提示词未选择年限时输出本命资料且不输出岁运重�
   assert.match(prompt.user, /分析对象：本命盘/);
   assert.match(prompt.user, /大运总览:/);
   assert.match(prompt.user, /\d+\. .+：?\d{4}年起，约\d+岁交运，含\d{4}-\d{4}年流年/);
-  assert.match(prompt.user, /当前大运:|当前阶段:/);
-  assert.match(prompt.user, /近年流年:/);
+  assert.doesNotMatch(prompt.user, /当前大运:|当前阶段:|近年流年:|【当前流年】/);
+  assert.doesNotMatch(prompt.user, /【当前时间】/);
   assert.doesNotMatch(prompt.user, /【岁运重点】/);
   assert.doesNotMatch(prompt.user, /【解读方法】/);
   assert.doesNotMatch(prompt.user, /资料说明：|本次未指定|不得自行指定/);

--- a/tests/bazi-ai-prompt.test.ts
+++ b/tests/bazi-ai-prompt.test.ts
@@ -119,6 +119,7 @@ test('八字提示词写入年限选择后应保留岁运资料并省略控制�
   const fortuneContext = buildFortuneSelectionContext(result, {
     scope: 'year',
     cycleIndex: 0,
+    year: 1990,
   });
 
   assert.ok(fortuneContext);

--- a/tests/core-new-systems.test.ts
+++ b/tests/core-new-systems.test.ts
@@ -855,7 +855,15 @@ test('taiyi: 核心年份边界不应把公元 1-99 年当成 1901-1999 年', ()
 
 test('qizheng: 七政四余与《七政算内篇》紫炁模型', () => {
   // 2024-06-15 12:00 北京：太阳约在寅宫，午时生 → 命宫亥(11)、命主木（亥→木）；七政7、四余4
-  const r = core.qizheng.generateQizheng({ year: 2024, month: 6, day: 15, hour: 12 });
+  const r = core.qizheng.generateQizheng({
+    year: 2024,
+    month: 6,
+    day: 15,
+    hour: 12,
+    latitude: 39.9,
+    longitude: 116.4,
+    timezone: 8,
+  });
   const qi = r.stars.filter((s) => s.kind === '七政');
   const yu = r.stars.filter((s) => s.kind === '四余');
   assert.equal(qi.length, 7);
@@ -944,8 +952,8 @@ test('qizheng: 七政四余与《七政算内篇》紫炁模型', () => {
     'celestine-true-lilith',
   );
   assert.equal(r.stars.find((star) => star.name.includes('紫炁'))?.precisionClass, '传统均速模型');
-  assert.equal(r.calculationContext.locationSource, '默认北京坐标');
-  assert.equal(r.calculationContext.timezoneSource, '默认东八区');
+  assert.equal(r.calculationContext.locationSource, '用户提供');
+  assert.equal(r.calculationContext.timezoneSource, '用户提供');
   assert.match(r.calculationContext.astronomicalTime.utcDateTime, /Z$/);
   assert.ok(r.calculationContext.astronomicalTime.julianDayUtc > 2400000);
   assert.ok(r.calculationContext.moonPhase.phaseAngleDegrees >= 0);
@@ -955,12 +963,12 @@ test('qizheng: 七政四余与《七政算内篇》紫炁模型', () => {
   assert.match(r.evidenceAnalysis.promptText, /【七政四余计算来源与证据分层】/);
   assert.equal(r.evidenceAnalysis.key, 'qizheng:evidence');
   assert.equal(r.evidenceAnalysis.status, '已计算');
-  assert.equal(r.evidenceAnalysis.calculationFact.status, '含默认值');
+  assert.equal(r.evidenceAnalysis.calculationFact.status, '输入明确');
   assert.equal(r.evidenceAnalysis.calculationFact.steps.length, 7);
   assert.strictEqual(r.evidenceAnalysis.calculationSteps, r.evidenceAnalysis.calculationFact.steps);
   assert.equal(r.evidenceAnalysis.calculationChain.length, 7);
   const qizhengStepKeys = new Set(r.evidenceAnalysis.calculationFact.steps.map((item) => item.key));
-  assert.ok(r.evidenceAnalysis.calculationFact.defaults.some((item) => item.includes('默认北京')));
+  assert.deepEqual(r.evidenceAnalysis.calculationFact.defaults, []);
   assert.ok(
     r.evidenceAnalysis.calculationFact.steps.every(
       (item) =>
@@ -990,15 +998,15 @@ test('qizheng: 七政四余与《七政算内篇》紫炁模型', () => {
   assert.deepEqual(
     r.evidenceAnalysis.counterEvidenceFacts.map((item) => [item.type, item.status]),
     [
-      ['输入完整性', '含默认值'],
+      ['输入完整性', '输入明确'],
       ['位置精度分层', '混合模型'],
       ['吊照覆盖', '有可用证据'],
     ],
   );
   assert.equal(r.evidenceAnalysis.counterSummaryFact.status, '存在需保留反证');
-  assert.equal(r.evidenceAnalysis.counterSummaryFact.factKeys.length, 2);
+  assert.equal(r.evidenceAnalysis.counterSummaryFact.factKeys.length, 1);
   assert.equal(r.evidenceAnalysis.summaryFact.key, 'qizheng:evidence-summary');
-  assert.equal(r.evidenceAnalysis.summaryFact.status, '证据链有缺口');
+  assert.equal(r.evidenceAnalysis.summaryFact.status, '证据链完整');
   assert.equal(
     r.evidenceAnalysis.summaryFact.positionSourceFactCount,
     r.evidenceAnalysis.positionSourceFacts.length,
@@ -1070,7 +1078,7 @@ test('qizheng: 七政四余与《七政算内篇》紫炁模型', () => {
   assert.doesNotMatch(r.prompt, /强度\d+%|成功率[：=]?\d|吉凶总分[：=]?\d/);
 });
 
-test('qizheng: 用户地点与默认地点必须在计算上下文中明确区分', () => {
+test('qizheng: 核心入口必须拒绝缺少出生地或时区', () => {
   const supplied = core.qizheng.generateQizheng({
     year: 2024,
     month: 6,
@@ -1086,26 +1094,40 @@ test('qizheng: 用户地点与默认地点必须在计算上下文中明确区�
   assert.equal(supplied.evidenceAnalysis.summaryFact.status, '证据链完整');
   assert.deepEqual(supplied.evidenceAnalysis.calculationFact.defaults, []);
 
-  const partial = core.qizheng.generateQizheng({
+  const base = { year: 2024, month: 6, day: 15, hour: 12 };
+  assert.throws(
+    () => core.qizheng.generateQizheng({ ...base, longitude: 121.47, timezone: 8 } as never),
+    /必须提供出生地纬度/,
+  );
+  assert.throws(
+    () => core.qizheng.generateQizheng({ ...base, latitude: 31.23, timezone: 8 } as never),
+    /必须提供出生地经度/,
+  );
+  assert.throws(
+    () =>
+      core.qizheng.generateQizheng({
+        ...base,
+        latitude: 31.23,
+        longitude: 121.47,
+      }),
+    /必须提供 timezone 或 timeZoneId/,
+  );
+  assert.throws(
+    () => core.qizheng.calculateZiqiTropicalLongitude({ ...base }),
+    /必须提供 timezone 或 timeZoneId/,
+  );
+});
+
+test('qizheng: 核心入口应拒绝不存在日期、越界时间坐标和非有限数字', () => {
+  const valid = {
     year: 2024,
     month: 6,
     day: 15,
     hour: 12,
     latitude: 31.23,
-  });
-  assert.equal(partial.calculationContext.locationSource, '部分坐标使用默认值');
-  assert.equal(partial.evidenceAnalysis.calculationFact.status, '含默认值');
-  assert.equal(partial.evidenceAnalysis.summaryFact.status, '证据链有缺口');
-  assert.ok(
-    partial.evidenceAnalysis.calculationFact.defaults.some((item) =>
-      item.includes('部分坐标使用默认值'),
-    ),
-  );
-  assert.match(partial.evidenceAnalysis.limitations.join('\n'), /部分坐标使用默认值/);
-});
-
-test('qizheng: 核心入口应拒绝不存在日期、越界时间坐标和非有限数字', () => {
-  const valid = { year: 2024, month: 6, day: 15, hour: 12 };
+    longitude: 121.47,
+    timezone: 8,
+  };
   assert.throws(() => core.qizheng.generateQizheng({ ...valid, day: 31 }), /日期需在 1-30 之间/);
   assert.throws(() => core.qizheng.generateQizheng({ ...valid, hour: 24 }), /小时需在 0-23 之间/);
   assert.throws(

--- a/tests/fortune-selection.test.ts
+++ b/tests/fortune-selection.test.ts
@@ -264,3 +264,50 @@ test('交运年份默认应归到后一步大运，而不是继续挂在童运�
   assert.equal(normalized.cycleIndex, 1);
   assert.equal(result.luckInfo.cycles[normalized.cycleIndex ?? -1]?.ganZhi, '乙亥');
 });
+
+test('核心运限选择不得把缺失字段静默替换成当前时间或第一项', () => {
+  const result = createMockResult();
+
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'dayun' }),
+    /必须提供有效的大运序号/,
+  );
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'year', cycleIndex: 0 }),
+    /必须提供属于该大运的有效流年年份/,
+  );
+  assert.throws(
+    () =>
+      normalizeFortuneSelection(result, {
+        scope: 'month',
+        cycleIndex: 0,
+        year: 2008,
+      }),
+    /必须提供有效的流月序号/,
+  );
+  assert.throws(
+    () =>
+      normalizeFortuneSelection(result, {
+        scope: 'day',
+        cycleIndex: 0,
+        year: 2008,
+        month: 1,
+      }),
+    /必须提供该节令月内的有效流日序号/,
+  );
+});
+
+test('明确流年可定位所属大运，但冲突的大运序号必须拒绝', () => {
+  const result = createMockResult();
+  const inferred = normalizeFortuneSelection(result, { scope: 'year', year: 2009 });
+
+  assert.deepEqual(inferred, {
+    scope: 'year',
+    cycleIndex: 0,
+    year: 2009,
+  });
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'year', cycleIndex: 99, year: 2009 }),
+    /必须提供有效的大运序号/,
+  );
+});

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -165,7 +165,18 @@ const toolCalls: Array<[string, Record<string, unknown>]> = [
   ['metaphysics_xuankong', { year: 2024, facingDegree: 0 }],
   ['metaphysics_zodiac', { zodiac: '鼠', year: 2024 }],
   ['metaphysics_taiyi', { year: 2004, scope: 'year' }],
-  ['metaphysics_qizheng', { year: 2024, month: 6, day: 15, hour: 12 }],
+  [
+    'metaphysics_qizheng',
+    {
+      year: 2024,
+      month: 6,
+      day: 15,
+      hour: 12,
+      latitude: 31.23,
+      longitude: 121.47,
+      timezone: 8,
+    },
+  ],
   [
     'astrolabe_synastry',
     {
@@ -292,6 +303,8 @@ const promptToolCalls: Array<[string, Record<string, unknown>, RegExp]> = [
       baziPromptTopic: 'job-change',
       ziweiPromptTopic: 'job-change',
       promptScope: 'yearly',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
     },
     /【八字排盘信息】/,
   ],
@@ -941,7 +954,7 @@ test('MCP 工具调用应同时返回 structuredContent 和文本 JSON', async (
         assert.equal(chart?.evidenceAnalysis?.aspectFacts?.length, chart?.aspects?.length);
         assert.equal(chart?.evidenceAnalysis?.key, 'qizheng:evidence');
         assert.equal(chart?.evidenceAnalysis?.status, '已计算');
-        assert.equal(chart?.evidenceAnalysis?.calculationFact?.status, '含默认值');
+        assert.equal(chart?.evidenceAnalysis?.calculationFact?.status, '输入明确');
         assert.equal(chart?.evidenceAnalysis?.calculationFact?.steps.length, 7);
         assert.deepEqual(
           chart?.evidenceAnalysis?.calculationSteps,
@@ -1032,9 +1045,9 @@ test('MCP 工具调用应同时返回 structuredContent 和文本 JSON', async (
         );
         assert.equal(chart?.evidenceAnalysis?.counterEvidenceFacts?.length, 3);
         assert.equal(chart?.evidenceAnalysis?.counterSummaryFact?.status, '存在需保留反证');
-        assert.equal(chart?.evidenceAnalysis?.counterSummaryFact?.factKeys.length, 2);
+        assert.equal(chart?.evidenceAnalysis?.counterSummaryFact?.factKeys.length, 1);
         assert.equal(chart?.evidenceAnalysis?.summaryFact?.key, 'qizheng:evidence-summary');
-        assert.equal(chart?.evidenceAnalysis?.summaryFact?.status, '证据链有缺口');
+        assert.equal(chart?.evidenceAnalysis?.summaryFact?.status, '证据链完整');
         assert.equal(
           chart?.evidenceAnalysis?.summaryFact?.positionSourceFactCount,
           chart?.evidenceAnalysis?.positionSourceFacts?.length,
@@ -2338,6 +2351,7 @@ test('MCP 西占双盘提示词应返回跨盘资料和简明任务', async () =
     assert.match(prompt, /【第一人本命盘】/);
     assert.match(prompt, /【跨盘相位】/);
     assert.match(prompt, /【跨盘落宫】/);
+    assert.doesNotMatch(prompt, /【当前时间】/);
     assert.match(prompt, /容许度/);
     assert.match(prompt, /分析互动主轴、互补点、张力点与现实触发条件/);
     assert.doesNotMatch(prompt, /不得输出|不得编造|只依据/);
@@ -3228,10 +3242,38 @@ test('MCP 八字与紫微工具应拒绝不存在的出生日期', async () => {
 test('MCP 七政四余应拒绝不存在日期和越界坐标时区', async () => {
   await withMcpClient(async (client) => {
     const invalidCalls: Array<[Record<string, unknown>, RegExp | null]> = [
-      [{ year: 2024, month: 6, day: 31, hour: 12 }, /日期需在 1-30 之间/],
-      [{ year: 2024, month: 6, day: 15, hour: 12, latitude: 91 }, null],
-      [{ year: 2024, month: 6, day: 15, hour: 12, longitude: 181 }, null],
-      [{ year: 2024, month: 6, day: 15, hour: 12, timezone: 15 }, null],
+      [
+        {
+          year: 2024,
+          month: 6,
+          day: 31,
+          hour: 12,
+          latitude: 31.23,
+          longitude: 121.47,
+          timezone: 8,
+        },
+        /日期需在 1-30 之间/,
+      ],
+      [
+        { year: 2024, month: 6, day: 15, hour: 12, latitude: 91, longitude: 121.47, timezone: 8 },
+        null,
+      ],
+      [
+        { year: 2024, month: 6, day: 15, hour: 12, latitude: 31.23, longitude: 181, timezone: 8 },
+        null,
+      ],
+      [
+        {
+          year: 2024,
+          month: 6,
+          day: 15,
+          hour: 12,
+          latitude: 31.23,
+          longitude: 121.47,
+          timezone: 15,
+        },
+        null,
+      ],
     ];
 
     for (const [args, messagePattern] of invalidCalls) {
@@ -3254,6 +3296,21 @@ test('MCP 七政、太乙和玄空不得补造缺失时间或返回替卦伪盘'
       ['metaphysics_qizheng', { year: 2024, day: 15, hour: 12 }, null],
       ['metaphysics_qizheng', { year: 2024, month: 6, hour: 12 }, null],
       ['metaphysics_qizheng', { year: 2024, month: 6, day: 15 }, null],
+      [
+        'metaphysics_qizheng',
+        { year: 2024, month: 6, day: 15, hour: 12, longitude: 121.47, timezone: 8 },
+        null,
+      ],
+      [
+        'metaphysics_qizheng',
+        { year: 2024, month: 6, day: 15, hour: 12, latitude: 31.23, timezone: 8 },
+        null,
+      ],
+      [
+        'metaphysics_qizheng',
+        { year: 2024, month: 6, day: 15, hour: 12, latitude: 31.23, longitude: 121.47 },
+        /timezone 与 timeZoneId 至少需要提供一项/,
+      ],
       ['metaphysics_taiyi', { scope: 'year' }, /年计必须提供公历年份/],
       [
         'metaphysics_taiyi',
@@ -3277,6 +3334,59 @@ test('MCP 七政、太乙和玄空不得补造缺失时间或返回替卦伪盘'
           messagePattern,
         );
       }
+    }
+  });
+});
+
+test('MCP 生肖和紫微不得用系统当前时间补齐分析目标', async () => {
+  await withMcpClient(async (client) => {
+    const zodiac = await client.callTool({
+      name: 'metaphysics_zodiac',
+      arguments: { zodiac: '马' },
+    });
+    assert.equal(zodiac.isError, true);
+    assert.match(
+      String((zodiac.structuredContent as { error?: string } | undefined)?.error),
+      /year 与 yearGanZhi 至少需要提供一项/,
+    );
+
+    const ziweiBase = {
+      gender: 'female',
+      dateType: 'solar',
+      year: '1992',
+      month: '8',
+      day: '21',
+      timeIndex: 4,
+      promptScope: 'yearly',
+    };
+    const ziweiCases: Array<[string, Record<string, unknown>, RegExp]> = [
+      ['ziwei_calculate', { ...ziweiBase, ziweiScopeTimeIndex: 4 }, /必须提供 ziweiScopeDate/],
+      [
+        'ziwei_prompt',
+        { ...ziweiBase, ziweiScopeDate: '2028-06-12', question: '事业如何？' },
+        /必须提供 ziweiScopeTimeIndex/,
+      ],
+      [
+        'bazi_ziwei_prompt',
+        {
+          ...ziweiBase,
+          year: 1992,
+          month: 8,
+          day: 21,
+          ziweiScopeTimeIndex: 4,
+          question: '事业如何？',
+        },
+        /必须提供 ziweiScopeDate/,
+      ],
+    ];
+
+    for (const [name, arguments_, messagePattern] of ziweiCases) {
+      const result = await client.callTool({ name, arguments: arguments_ });
+      assert.equal(result.isError, true, `${name} 应拒绝缺失的紫微行运目标`);
+      assert.match(
+        String((result.structuredContent as { error?: string } | undefined)?.error),
+        messagePattern,
+      );
     }
   });
 });

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -1481,6 +1481,7 @@ test('MCP 八字年限提示词应返回逐层岁运触发证据', async () => {
         promptTopic: 'career',
         baziFortuneScope: 'year',
         baziFortuneCycleIndex: 1,
+        baziFortuneYear: 1998,
       },
     });
 
@@ -1530,9 +1531,52 @@ test('MCP 八字年限提示词应返回逐层岁运触发证据', async () => {
     assert.ok(triggerEvidence?.limitationFacts?.some((item) => item.type === '层级应期边界'));
     assertEvidenceOwnerReferences(triggerEvidence);
     const prompt = String(response.structuredContent?.prompt);
-    assert.match(prompt, /【分析对象】[\s\S]*分析对象：1997年流年/);
+    assert.match(prompt, /【分析对象】[\s\S]*分析对象：1998年流年/);
     assert.match(prompt, /【岁运重点】[\s\S]*主要触发：/);
     assert.doesNotMatch(prompt, /结构化证据|计算链|证据汇总|解释限制|证据边界/);
+  });
+});
+
+test('MCP 八字和星盘年限缺少明确层级参数时应返回业务错误', async () => {
+  await withMcpClient(async (client) => {
+    const bazi = await client.callTool({
+      name: 'bazi_prompt',
+      arguments: {
+        gender: 'male',
+        year: 1990,
+        month: 5,
+        day: 15,
+        timeIndex: 1,
+        dateType: 'solar',
+        question: '请分析指定流年。',
+        baziFortuneScope: 'year',
+        baziFortuneCycleIndex: 1,
+      },
+    });
+    assert.equal(bazi.isError, true);
+    const baziText = bazi.content[0]?.type === 'text' ? bazi.content[0].text : '';
+    assert.match(baziText, /baziFortuneYear/);
+
+    const astrolabe = await client.callTool({
+      name: 'astrolabe_prompt',
+      arguments: {
+        name: '本人',
+        gender: '女',
+        year: 1995,
+        month: 5,
+        day: 20,
+        hour: 12,
+        minute: 30,
+        latitude: 39.9042,
+        longitude: 116.4074,
+        timezone: 8,
+        question: '请分析完整行运。',
+        astrolabeScope: 'full',
+      },
+    });
+    assert.equal(astrolabe.isError, true);
+    const astrolabeText = astrolabe.content[0]?.type === 'text' ? astrolabe.content[0].text : '';
+    assert.match(astrolabeText, /astrolabeScopeDate/);
   });
 });
 

--- a/tests/mcp/ziwei.test.ts
+++ b/tests/mcp/ziwei.test.ts
@@ -7,6 +7,8 @@ import {
 } from '../../src/lib/full-chart-engine/ziwei';
 import { buildSerializableZiweiResult } from '../../src/lib/public-api/prompt-builders';
 
+const TEST_ZIWEI_CONTEXT = { dateStr: '2028-06-12', hourIndex: 4 };
+
 test('紫微 MCP 返回结果应为可 JSON 序列化的纯数据', async () => {
   const input = buildZiweiChartInput({
     name: '',
@@ -20,7 +22,7 @@ test('紫微 MCP 返回结果应为可 JSON 序列化的纯数据', async () => 
     useTrueSolarTime: false,
   });
 
-  const runtime = await calculateFullZiweiChart(input);
+  const runtime = await calculateFullZiweiChart(input, TEST_ZIWEI_CONTEXT);
   const result = buildSerializableZiweiResult(runtime);
   const parsed = JSON.parse(JSON.stringify(result));
 
@@ -64,8 +66,8 @@ test('紫微合盘主题只作为关系范围，不再注入固定问题与任�
     useTrueSolarTime: false,
   });
 
-  const firstRuntime = await calculateFullZiweiChart(firstInput);
-  const secondRuntime = await calculateFullZiweiChart(secondInput);
+  const firstRuntime = await calculateFullZiweiChart(firstInput, TEST_ZIWEI_CONTEXT);
+  const secondRuntime = await calculateFullZiweiChart(secondInput, TEST_ZIWEI_CONTEXT);
 
   const cooperationPrompt = buildCombinedZiweiCompatibilityPrompt({
     primaryPayload: firstRuntime.payloadByScope.origin,
@@ -127,8 +129,8 @@ test('紫微合盘自定义问题不应额外拼接任务与输出要求', async
     useTrueSolarTime: false,
   });
 
-  const firstRuntime = await calculateFullZiweiChart(firstInput);
-  const secondRuntime = await calculateFullZiweiChart(secondInput);
+  const firstRuntime = await calculateFullZiweiChart(firstInput, TEST_ZIWEI_CONTEXT);
+  const secondRuntime = await calculateFullZiweiChart(secondInput, TEST_ZIWEI_CONTEXT);
 
   const prompt = buildCombinedZiweiCompatibilityPrompt({
     primaryPayload: firstRuntime.payloadByScope.origin,

--- a/tests/moon-phase-evidence.test.ts
+++ b/tests/moon-phase-evidence.test.ts
@@ -142,6 +142,8 @@ test('奇门和七政四余应携带月相证据且不将其解释为吉凶', ()
     day: 9,
     hour: 2,
     minute: 21,
+    latitude: 31.23,
+    longitude: 121.47,
     timezone: 8,
   });
 

--- a/tests/prompt-role-coverage.test.ts
+++ b/tests/prompt-role-coverage.test.ts
@@ -65,12 +65,12 @@ test('八宅、住宅风水、生肖、太乙、七政与玄空提示词使用�
   methods.forEach((method) => {
     const prompt = buildMetaphysicsPrompt('【排盘信息】\n测试盘面', '请解读重点。', {
       method,
-      currentTime: new Date('2026-07-16T12:00:00+08:00'),
     });
 
     assertPromptHasSingleRole(prompt, PROMPT_GUIDANCE_TEXT[method]);
     assert.match(prompt, /【问题】\n请解读重点。/);
     assert.match(prompt, /【传统判断规则】/);
     assert.match(prompt, /【传统依据】/);
+    assert.doesNotMatch(prompt, /【当前时间】/);
   });
 });

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -2,7 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { handlePublicApiRequest, isPublicApiRequestPath } from '../src/lib/public-api/handler';
 import { onRequest as handleWellKnownApiRequest } from '../functions/.well-known/[[path]]';
-import { buildZiweiChartInput, calculateFullZiweiChart } from '../src/lib/full-chart-engine/ziwei';
+import {
+  buildZiweiChartInput,
+  calculateFullZiweiChart,
+  calculateZiweiChartForScopes,
+} from '../src/lib/full-chart-engine/ziwei';
 import {
   buildBaziZiweiPromptForResults,
   buildBaziPromptForResult,
@@ -15,6 +19,8 @@ import { getTimeIndexFromClock } from 'mingyu-core/calendar';
 import { generateQimen } from 'mingyu-core/divination/qimen';
 import { assertPromptHasSingleRole, assertPromptIsPortableTaskText } from './prompt-assertions';
 import { PROMPT_GUIDANCE_TEXT as PROMPT_ROLE_TEXT } from '../src/lib/prompt-guidance';
+
+const TEST_ZIWEI_CONTEXT = { dateStr: '2028-06-12', hourIndex: 4 };
 
 async function callApi(path: string, init?: RequestInit) {
   const request = new Request(`https://aov.cc/api/v1/${path}`, init);
@@ -461,6 +467,22 @@ test('公开 API OpenAPI 文档应标明占卜提示词接口返回摘要', asyn
     body.data.components.schemas.ZiweiRequest.properties.promptScope.description,
     /full 会返回本命、大限、流年、流月、流日、流时/,
   );
+  assert.match(
+    body.data.components.schemas.ZiweiRequest.properties.ziweiScopeDate.description,
+    /选择非本命范围时必填/,
+  );
+  assert.ok(
+    body.data.components.schemas.BaziZiweiPromptRequest.allOf[1].properties.ziweiScopeTimeIndex,
+  );
+  assert.match(
+    body.data.components.schemas.MetaphysicsRequest.properties.year.description,
+    /yearGanZhi 至少提供一项/,
+  );
+  assert.match(
+    body.data.components.schemas.MetaphysicsRequest.properties.latitude.description,
+    /七政四余必填/,
+  );
+  assert.ok(body.data.components.schemas.MetaphysicsRequest.properties.timeZoneId);
   assert.equal(
     body.data.components.schemas.BaziRequest.properties.shenShaVariants.$ref,
     '#/components/schemas/ShenShaVariants',
@@ -1056,6 +1078,7 @@ test('公开 API 八字排盘支持轻量模式，避免默认拉取大流年明
   assert.equal(body.ok, true);
   assert.equal(body.data.gender, 'female');
   assert.equal(body.data.liunian, undefined);
+  assert.equal(body.data.currentLiunian, undefined);
   assert.ok(body.data.luckInfo.cycles.length > 0);
   assert.equal(body.data.luckInfo.cycles[0].years, undefined);
   assert.equal(body.data.evidenceAnalysis.key, 'bazi:natal:evidence');
@@ -1261,6 +1284,8 @@ test('公开 API 应支持八字紫微合参提示词', async () => {
       baziPromptTopic: 'job-change',
       ziweiPromptTopic: 'job-change',
       promptScope: 'yearly',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
     }),
   });
 
@@ -1302,6 +1327,7 @@ test('八字紫微合参提示词自定义模式不额外拼接任务框架', as
       isLeapMonth: false,
       useTrueSolarTime: false,
     }),
+    TEST_ZIWEI_CONTEXT,
   );
 
   const prompt = buildBaziZiweiPromptForResults({
@@ -1663,6 +1689,8 @@ test('公开 API 紫微提示词接口只生成所需范围，避免线上函数
       question: '今年适合换工作吗？',
       promptTopic: 'job-change',
       promptScope: 'yearly',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
     }),
   });
 
@@ -1698,6 +1726,8 @@ test('公开 API 紫微提示词支持完整输出版范围', async () => {
       question: '整体人生和近期重点怎么看？',
       promptTopic: 'life',
       promptScope: 'full',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
     }),
   });
 
@@ -1754,6 +1784,7 @@ test('紫微公开 API prompt builder 空问题走通用问题，主题只作为
       isLeapMonth: false,
       useTrueSolarTime: false,
     }),
+    TEST_ZIWEI_CONTEXT,
   );
 
   const prompt = buildZiweiPromptForRuntime({
@@ -1782,6 +1813,7 @@ test('紫微公开 API 工作变动主题只切换范围，不补固定问题', 
       isLeapMonth: false,
       useTrueSolarTime: false,
     }),
+    TEST_ZIWEI_CONTEXT,
   );
 
   const prompt = buildZiweiPromptForRuntime({
@@ -1902,6 +1934,8 @@ test('公开 API 紫微排盘接口支持按需返回指定范围', async () => 
       day: '21',
       timeIndex: 4,
       promptScope: 'monthly',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
     }),
   });
 
@@ -1958,6 +1992,70 @@ test('公开 API 紫微排盘接口支持按需返回指定范围', async () => 
   assertEvidenceOwnerReferences(patternAnalysis);
 });
 
+test('公开 API 紫微非本命范围必须提供明确目标日期和时辰', async () => {
+  const base = {
+    gender: 'female',
+    dateType: 'solar',
+    year: '1992',
+    month: '8',
+    day: '21',
+    timeIndex: 4,
+    promptScope: 'yearly',
+  };
+  const cases = [
+    ['ziwei/calculate', { ...base, ziweiScopeTimeIndex: 4 }, /ziweiScopeDate/],
+    [
+      'ziwei/prompt',
+      { ...base, ziweiScopeDate: '2028-06-12', question: '事业如何？' },
+      /ziweiScopeTimeIndex/,
+    ],
+    [
+      'bazi-ziwei/prompt',
+      {
+        ...base,
+        year: 1992,
+        month: 8,
+        day: 21,
+        ziweiScopeTimeIndex: 4,
+        question: '事业如何？',
+      },
+      /ziweiScopeDate/,
+    ],
+  ] as const;
+
+  for (const [path, payload, messagePattern] of cases) {
+    const { response, body } = await callApi(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 400, path);
+    assert.equal(body.error.code, 'BAD_REQUEST', path);
+    assert.match(body.error.message, messagePattern, path);
+  }
+});
+
+test('紫微核心入口的本命范围使用确定上下文，非本命范围拒绝隐式当前时间', async () => {
+  const input = buildZiweiChartInput({
+    name: '测试',
+    gender: 'female',
+    dateType: 'solar',
+    year: '1992',
+    month: '8',
+    day: '21',
+    timeIndex: 4,
+    isLeapMonth: false,
+    useTrueSolarTime: false,
+  });
+
+  const origin = await calculateZiweiChartForScopes(input, ['origin']);
+  assert.equal(origin.payloadByScope.origin.active_scope.solar_date, '1992-08-21');
+  await assert.rejects(
+    calculateZiweiChartForScopes(input, ['yearly']),
+    /紫微非本命计算必须明确提供目标日期和时辰/,
+  );
+});
+
 test('公开 API 紫微排盘支持轻量模式，减少默认响应体积', async () => {
   const { response, body } = await callApi('ziwei/calculate', {
     method: 'POST',
@@ -1971,6 +2069,8 @@ test('公开 API 紫微排盘支持轻量模式，减少默认响应体积', asy
       day: '21',
       timeIndex: 4,
       promptScope: 'monthly',
+      ziweiScopeDate: '2028-06-12',
+      ziweiScopeTimeIndex: 4,
       detailMode: 'compact',
     }),
   });
@@ -2040,7 +2140,11 @@ test('公开 API 紫微排盘应提供 agent 易解析的四化和宫位列表',
     opposite_palace_index: number;
     surrounded_palace_indexes: number[];
   }>;
-  const fullRuntime = await calculateFullZiweiChart(buildZiweiChartInput(ziweiInput), true);
+  const fullRuntime = await calculateFullZiweiChart(
+    buildZiweiChartInput(ziweiInput),
+    TEST_ZIWEI_CONTEXT,
+    true,
+  );
   const fullPalaces = fullRuntime.payloadByScope.origin.palaces;
 
   assert.equal(publicPalaces.length, fullPalaces.length);
@@ -3881,6 +3985,7 @@ test('公开 API 西占双盘提示词应携带双方本命盘与简明任务', 
   assert.match(body.data.prompt, /【跨盘相位】/);
   assert.match(body.data.prompt, /实际夹角\d+\.\d{2}°，容许度\d+\.\d{2}°，(?:紧密|中等|宽松)/);
   assert.match(body.data.prompt, /【跨盘落宫】/);
+  assert.doesNotMatch(body.data.prompt, /【当前时间】/);
   assert.doesNotMatch(body.data.prompt, /强度\d+%|匹配率\d+%/);
   assert.match(body.data.prompt, /分析互动主轴、互补点、张力点与现实触发条件/);
   assert.doesNotMatch(body.data.prompt, /不得输出|不得编造|只依据/);
@@ -4889,7 +4994,7 @@ test('公开 API 新增术数提示词应包含用户问题和统一章节', asy
   assert.match(body.data.prompt, /【八宅风水排盘】/);
   assert.match(body.data.prompt, /【测量换算】/);
   assert.match(body.data.prompt, /误差候选：/);
-  assert.match(body.data.prompt, /【当前时间】/);
+  assert.doesNotMatch(body.data.prompt, /【当前时间】/);
   assert.match(body.data.prompt, /【问题】\n住宅办公方位怎么安排？/);
   assert.match(body.data.prompt, /【任务】/);
   assert.match(body.data.prompt, /【输出要求】/);
@@ -5041,6 +5146,8 @@ test('公开 API 七政四余应只返回《七政算内篇》紫炁模型与完
       month: 12,
       day: 31,
       hour: 8,
+      latitude: 39.9,
+      longitude: 116.4,
       timezone: 8,
     }),
   });
@@ -5053,7 +5160,7 @@ test('公开 API 七政四余应只返回《七政算内篇》紫炁模型与完
   assert.ok(Math.abs(body.data.ziqi.tropicalLongitude - 237.038993) < 1e-9);
   assert.equal(body.data.stars.filter((star: { kind: string }) => star.kind === '四余').length, 4);
   assert.equal(body.data.positionSources.length, 4);
-  assert.equal(body.data.calculationContext.locationSource, '默认北京坐标');
+  assert.equal(body.data.calculationContext.locationSource, '用户提供');
   assert.equal(body.data.calculationContext.timezoneSource, '用户提供');
   assert.match(body.data.calculationContext.astronomicalTime.utcDateTime, /Z$/);
   assert.ok(body.data.calculationContext.astronomicalTime.julianDayTtApprox > 2400000);
@@ -5104,7 +5211,7 @@ test('公开 API 七政四余应只返回《七政算内篇》紫炁模型与完
   assert.match(body.data.evidenceAnalysis.promptText, /【七政四余计算来源与证据分层】/);
   assert.equal(body.data.evidenceAnalysis.key, 'qizheng:evidence');
   assert.equal(body.data.evidenceAnalysis.status, '已计算');
-  assert.equal(body.data.evidenceAnalysis.calculationFact.status, '含默认值');
+  assert.equal(body.data.evidenceAnalysis.calculationFact.status, '输入明确');
   assert.equal(body.data.evidenceAnalysis.calculationFact.steps.length, 7);
   assert.deepEqual(
     body.data.evidenceAnalysis.calculationSteps,
@@ -5147,9 +5254,9 @@ test('公开 API 七政四余应只返回《七政算内篇》紫炁模型与完
   assert.equal(body.data.evidenceAnalysis.aspectFacts.length, body.data.aspects.length);
   assert.equal(body.data.evidenceAnalysis.counterEvidenceFacts.length, 3);
   assert.equal(body.data.evidenceAnalysis.counterSummaryFact.status, '存在需保留反证');
-  assert.equal(body.data.evidenceAnalysis.counterSummaryFact.factKeys.length, 2);
+  assert.equal(body.data.evidenceAnalysis.counterSummaryFact.factKeys.length, 1);
   assert.equal(body.data.evidenceAnalysis.summaryFact.key, 'qizheng:evidence-summary');
-  assert.equal(body.data.evidenceAnalysis.summaryFact.status, '证据链有缺口');
+  assert.equal(body.data.evidenceAnalysis.summaryFact.status, '证据链完整');
   assert.equal(
     body.data.evidenceAnalysis.summaryFact.positionSourceFactCount,
     body.data.evidenceAnalysis.positionSourceFacts.length,
@@ -5229,6 +5336,9 @@ test('公开 API 七政四余提示词应展示逐星来源、混合模型和输
       month: 6,
       day: 15,
       hour: 12,
+      latitude: 31.23,
+      longitude: 121.47,
+      timezone: 8,
       question: '请分析本命结构。',
       responseMode: 'full',
     }),
@@ -5240,7 +5350,8 @@ test('公开 API 七政四余提示词应展示逐星来源、混合模型和输
   assert.match(body.data.prompt, /【七政四余 · 果老星宗】/);
   assert.match(body.data.prompt, /计算上下文：/);
   assert.match(body.data.prompt, /位置来源：/);
-  assert.match(body.data.prompt, /地点来源默认北京坐标/);
+  assert.match(body.data.prompt, /地点来源输入明确，时区来源输入明确/);
+  assert.doesNotMatch(body.data.prompt, /【当前时间】/);
   assert.match(body.data.prompt, /现代天文计算/);
   assert.match(body.data.prompt, /传统均速模型/);
   assert.match(body.data.prompt, /混合模型/);
@@ -5249,7 +5360,7 @@ test('公开 API 七政四余提示词应展示逐星来源、混合模型和输
   body.data.result.aspects.forEach((aspect: { strength?: number }) => {
     assert.equal(aspect.strength, undefined);
   });
-  assert.equal(body.data.result.calculationContext.locationSource, '默认北京坐标');
+  assert.equal(body.data.result.calculationContext.locationSource, '用户提供');
 });
 
 test('公开 API 太乙应返回年计七十二局立成结果', async () => {
@@ -5419,6 +5530,7 @@ test('公开 API 新增术数应拒绝缺失组合和无效日期坐标', async 
     ['metaphysics/bazhai/calculate', { birthYear: 1990 }],
     ['metaphysics/bazhai/calculate', { mingGua: '未知卦' }],
     ['metaphysics/bazhai/calculate', { mingGua: '坎', sitMountain: '未知山' }],
+    ['metaphysics/zodiac/calculate', { zodiac: '猴' }],
     ['metaphysics/zodiac/calculate', { zodiac: '猴', yearGanZhi: '甲丑' }],
     ['metaphysics/taiyi/calculate', { scope: 'year' }],
     ['metaphysics/taiyi/calculate', { year: 2004, scope: 'month' }],
@@ -5428,9 +5540,54 @@ test('公开 API 新增术数应拒绝缺失组合和无效日期坐标', async 
     ['metaphysics/qizheng/calculate', { year: 2026, day: 1, hour: 12 }],
     ['metaphysics/qizheng/calculate', { year: 2026, month: 1, hour: 12 }],
     ['metaphysics/qizheng/calculate', { year: 2026, month: 1, day: 1 }],
-    ['metaphysics/qizheng/calculate', { year: 2026, month: 2, day: 30, hour: 12 }],
-    ['metaphysics/qizheng/calculate', { year: 2026, month: 1, day: 1, hour: 12, latitude: 120 }],
-    ['metaphysics/qizheng/calculate', { year: 2026, month: 1, day: 1, hour: 12, timezone: 15 }],
+    [
+      'metaphysics/qizheng/calculate',
+      { year: 2026, month: 1, day: 1, hour: 12, longitude: 121.47, timezone: 8 },
+    ],
+    [
+      'metaphysics/qizheng/calculate',
+      { year: 2026, month: 1, day: 1, hour: 12, latitude: 31.23, timezone: 8 },
+    ],
+    [
+      'metaphysics/qizheng/calculate',
+      { year: 2026, month: 1, day: 1, hour: 12, latitude: 31.23, longitude: 121.47 },
+    ],
+    [
+      'metaphysics/qizheng/calculate',
+      {
+        year: 2026,
+        month: 2,
+        day: 30,
+        hour: 12,
+        latitude: 31.23,
+        longitude: 121.47,
+        timezone: 8,
+      },
+    ],
+    [
+      'metaphysics/qizheng/calculate',
+      {
+        year: 2026,
+        month: 1,
+        day: 1,
+        hour: 12,
+        latitude: 120,
+        longitude: 121.47,
+        timezone: 8,
+      },
+    ],
+    [
+      'metaphysics/qizheng/calculate',
+      {
+        year: 2026,
+        month: 1,
+        day: 1,
+        hour: 12,
+        latitude: 31.23,
+        longitude: 121.47,
+        timezone: 15,
+      },
+    ],
     ['metaphysics/xuankong/calculate', { sitMountain: '子' }],
   ] as const;
 

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -1444,6 +1444,7 @@ test('公开 API 八字年限提示词保留岁运资料但不拼接工程证据
       promptTopic: 'career',
       baziFortuneScope: 'year',
       baziFortuneCycleIndex: 1,
+      baziFortuneYear: 1998,
     }),
   });
 
@@ -3002,6 +3003,39 @@ test('公开 API 奇门默认转盘，可通过 qimenMethod 请求飞盘', async
   );
 });
 
+test('公开 API 八字年限范围缺少必要层级参数时应拒绝而非套用第一项', async () => {
+  const base = {
+    gender: 'male',
+    year: 1990,
+    month: 5,
+    day: 15,
+    timeIndex: 1,
+    dateType: 'solar',
+    question: '请分析指定年限。',
+  };
+  const cases = [
+    { ...base, baziFortuneScope: 'dayun' },
+    { ...base, baziFortuneScope: 'year', baziFortuneCycleIndex: 1 },
+    { ...base, baziFortuneScope: 'month', baziFortuneYear: 1998 },
+    {
+      ...base,
+      baziFortuneScope: 'day',
+      baziFortuneYear: 1998,
+      baziFortuneMonth: 1,
+    },
+  ];
+
+  for (const payload of cases) {
+    const { response, body } = await callApi('bazi/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 400, JSON.stringify(payload));
+    assert.equal(body.error.code, 'BAD_REQUEST');
+  }
+});
+
 test('公开 API 奇门排盘支持轻量模式，便于调用方按需拆分请求', async () => {
   const customDate = '2025-01-01T08:00:00+08:00';
   const fullResult = await callApi('divination/qimen', {
@@ -3630,6 +3664,7 @@ test('公开 API 星盘提示词支持完整输出版行运资料', async () => 
       question: '整体人生和近期重点怎么看？',
       astrolabeTopic: 'life',
       astrolabeScope: 'full',
+      astrolabeScopeDate: '2028-06-12',
       responseMode: 'prompt-only',
     }),
   });
@@ -3696,6 +3731,38 @@ test('公开 API 星盘提示词支持完整输出版行运资料', async () => 
       ),
     );
     assert.match(evidence.promptText, /证据汇总：/);
+  }
+});
+
+test('公开 API 星盘非本命范围必须提供匹配范围的明确日期', async () => {
+  const base = {
+    name: '本人',
+    gender: '女',
+    year: 1995,
+    month: 5,
+    day: 20,
+    hour: 12,
+    minute: 30,
+    latitude: 39.9042,
+    longitude: 116.4074,
+    timezone: 8,
+    question: '请分析指定行运。',
+  };
+  const cases = [
+    { ...base, astrolabeScope: 'full' },
+    { ...base, astrolabeScope: 'yearly', astrolabeScopeDate: '2028-06' },
+    { ...base, astrolabeScope: 'monthly', astrolabeScopeDate: '2028-13' },
+    { ...base, astrolabeScope: 'daily', astrolabeScopeDate: '2028-02-31' },
+  ];
+
+  for (const payload of cases) {
+    const { response, body } = await callApi('divination/astrolabe/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 400, JSON.stringify(payload));
+    assert.equal(body.error.code, 'BAD_REQUEST');
   }
 });
 

--- a/tests/query-state-defaults.test.ts
+++ b/tests/query-state-defaults.test.ts
@@ -467,20 +467,20 @@ test('星盘提示词指定年限日期会写入并从地址栏恢复', () => {
   assert.equal(parsed.astrolabeScopeDate, '2028-06');
 });
 
-test('星盘提示词完整输出版会写入并清空日期', () => {
+test('星盘提示词完整输出版会写入并恢复明确基准日', () => {
   const search = buildResultSearch(defaultInputState, {
     ...defaultPromptState,
     promptSource: 'astrolabe',
     astrolabeScope: 'full',
-    astrolabeScopeDate: '2028-06',
+    astrolabeScopeDate: '2028-06-12',
   });
 
   assert.match(search, /as=full/);
-  assert.doesNotMatch(search, /asd=2028-06/);
+  assert.match(search, /asd=2028-06-12/);
 
   const parsed = parsePromptState(new URLSearchParams(search));
   assert.equal(parsed.astrolabeScope, 'full');
-  assert.equal(parsed.astrolabeScopeDate, '');
+  assert.equal(parsed.astrolabeScopeDate, '2028-06-12');
 });
 
 test('七政四余和八宅提示词来源可从地址栏恢复', () => {
@@ -551,7 +551,15 @@ test('星盘提示词范围日期应按范围校验并清空非法日期', () =>
       }),
     );
 
-    assert.equal(parsed.astrolabeScope, scope);
+    assert.equal(parsed.astrolabeScope, 'natal');
+    assert.equal(parsed.astrolabeScopeDate, '');
+  }
+});
+
+test('星盘非本命范围缺少日期时应整体回到本命而不是等待核心补当前日期', () => {
+  for (const scope of ['full', 'yearly', 'monthly', 'daily'] as const) {
+    const parsed = parsePromptState(new URLSearchParams({ astrolabeScope: scope }));
+    assert.equal(parsed.astrolabeScope, 'natal');
     assert.equal(parsed.astrolabeScopeDate, '');
   }
 });

--- a/tests/result-page-helpers.test.ts
+++ b/tests/result-page-helpers.test.ts
@@ -26,6 +26,8 @@ import type { AnalysisPayloadV1 } from '../src/types/analysis';
 import { PROMPT_GUIDANCE_TEXT as PROMPT_ROLE_TEXT } from '../src/lib/prompt-guidance';
 import { assertPromptHasSingleRole } from './prompt-assertions';
 
+const TEST_ZIWEI_CONTEXT = { dateStr: '2028-06-12', hourIndex: 4 };
+
 test('parseZiweiDateParts 正确解析合法日期', () => {
   assert.deepEqual(parseZiweiDateParts('2024-05-13'), { year: 2024, month: 5, day: 13 });
   assert.deepEqual(parseZiweiDateParts('1990-12-01'), { year: 1990, month: 12, day: 1 });
@@ -253,6 +255,7 @@ test('单人增强提示词会保留 section 结构并强调双体系交叉校�
       isLeapMonth: false,
       useTrueSolarTime: false,
     }),
+    TEST_ZIWEI_CONTEXT,
   );
 
   const prompt = buildBaziZiweiEnhancedPrompt({
@@ -265,7 +268,7 @@ test('单人增强提示词会保留 section 结构并强调双体系交叉校�
   });
 
   assertPromptHasSingleRole(prompt, PROMPT_ROLE_TEXT['bazi-ziwei']);
-  assert.match(prompt, /【当前时间】/);
+  assert.doesNotMatch(prompt, /【当前时间】/);
   assert.match(prompt, /【分析对象】\n八字分析对象：当前大运\n紫微分析范围：流年 · 2028-01-01/);
   assert.match(prompt, /【八字排盘信息】/);
   assert.match(prompt, /【紫微盘面信息】/);
@@ -329,6 +332,7 @@ test('紫微完整输出版会整理本命与各层运限资料', async () => {
       isLeapMonth: false,
       useTrueSolarTime: false,
     }),
+    TEST_ZIWEI_CONTEXT,
   );
 
   const text = formatZiweiFullScopeText(ziweiRuntime.payloadByScope);

--- a/tests/ziwei-prompt-snapshot.test.ts
+++ b/tests/ziwei-prompt-snapshot.test.ts
@@ -9,10 +9,7 @@ import { buildEvidenceAnalysis, buildEvidencePool, buildPatternAnalysis } from '
 import { buildEvidenceSummary, buildPalaceSummary } from '../src/lib/ziwei-prompts/builders';
 import { buildZiweiReadableSnapshot } from '../src/lib/ziwei-prompts/snapshot';
 import type { PromptContext } from '../src/lib/ziwei-prompts/types';
-import {
-  assertPromptCurrentTimeHasGanzhiCalendar,
-  assertPromptHasSingleRole,
-} from './prompt-assertions';
+import { assertPromptHasSingleRole } from './prompt-assertions';
 import type { AnalysisPayloadV1, PalaceFact } from '../src/types/analysis';
 import { PROMPT_GUIDANCE_TEXT as PROMPT_ROLE_TEXT } from '../src/lib/prompt-guidance';
 
@@ -345,7 +342,7 @@ test('紫微运限提示词应保留分析对象和简短任务', () => {
 
   assert.match(prompt, /【本命资料】/);
   assert.match(prompt, /【分析对象】/);
-  assertPromptCurrentTimeHasGanzhiCalendar(prompt);
+  assert.doesNotMatch(prompt, /【当前时间】/);
   assert.match(prompt, /【运限重点】/);
   assert.doesNotMatch(prompt, /【运限资料】/);
   assert.doesNotMatch(prompt, /【十二宫资料】/);


### PR DESCRIPTION
## 目标

对公开算法做一次全局一致性审查，确保核心包、公开 API、MCP、前端调用、能力目录、文档与测试采用同一输入契约；移除命盘、行运和环境类算法中缺参时自动读取系统当前时间、选择第一项、使用固定北京时间、默认北京坐标或零度坐标的隐式兜底。

## 审查范围

已按算法家族复核公开入口及直接证据：

- 公共地基：能力目录、干支、五行、方位、神煞
- 历法天文：真太阳时、出生时间校正、太阳光照、天文时间、月相、节气
- 命盘：八字、八字合盘、紫微、紫微合盘、八字紫微合参、西占本命与双盘
- 即时占卜：六爻、梅花、小六壬、金口诀、奇门、大六壬、塔罗、灵签、雷诺曼
- 择日：黄历择日
- 环境与专项术数：八宅、住宅风水、玄空、生肖、太乙、七政四余

核对位置包括核心导出与能力目录、API 路由与 OpenAPI、MCP 工具、公开文档与 Skill、主回归和 MCP 回归测试。

## 主要修改

- 八字大运、流年、流月、流日要求明确层级参数；提示词和轻量 API 结果不再自动选择当前大运、当前流年或近年流年。
- 紫微本命范围在没有行运上下文时使用出生盘自身的确定性日期和时辰；`full`、大限、流年、流月、流日、流时、年龄等非本命范围必须提供 `ziweiScopeDate` 与 `ziweiScopeTimeIndex`。
- 星盘流年、流月、流日及完整输出要求明确日期，并使用出生地经纬度和目标日期对应的时区。
- 七政四余必须提供真实 `latitude`、`longitude`，并在 `timezone` 与 `timeZoneId` 中至少提供一项；紫炁独立核心入口同样不再默认东八区。
- 生肖必须提供 `year` 或 `yearGanZhi`，不再默认系统当前年份。
- 命盘、合盘、行运与环境类提示词不再插入系统“当前时间”；即时占卜仍保留明确的起盘当下时间契约。
- 页面主线程与 Worker 显式传递紫微行运上下文；核心、API、MCP、OpenAPI、能力目录、文档、公开 Skill 与测试同步更新。
- 公开 Skill 中太乙能力说明同步为年、月、日、时、分五计。

## 验证

- `pnpm test`：1433 项全部通过
- `pnpm test:e2e`：39 项全部通过
- `pnpm exec tsc -p tsconfig.app.json --noEmit`：通过
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm exec tsc -p mcp/tsconfig.json --noEmit`：通过
- `pnpm lint`：通过
- `pnpm build`：通过
- `git diff --check`：通过
- 本次改动文件 Prettier 检查：通过
- 公开 API Skill 校验：通过
- `pnpm prompt:audit`：通过
- `pnpm format:check` 仍只被三个本次未修改的历史文件阻挡：`tests/bazi-natal-evidence.test.ts`、`tests/divination-prompt-structure.test.ts`、`tests/paipan-boundary.test.ts`

## 兼容风险

此前省略年限、紫微行运目标、星盘行运日期、七政时空参数或生肖年份的 API/MCP/核心调用，会从隐式默认改为 400 或明确业务错误，需要调用方补充真实参数。旧页面链接中的无效星盘范围会安全回退为本命范围。

本 PR 当前仅供审查，尚未合并到正式版本。
