### PR TITLE
修正六爻主互变卦爻序

### DIFF
--- a/packages/core/src/divination/algorithms/liuyao.ts
+++ b/packages/core/src/divination/algorithms/liuyao.ts
@@ -866,6 +866,15 @@ function resolveRawYaos(
   return { yaos, generation: { method: 'manual' } };
 }
 
+function toHexagramBinary(yaos: string[]): string {
+  if (yaos.length !== 6) {
+    throw new Error(`六爻卦象必须恰好包含 6 爻，实际 ${yaos.length} 爻。`);
+  }
+  const lines = yaos.map((yao) => (yao === '阳' ? '1' : '0'));
+  // binarySymbol 按“上卦、下卦”存储，但每个经卦内部仍保持初爻到三爻的顺序。
+  return [...lines.slice(3, 6), ...lines.slice(0, 3)].join('');
+}
+
 export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOptions) {
   // 1. 获取占卜时间的干支信息
   const { ganzhi, timestamp } = getDivinationTime(customDate);
@@ -879,14 +888,8 @@ export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOpti
     return mainYaos[index];
   });
 
-  const mainBinary = mainYaos
-    .map((y) => (y === '阳' ? '1' : '0'))
-    .reverse()
-    .join('');
-  const changedBinary = changedYaos
-    .map((y) => (y === '阳' ? '1' : '0'))
-    .reverse()
-    .join('');
+  const mainBinary = toHexagramBinary(mainYaos);
+  const changedBinary = toHexagramBinary(changedYaos);
 
   const getInterHexagram = (yaos: string[]) => {
     const interLower = yaos.slice(1, 4);
@@ -894,10 +897,7 @@ export function generateLiuyao(customDate?: Date, options?: LiuyaoGenerationOpti
     return [...interLower, ...interUpper];
   };
   const interYaos = getInterHexagram(mainYaos);
-  const interBinary = interYaos
-    .map((y) => (y === '阳' ? '1' : '0'))
-    .reverse()
-    .join('');
+  const interBinary = toHexagramBinary(interYaos);
 
   const mainHexagram = hexagramsData.find((h) => h.binarySymbol === mainBinary);
   const changedHexagram = hexagramsData.find((h) => h.binarySymbol === changedBinary);

--- a/tests/liuyao-najia-data.test.ts
+++ b/tests/liuyao-najia-data.test.ts
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { getSixAnimals } from '../packages/core/src/calendar/lunar.ts';
+import { generateLiuyao } from '../packages/core/src/divination/algorithms/liuyao.ts';
 import { hexagramNaJia as coreHexagramNaJia } from '../packages/core/src/divination/divination-data.ts';
+import { hexagramsData } from '../packages/core/src/divination/hexagram-data.ts';
 
 /**
  * 六爻纳甲回归：下三爻按下经卦所属八纯卦纳支，上三爻按上经卦所属八纯卦纳支。
@@ -19,6 +21,31 @@ const pureNaJia: Record<string, { inner: string[]; outer: string[] }> = {
   坤: { inner: ['未', '巳', '卯'], outer: ['丑', '亥', '酉'] },
   兑: { inner: ['巳', '卯', '丑'], outer: ['亥', '酉', '未'] },
 };
+
+const trigramLinesBottomUp: Record<string, number[]> = {
+  乾: [1, 1, 1],
+  兑: [1, 1, 0],
+  离: [1, 0, 1],
+  震: [0, 0, 1],
+  巽: [0, 1, 1],
+  坎: [0, 1, 0],
+  艮: [1, 0, 0],
+  坤: [0, 0, 0],
+};
+
+const trigramSymbols: Record<string, string> = {
+  乾: '☰',
+  兑: '☱',
+  离: '☲',
+  震: '☳',
+  巽: '☴',
+  坎: '☵',
+  艮: '☶',
+  坤: '☷',
+};
+
+// 与下方独立六十四卦表一致：每宫连续 8 卦，依次为本宫、一至五世、游魂、归魂。
+const palaceOrder = ['乾', '坎', '艮', '震', '巽', '离', '坤', '兑'];
 
 // 64 卦 → [上经卦, 下经卦]（所属八纯卦）。按八宫顺序列出。
 const trigrams: Record<string, [string, string]> = {
@@ -95,6 +122,92 @@ const trigrams: Record<string, [string, string]> = {
   雷山小过: ['震', '艮'],
   雷泽归妹: ['震', '兑'],
 };
+
+const trigramByBottomUpLines = new Map(
+  Object.entries(trigramLinesBottomUp).map(([name, lines]) => [lines.join(''), name]),
+);
+
+const hexagramByTrigrams = new Map(
+  Object.entries(trigrams).map(([name, [upper, lower]]) => [`${upper}/${lower}`, name]),
+);
+
+test('六十四卦底表：卦名、上下卦、爻序、符号和八宫应与独立规则表完全一致', () => {
+  assert.equal(hexagramsData.length, 64, '六十四卦底表必须恰好有 64 项');
+  assert.equal(new Set(hexagramsData.map((item) => item.id)).size, 64, '卦序不得重复');
+  assert.equal(new Set(hexagramsData.map((item) => item.name)).size, 64, '卦名不得重复');
+  assert.equal(new Set(hexagramsData.map((item) => item.symbol)).size, 64, '卦符不得重复');
+  assert.equal(
+    new Set(hexagramsData.map((item) => item.binarySymbol)).size,
+    64,
+    '六爻二进制不得重复',
+  );
+  assert.deepEqual(
+    hexagramsData.map((item) => item.id).sort((left, right) => left - right),
+    Array.from({ length: 64 }, (_, index) => index + 1),
+    '卦序必须完整覆盖文王六十四卦的 1 至 64',
+  );
+
+  const dataByName = new Map(hexagramsData.map((item) => [item.name, item]));
+  assert.deepEqual(
+    [...dataByName.keys()].sort(),
+    Object.keys(trigrams).sort(),
+    '底表卦名必须与独立六十四卦表完全相同',
+  );
+
+  Object.entries(trigrams).forEach(([name, [upper, lower]], index) => {
+    const item = dataByName.get(name);
+    assert.ok(item, `缺少${name}`);
+    assert.equal(item.upper, upper, `${name}上卦`);
+    assert.equal(item.lower, lower, `${name}下卦`);
+    assert.equal(
+      item.binarySymbol,
+      [...trigramLinesBottomUp[upper], ...trigramLinesBottomUp[lower]].join(''),
+      `${name}六爻二进制应按“上卦、下卦”存储，且每个经卦内部自下而上`,
+    );
+    assert.equal(item.symbol, `${trigramSymbols[upper]}${trigramSymbols[lower]}`, `${name}卦符`);
+    assert.equal(item.palace, palaceOrder[Math.floor(index / 8)], `${name}所属八宫`);
+    assert.equal(item.yaoCi?.length, 6, `${name}必须包含从初爻到上爻的 6 条爻辞`);
+  });
+});
+
+test('六爻排盘：全六十四卦每爻发动时主卦、互卦、变卦应与自下而上爻序一致', () => {
+  const sampleDate = new Date('2026-07-25T23:30:00+08:00');
+
+  for (const [originalName, [upper, lower]] of Object.entries(trigrams)) {
+    const mainLines = [...trigramLinesBottomUp[lower], ...trigramLinesBottomUp[upper]];
+    const interLower = trigramByBottomUpLines.get(mainLines.slice(1, 4).join(''));
+    const interUpper = trigramByBottomUpLines.get(mainLines.slice(2, 5).join(''));
+    const expectedInterName = hexagramByTrigrams.get(`${interUpper}/${interLower}`);
+
+    for (let movingYao = 1; movingYao <= 6; movingYao += 1) {
+      const changedLines = [...mainLines];
+      changedLines[movingYao - 1] = 1 - changedLines[movingYao - 1];
+      const changedLower = trigramByBottomUpLines.get(changedLines.slice(0, 3).join(''));
+      const changedUpper = trigramByBottomUpLines.get(changedLines.slice(3, 6).join(''));
+      const expectedChangedName = hexagramByTrigrams.get(`${changedUpper}/${changedLower}`);
+      const yaos = mainLines.map((line, index) => {
+        if (index === movingYao - 1) return line === 1 ? 9 : 6;
+        return line === 1 ? 7 : 8;
+      });
+      const data = generateLiuyao(sampleDate, { method: 'manual', yaos });
+      const label = `${originalName}第${movingYao}爻`;
+
+      assert.equal(data.originalName, originalName, `${label}主卦`);
+      assert.equal(data.interName, expectedInterName, `${label}互卦`);
+      assert.equal(data.changedName, expectedChangedName, `${label}变卦`);
+      assert.deepEqual(
+        data.yaosDetail.map((yao) => (yao.yaoType === '阳' ? 1 : 0)),
+        mainLines,
+        `${label}逐爻阴阳`,
+      );
+      assert.deepEqual(
+        data.changingYaos.map((yao) => yao.position),
+        [movingYao],
+        `${label}动爻位置`,
+      );
+    }
+  }
+});
 
 test('六爻纳甲：核心包全 64 卦按上下经卦所属纯卦分别纳甲', () => {
   for (const [name, [upper, lower]] of Object.entries(trigrams)) {

--- a/tests/liuyao-najia-data.test.ts
+++ b/tests/liuyao-najia-data.test.ts
@@ -3,7 +3,6 @@ import { strict as assert } from 'node:assert';
 import { getSixAnimals } from '../packages/core/src/calendar/lunar.ts';
 import { generateLiuyao } from '../packages/core/src/divination/algorithms/liuyao.ts';
 import { hexagramNaJia as coreHexagramNaJia } from '../packages/core/src/divination/divination-data.ts';
-import { hexagramsData } from '../packages/core/src/divination/hexagram-data.ts';
 
 /**
  * 六爻纳甲回归：下三爻按下经卦所属八纯卦纳支，上三爻按上经卦所属八纯卦纳支。
@@ -21,31 +20,6 @@ const pureNaJia: Record<string, { inner: string[]; outer: string[] }> = {
   坤: { inner: ['未', '巳', '卯'], outer: ['丑', '亥', '酉'] },
   兑: { inner: ['巳', '卯', '丑'], outer: ['亥', '酉', '未'] },
 };
-
-const trigramLinesBottomUp: Record<string, number[]> = {
-  乾: [1, 1, 1],
-  兑: [1, 1, 0],
-  离: [1, 0, 1],
-  震: [0, 0, 1],
-  巽: [0, 1, 1],
-  坎: [0, 1, 0],
-  艮: [1, 0, 0],
-  坤: [0, 0, 0],
-};
-
-const trigramSymbols: Record<string, string> = {
-  乾: '☰',
-  兑: '☱',
-  离: '☲',
-  震: '☳',
-  巽: '☴',
-  坎: '☵',
-  艮: '☶',
-  坤: '☷',
-};
-
-// 与下方独立六十四卦表一致：每宫连续 8 卦，依次为本宫、一至五世、游魂、归魂。
-const palaceOrder = ['乾', '坎', '艮', '震', '巽', '离', '坤', '兑'];
 
 // 64 卦 → [上经卦, 下经卦]（所属八纯卦）。按八宫顺序列出。
 const trigrams: Record<string, [string, string]> = {
@@ -123,90 +97,31 @@ const trigrams: Record<string, [string, string]> = {
   雷泽归妹: ['震', '兑'],
 };
 
-const trigramByBottomUpLines = new Map(
-  Object.entries(trigramLinesBottomUp).map(([name, lines]) => [lines.join(''), name]),
-);
-
-const hexagramByTrigrams = new Map(
-  Object.entries(trigrams).map(([name, [upper, lower]]) => [`${upper}/${lower}`, name]),
-);
-
-test('六十四卦底表：卦名、上下卦、爻序、符号和八宫应与独立规则表完全一致', () => {
-  assert.equal(hexagramsData.length, 64, '六十四卦底表必须恰好有 64 项');
-  assert.equal(new Set(hexagramsData.map((item) => item.id)).size, 64, '卦序不得重复');
-  assert.equal(new Set(hexagramsData.map((item) => item.name)).size, 64, '卦名不得重复');
-  assert.equal(new Set(hexagramsData.map((item) => item.symbol)).size, 64, '卦符不得重复');
-  assert.equal(
-    new Set(hexagramsData.map((item) => item.binarySymbol)).size,
-    64,
-    '六爻二进制不得重复',
-  );
-  assert.deepEqual(
-    hexagramsData.map((item) => item.id).sort((left, right) => left - right),
-    Array.from({ length: 64 }, (_, index) => index + 1),
-    '卦序必须完整覆盖文王六十四卦的 1 至 64',
-  );
-
-  const dataByName = new Map(hexagramsData.map((item) => [item.name, item]));
-  assert.deepEqual(
-    [...dataByName.keys()].sort(),
-    Object.keys(trigrams).sort(),
-    '底表卦名必须与独立六十四卦表完全相同',
-  );
-
-  Object.entries(trigrams).forEach(([name, [upper, lower]], index) => {
-    const item = dataByName.get(name);
-    assert.ok(item, `缺少${name}`);
-    assert.equal(item.upper, upper, `${name}上卦`);
-    assert.equal(item.lower, lower, `${name}下卦`);
-    assert.equal(
-      item.binarySymbol,
-      [...trigramLinesBottomUp[upper], ...trigramLinesBottomUp[lower]].join(''),
-      `${name}六爻二进制应按“上卦、下卦”存储，且每个经卦内部自下而上`,
-    );
-    assert.equal(item.symbol, `${trigramSymbols[upper]}${trigramSymbols[lower]}`, `${name}卦符`);
-    assert.equal(item.palace, palaceOrder[Math.floor(index / 8)], `${name}所属八宫`);
-    assert.equal(item.yaoCi?.length, 6, `${name}必须包含从初爻到上爻的 6 条爻辞`);
-  });
-});
-
-test('六爻排盘：全六十四卦每爻发动时主卦、互卦、变卦应与自下而上爻序一致', () => {
+test('六爻排盘：手工爻值应按初爻到上爻识别主卦、互卦和变卦', () => {
   const sampleDate = new Date('2026-07-25T23:30:00+08:00');
+  const tianZeLv = generateLiuyao(sampleDate, {
+    method: 'manual',
+    yaos: [7, 9, 8, 7, 7, 7],
+  });
+  assert.equal(tianZeLv.originalName, '天泽履');
+  assert.equal(tianZeLv.interName, '风火家人');
+  assert.equal(tianZeLv.changedName, '天山遁');
+  assert.deepEqual(
+    tianZeLv.yaosDetail.map((yao) => yao.yaoType),
+    ['阳', '阳', '阴', '阳', '阳', '阳'],
+  );
+  assert.deepEqual(
+    tianZeLv.changingYaos.map((yao) => yao.position),
+    [2],
+  );
 
-  for (const [originalName, [upper, lower]] of Object.entries(trigrams)) {
-    const mainLines = [...trigramLinesBottomUp[lower], ...trigramLinesBottomUp[upper]];
-    const interLower = trigramByBottomUpLines.get(mainLines.slice(1, 4).join(''));
-    const interUpper = trigramByBottomUpLines.get(mainLines.slice(2, 5).join(''));
-    const expectedInterName = hexagramByTrigrams.get(`${interUpper}/${interLower}`);
-
-    for (let movingYao = 1; movingYao <= 6; movingYao += 1) {
-      const changedLines = [...mainLines];
-      changedLines[movingYao - 1] = 1 - changedLines[movingYao - 1];
-      const changedLower = trigramByBottomUpLines.get(changedLines.slice(0, 3).join(''));
-      const changedUpper = trigramByBottomUpLines.get(changedLines.slice(3, 6).join(''));
-      const expectedChangedName = hexagramByTrigrams.get(`${changedUpper}/${changedLower}`);
-      const yaos = mainLines.map((line, index) => {
-        if (index === movingYao - 1) return line === 1 ? 9 : 6;
-        return line === 1 ? 7 : 8;
-      });
-      const data = generateLiuyao(sampleDate, { method: 'manual', yaos });
-      const label = `${originalName}第${movingYao}爻`;
-
-      assert.equal(data.originalName, originalName, `${label}主卦`);
-      assert.equal(data.interName, expectedInterName, `${label}互卦`);
-      assert.equal(data.changedName, expectedChangedName, `${label}变卦`);
-      assert.deepEqual(
-        data.yaosDetail.map((yao) => (yao.yaoType === '阳' ? 1 : 0)),
-        mainLines,
-        `${label}逐爻阴阳`,
-      );
-      assert.deepEqual(
-        data.changingYaos.map((yao) => yao.position),
-        [movingYao],
-        `${label}动爻位置`,
-      );
-    }
-  }
+  const tianFengGou = generateLiuyao(sampleDate, {
+    method: 'manual',
+    yaos: [6, 7, 7, 7, 7, 7],
+  });
+  assert.equal(tianFengGou.originalName, '天风姤');
+  assert.equal(tianFengGou.interName, '乾为天');
+  assert.equal(tianFengGou.changedName, '乾为天');
 });
 
 test('六爻纳甲：核心包全 64 卦按上下经卦所属纯卦分别纳甲', () => {

--- a/tests/liuyao-strength-change.test.ts
+++ b/tests/liuyao-strength-change.test.ts
@@ -15,9 +15,10 @@ import type { LiuyaoYaoDetail } from 'mingyu-core/types';
 // 2025-01-01 农历为丙子月（子月：水旺木相金休土囚火死）、丙寅日（日支寅）
 // 该日期的卦象固定，用于回归月令旺衰、暗动、回头生克冲的字段输出。
 const SAMPLE_DATE = new Date('2025-01-01T08:00:00+08:00');
-const SHAN_HUO_BI_YAOS = [7, 8, 7, 8, 8, 7] as const;
-const XUN_WEI_FENG_YAOS = [7, 7, 8, 7, 7, 8] as const;
-const FENG_SHUI_HUAN_YAOS = [8, 7, 8, 7, 7, 8] as const;
+const SHAN_HUO_BI_YAOS = [7, 8, 7, 7, 8, 8] as const;
+const XUN_WEI_FENG_YAOS = [8, 7, 7, 8, 7, 7] as const;
+const DUI_WEI_ZE_YAOS = [7, 7, 8, 7, 7, 8] as const;
+const FENG_SHUI_HUAN_YAOS = [8, 7, 8, 8, 7, 7] as const;
 const KAN_WEI_SHUI_YAOS = [8, 7, 8, 8, 7, 8] as const;
 
 function generateSampleLiuyao(yaos: readonly number[] = SHAN_HUO_BI_YAOS) {
@@ -231,7 +232,7 @@ test('六爻：静卦不能仅凭静态纳甲支凑成三合局', () => {
 
 test('六爻：动爻的变爻可以与日辰补成完整三合局', () => {
   const data = generateLiuyao(new Date('2025-01-01T00:00:00+08:00'), {
-    yaos: [7, 6, 7, 7, 7, 6],
+    yaos: [6, 7, 8, 6, 8, 8],
   });
 
   assert.equal(data.ganzhi.day.slice(1), '午');
@@ -240,8 +241,8 @@ test('六爻：动爻的变爻可以与日辰补成完整三合局', () => {
       .filter((yao) => yao.isChanging)
       .map((yao) => [yao.najiaDizhi, yao.changedYao?.dizhi]),
     [
-      ['丑', '寅'],
-      ['卯', '戌'],
+      ['寅', '巳'],
+      ['丑', '戌'],
     ],
   );
   assert.equal(data.sanheWithDay?.group, '火局');
@@ -261,13 +262,13 @@ test('六爻：月卦身应按阳世起子、阴世起午逐爻顺数', () => {
   assert.equal(yangShi.guaShen?.position, 2);
 
   const yinShi = generateLiuyao(new Date('2025-01-01T01:00:00+08:00'), {
-    yaos: XUN_WEI_FENG_YAOS,
+    yaos: DUI_WEI_ZE_YAOS,
   });
-  assert.equal(yinShi.originalName, '巽为风');
+  assert.equal(yinShi.originalName, '兑为泽');
   assert.equal(yinShi.worldAndResponse.indexOf('世') + 1, 6);
   assert.equal(yinShi.yaosDetail[5].yaoType, '阴');
   assert.equal(yinShi.guaShen?.branch, '亥');
-  assert.equal(yinShi.guaShen?.position, 2);
+  assert.equal(yinShi.guaShen?.position, 4);
 });
 
 test('六爻：动变关系与月卦身应拒绝非法资料', () => {


### PR DESCRIPTION
## 目标

修复算法审查中发现的六爻主卦、互卦和变卦爻序错误。该问题与 #177 暴露的梅花爻序问题同源，但发生在独立的六爻入口。

## 问题与修改

- 手工六爻按“初爻到上爻”输入，旧实现却把六爻整体反转后查卦，导致上下卦和经卦内部爻序同时颠倒。
- 例如 `[7, 7, 8, 7, 7, 7]` 应为天泽履，旧版会排成天风姤。
- 统一按底表约定转换：先上卦、后下卦，每个经卦内部保持自下而上。
- 修正受旧错误方向影响的测试夹具。
- 审查时已完成 64 卦 × 6 动爻的 384 组合独立穷举；常驻测试按维护成本收缩为两个能复现兑、巽互换的关键回归案例。

## 验证

- 六爻定向测试：21 项通过
- `pnpm test`：1426 项通过（收缩常驻测试前；生产修改相同）
- `pnpm test:e2e`：37 项通过
- `pnpm exec tsc -p tsconfig.app.json --noEmit`：通过
- `pnpm lint`：通过
- `pnpm build`：通过
- Prettier 与 `git diff --check`：通过

本 PR 仅处理六爻爻序，不包含其他审查批次。