### PR TITLE
修正梅花易数爻序与互卦计算

### DIFF
--- a/packages/core/src/divination/algorithms/meihua/index.ts
+++ b/packages/core/src/divination/algorithms/meihua/index.ts
@@ -163,25 +163,18 @@ export function generateMeihua(customDate?: Date, settings?: MeihuaSettings): Me
   }
   const mainHexagram = findHexagramByTrigrams(upperTrigramIndex, lowerTrigramIndex);
 
-  const toBottomUpLines = (lines: number[]) => [...lines].reverse();
-  const toStoredLines = (bottomUpLines: number[]) => [...bottomUpLines].reverse();
-
-  const mainLines = [
-    ...toBottomUpLines(lowerTrigram.lines),
-    ...toBottomUpLines(upperTrigram.lines),
-  ];
+  const mainLines = [...lowerTrigram.lines, ...upperTrigram.lines];
 
   const interLowerLines = mainLines.slice(1, 4);
   const interUpperLines = mainLines.slice(2, 5);
 
   const findTrigramByBottomUpLines = (lines: number[]) => {
-    const storedLines = toStoredLines(lines);
     for (let i = 1; i <= 8; i++) {
       const trigram = trigrams[i];
-      if (trigram && trigram.lines.length === storedLines.length) {
+      if (trigram && trigram.lines.length === lines.length) {
         let match = true;
-        for (let j = 0; j < storedLines.length; j++) {
-          if (trigram.lines[j] !== storedLines[j]) {
+        for (let j = 0; j < lines.length; j++) {
+          if (trigram.lines[j] !== lines[j]) {
             match = false;
             break;
           }

--- a/packages/core/src/divination/hexagram-data.ts
+++ b/packages/core/src/divination/hexagram-data.ts
@@ -22,7 +22,7 @@ export interface TrigramData {
   symbol: string; // 八卦符号
   nature: string; // 自然属性
   element: string; // 五行属性
-  lines: number[]; // 爻线数组，1 为阳爻，0 为阴爻
+  lines: number[]; // 自下而上（初爻至三爻）的爻线数组，1 为阳爻，0 为阴爻
 }
 
 // 八卦数据（字符串键格式，用于二进制查找）

--- a/tests/meihua-algorithm.test.ts
+++ b/tests/meihua-algorithm.test.ts
@@ -45,9 +45,34 @@ test('梅花：变卦应按初爻到上爻的传统爻位计算', () => {
 test('梅花：互卦应取二三四爻为下互、三四五爻为上互', () => {
   const data = generateMeihua(SAMPLE_DATE, { method: 'number', number: 123 });
 
-  assert.equal(data.interName, '水山蹇');
+  assert.equal(data.interName, '水雷屯');
   assert.equal(data.interHexagram?.upper, '坎');
-  assert.equal(data.interHexagram?.lower, '艮');
+  assert.equal(data.interHexagram?.lower, '震');
+});
+
+test('梅花：天泽履应按自下而上的爻序生成互卦和变卦', () => {
+  const data = generateMeihua(new Date('2026-07-25T23:30:00+08:00'), { method: 'time' });
+
+  assert.deepEqual(data.ganzhi, {
+    year: '丙午',
+    month: '乙未',
+    day: '辛丑',
+    hour: '戊子',
+  });
+  assert.equal(data.originalName, '天泽履');
+  assert.equal(data.movingYao.position, 2);
+  assert.deepEqual(
+    data.yaosDetail.map((yao) => yao.yaoType),
+    ['阳', '阳', '阴', '阳', '阳', '阳'],
+  );
+  assert.equal(data.interName, '风火家人');
+  assert.equal(data.interHexagram?.upper, '巽');
+  assert.equal(data.interHexagram?.lower, '离');
+  assert.equal(data.changedName, '天山遁');
+  assert.equal(data.changedHexagram?.upper, '乾');
+  assert.equal(data.changedHexagram?.lower, '艮');
+  assert.equal(data.analysis.tiSeasonState, '相');
+  assert.equal(data.analysis.yongSeasonState, '相');
 });
 
 test('梅花：数字起卦生成的主互变三卦与动爻资料必须始终完整', () => {
@@ -137,7 +162,7 @@ test('梅花：年月日时起卦应以农历年支入数，不应在立春后�
   assert.equal(data.calculation.lowerTrigramIndex, 1);
   assert.equal(data.calculation.movingYaoIndex, 1);
   assert.equal(data.originalName, '泽天夬');
-  assert.equal(data.changedName, '兑为泽');
+  assert.equal(data.changedName, '泽风大过');
 });
 
 test('梅花：未知起卦方式应明确报错，不应静默退回时间卦', () => {

--- a/tests/meihua-algorithm.test.ts
+++ b/tests/meihua-algorithm.test.ts
@@ -15,6 +15,25 @@ import { MeihuaHelpers } from '../packages/core/src/divination/divination-helper
 
 const SAMPLE_DATE = new Date('2025-01-01T08:00:00+08:00');
 
+const TRIGRAM_LINES_BOTTOM_UP: Record<string, number[]> = {
+  乾: [1, 1, 1],
+  兑: [1, 1, 0],
+  离: [1, 0, 1],
+  震: [0, 0, 1],
+  巽: [0, 1, 1],
+  坎: [0, 1, 0],
+  艮: [1, 0, 0],
+  坤: [0, 0, 0],
+};
+
+const TRIGRAM_BY_BOTTOM_UP_LINES = new Map(
+  Object.entries(TRIGRAM_LINES_BOTTOM_UP).map(([name, lines]) => [lines.join(''), name]),
+);
+
+function replaySampleForIndex(index: number, total: number): number {
+  return (index - 0.5) / total;
+}
+
 test('梅花：变卦应按初爻到上爻的传统爻位计算', () => {
   const data = generateMeihua(SAMPLE_DATE, { method: 'number', number: 123 });
 
@@ -73,6 +92,51 @@ test('梅花：天泽履应按自下而上的爻序生成互卦和变卦', () =>
   assert.equal(data.changedHexagram?.lower, '艮');
   assert.equal(data.analysis.tiSeasonState, '相');
   assert.equal(data.analysis.yongSeasonState, '相');
+});
+
+test('梅花：八八六共三百八十四种主卦动爻组合应保持爻序、互卦和变卦一致', () => {
+  for (let upperIndex = 1; upperIndex <= 8; upperIndex += 1) {
+    for (let lowerIndex = 1; lowerIndex <= 8; lowerIndex += 1) {
+      for (let movingYaoIndex = 1; movingYaoIndex <= 6; movingYaoIndex += 1) {
+        const data = generateMeihua(SAMPLE_DATE, {
+          method: 'random',
+          replay: [
+            replaySampleForIndex(upperIndex, 8),
+            replaySampleForIndex(lowerIndex, 8),
+            replaySampleForIndex(movingYaoIndex, 6),
+          ],
+        });
+        const mainLines = [
+          ...TRIGRAM_LINES_BOTTOM_UP[data.mainHexagram.lower],
+          ...TRIGRAM_LINES_BOTTOM_UP[data.mainHexagram.upper],
+        ];
+        const expectedInterLower = TRIGRAM_BY_BOTTOM_UP_LINES.get(mainLines.slice(1, 4).join(''));
+        const expectedInterUpper = TRIGRAM_BY_BOTTOM_UP_LINES.get(mainLines.slice(2, 5).join(''));
+        const changedLines = [...mainLines];
+        changedLines[movingYaoIndex - 1] = 1 - changedLines[movingYaoIndex - 1];
+        const expectedChangedLower = TRIGRAM_BY_BOTTOM_UP_LINES.get(
+          changedLines.slice(0, 3).join(''),
+        );
+        const expectedChangedUpper = TRIGRAM_BY_BOTTOM_UP_LINES.get(
+          changedLines.slice(3, 6).join(''),
+        );
+        const label = `${data.originalName}第${movingYaoIndex}爻`;
+
+        assert.deepEqual(
+          data.yaosDetail.map((yao) => (yao.yaoType === '阳' ? 1 : 0)),
+          mainLines,
+          `${label}主卦爻序`,
+        );
+        assert.equal(data.interHexagram?.lower, expectedInterLower, `${label}下互卦`);
+        assert.equal(data.interHexagram?.upper, expectedInterUpper, `${label}上互卦`);
+        assert.equal(data.changedHexagram?.lower, expectedChangedLower, `${label}变卦下卦`);
+        assert.equal(data.changedHexagram?.upper, expectedChangedUpper, `${label}变卦上卦`);
+        assert.equal(data.originalName, data.mainHexagram.name, `${label}主卦名称`);
+        assert.equal(data.interName, data.interHexagram?.name, `${label}互卦名称`);
+        assert.equal(data.changedName, data.changedHexagram?.name, `${label}变卦名称`);
+      }
+    }
+  }
 });
 
 test('梅花：数字起卦生成的主互变三卦与动爻资料必须始终完整', () => {


### PR DESCRIPTION
## 目标

修复 #177 反馈的梅花易数爻序与互卦计算不一致问题。

## 主要修改

- 按八卦数据原有的“自下而上（初爻至三爻）”顺序直接组成六爻，移除重复反转。
- 互卦与变卦的经卦匹配统一使用自下而上的爻序。
- 明确八卦爻数组的数据方向注释。
- 增加反馈案例回归测试，并修正受错误爻序影响的旧断言。

反馈案例修复后的结果：

- 主卦：天泽履
- 动爻：二爻
- 六爻自下而上：阳、阳、阴、阳、阳、阳
- 互卦：风火家人（上巽下离）
- 变卦：天山遁（上乾下艮）
- 乙未月按项目月建五行口径，乾、兑金仍为“相”

## 验证

- `pnpm exec tsx --test tests/meihua-algorithm.test.ts`：17 项通过
- `pnpm test`：1425 项通过
- `pnpm test:e2e`：37 项通过
- `pnpm exec tsc -p tsconfig.app.json --noEmit`：通过
- `pnpm lint`：通过
- 本次修改文件 Prettier 检查：通过
- `pnpm build`：通过

全库 `pnpm format:check` 仍会报告 3 个既有测试文件的格式问题，与本次改动无关，未混入本 PR。

Closes #177