### PR TITLE
收紧运限输入并修正星盘行运基准

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,8 @@
 | `POST /divination/ssgw/prompt`               | 三山国王灵签求签并生成 AI 解读提示词                                           |
 | `POST /divination/almanac`                   | 黄历择日                                                                       |
 | `POST /divination/almanac/prompt`            | 黄历择日并生成 AI 解读提示词                                                   |
+| `POST /divination/lenormand`                 | 雷诺曼抽牌，分层返回固定组合、相邻合读与布局证据                               |
+| `POST /divination/lenormand/prompt`          | 雷诺曼抽牌并生成含证据缺口和解释边界的 AI 解读提示词                           |
 | `POST /divination/astrolabe`                 | 星盘生成                                                                       |
 | `POST /divination/astrolabe/prompt`          | 星盘生成并生成 AI 解读提示词                                                   |
 | `POST /divination/astrolabe/synastry`        | 西占双盘相位、落宫与证据计算                                                   |
@@ -80,6 +82,8 @@
 | `POST /metaphysics/bazhai/prompt`            | 八宅排盘并生成含测量和现实边界的 AI 解读提示词                                 |
 | `POST /metaphysics/residential/calculate`   | 住宅风水：八宅与玄空飞星分层合参结果                                           |
 | `POST /metaphysics/residential/prompt`      | 住宅风水合参并生成 AI 解读提示词                                               |
+| `POST /metaphysics/zodiac/calculate`         | 生肖与流年值冲刑害破、三合六合及结构化关系证据                                 |
+| `POST /metaphysics/zodiac/prompt`            | 生肖流年关系排盘并生成含信息量限制的 AI 解读提示词                             |
 | `POST /metaphysics/taiyi/calculate`          | 太乙神数排盘                                                                   |
 | `POST /metaphysics/taiyi/prompt`             | 太乙神数排盘并生成 AI 解读提示词                                               |
 | `POST /metaphysics/qizheng/calculate`        | 七政四余十一星、真实距星宿界、命身十二宫、庙旺吊照与结构化证据                 |
@@ -117,15 +121,18 @@
 | 只看紫微宫位、四化、某年某月运限   | `POST /ziwei/prompt`                         | `promptTopic`，`promptScope: "full"`、`"yearly"`、`"monthly"`、`"daily"` 或 `"hourly"`                                                                      | 明确要求紫微时使用                                                               |
 | 当前事项能否推进、短期成败         | `POST /divination/liuyao/prompt`             | `question`，必要时传 `customDate`                                                                                                                           | 六爻适合一事一问、取用和应期                                                     |
 | 项目推进、方向选择、谈判出行、方位 | `POST /divination/qimen/prompt`              | `question`，可选 `qimenMethod: "zhuanpan"` 或 `"feipan"`，必要时传 `customDate`                                                                             | 奇门适合时空局势、路径、方位和行动窗口                                           |
+| 临时小事、快速判断                 | `POST /divination/xiaoliuren/prompt`         | `question`，可选 `xiaoliurenMethod`、`xiaoliurenSchool` 和 `xiaoliurenNumber`                                                                               | 返回三宫推进、五行、旺衰、触发条件与反证限制；不用于长期命运                       |
 | 以数字或时间起卦的象意判断         | `POST /divination/meihua/prompt`             | `question`，可选 `method`、`number` 或 `customDate`                                                                                                         | 梅花适合象意、触发点和过程结果                                                   |
 | 更传统复杂的一事一课               | `POST /divination/liuren/prompt`             | `question`，可选 `liurenTemplate` 和 `customDate`                                                                                                           | 大六壬适合较严肃的事项推演                                                       |
 | 结婚、搬家、开业、签约、出行、安葬 | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`                                                                                    | 只在候选日期范围内择优，不应让 AI 推荐范围外日期                                 |
-| 星盘本命、行运、流年流月           | `POST /divination/astrolabe/prompt`          | 出生时间地点，经纬度，`astrolabeTopic`，`astrolabeScope: "full"` 或指定范围                                                                                 | 需要经纬度和时区，资料不足时应先补齐                                             |
+| 星盘本命、行运、流年流月           | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、时区、`astrolabeTopic`、`astrolabeScope`；行运范围同时传 `astrolabeScopeDate`                                                         | 需要明确行运日期；不会自动套用服务器当前日期                                     |
 | 西占双方关系、合作或婚恋互动       | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                                                                                                     | 返回跨盘相位、容许度、落宫和解释边界，不给虚假匹配分                             |
 | 牌面灵感、关系牌阵、选择牌阵       | `POST /divination/tarot/prompt`             | `spreadType`、`question`                                                                                                                                    | 适合轻量启发，不作为长期命盘判断                                                 |
-| 求签                               | `POST /divination/ssgw/prompt`               | `question`                                                                                                                                                  | 返回签号、签题与签诗，直接围绕问题解读                                           |
+| 雷诺曼关系或选择牌阵               | `POST /divination/lenormand/prompt`         | `spreadType`、`question`                                                                                                                                    | 适合轻量启发，不作为长期命盘判断                                                 |
+| 求签                               | `POST /divination/ssgw/prompt`               | `question`                                                                                                                                                  | 有拒签情况时如实返回，不强行解释                                                 |
 | 住宅风水（八宅+玄空）             | `POST /metaphysics/residential/prompt`       | 山向或居住人至少一项：`birthYear`+`gender`/`mingGua`，`sitMountain`/`facingDegree`/`doorToInteriorDegree`，可选 `year` 建造/起运年                         | 统一入口；可只做人宅、只做宅运或两者合参；不给综合吉凶总分                        |
 | 仅八宅命卦、坐山吉凶               | `POST /metaphysics/bazhai/prompt`            | `birthYear`、`gender`、可选 `sitMountain`；实测可传 `doorToInteriorDegree`、`northReference`、`magneticDeclinationDegrees`、`measurementUncertaintyDegrees` | 返回磁北/真北换算、候选坐向与边界稳定性                                          |
+| 生肖犯太岁、流年贵人               | `POST /metaphysics/zodiac/prompt`            | `zodiac`、`year` 或 `yearGanZhi`                                                                                                                            | 生肖可传“鼠”或“子”                                                                |
 | 太乙神数                           | `POST /metaphysics/taiyi/prompt`             | 当前只接受 `scope: "year"` 与 `year`                                                                                                                       | 年计按积年与阳遁七十二局立成；结果含 `evidenceAnalysis` 结构化证据              |
 | 七政四余                           | `POST /metaphysics/qizheng/prompt`           | 精准出生年月日时、经纬度，并提供 `timezone` 或 `timeZoneId`；可选 `useTrueSolarTime`                                                                        | 返回十一星、真实距星宿界、命身十二宫、庙旺吊照和分层天文证据                       |
 | 玄空飞星                           | `POST /metaphysics/xuankong/prompt`          | `year`、`sitMountain`/`facingMountain` 或度数；可选测量误差                                                                                                | 返回下卦的三元九运、三盘飞星、局型、到山到向与结构化证据                           |
@@ -133,7 +140,7 @@
 参数选择建议：
 
 - `responseMode` 默认用 `summary`；只转交提示词给 AI 时用 `prompt-only`；确实需要完整结构化排盘时再用 `full`。
-- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"`。
+- 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"` 并以 `astrolabeScopeDate: "YYYY-MM-DD"` 明确行运基准日。
 - 只问某一年、某月、某日时，优先选择对应范围，避免把短期问题做成泛泛终身解读。
 - `promptMode` 默认用 `framework`，这样返回的提示词结构更完整；只有用户明确要自由问答或自己已经写好完整问题时，才用 `custom`。
 - 出生时辰未知时，不要自行补时辰；八字只能保守使用已知信息，紫微和八字紫微合参应等用户补足时辰后再调用。
@@ -198,7 +205,7 @@ curl -X POST https://aov.cc/api/v1/bazi/calculate \
   -d '{"gender":"male","year":1990,"month":5,"day":15,"timeIndex":1,"dateType":"solar","shenShaVariants":{"kongWangBasis":"day-and-year","yangRenMode":"include-yin-ren","tongZiScope":"all-pillars"}}'
 ```
 
-八字提示词可指定命限范围。`baziFortuneScope` 支持 `natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）；配套参数为 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
+八字提示词可指定命限范围。`baziFortuneScope` 支持 `natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`dayun` 必须传 `baziFortuneCycleIndex`；`year`、`month`、`day` 必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`，交运年份可同时传 `baziFortuneCycleIndex` 消除重叠歧义。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
 
 ```bash
 curl -X POST https://aov.cc/api/v1/bazi/prompt \
@@ -240,12 +247,12 @@ curl -X POST https://aov.cc/api/v1/bazi-ziwei/prompt \
   -d '{"name":"测试","gender":"female","dateType":"solar","year":1992,"month":8,"day":21,"timeIndex":4,"question":"我现在适合换工作还是继续等待？","baziPromptTopic":"job-change","ziweiPromptTopic":"job-change","promptScope":"yearly"}'
 ```
 
-星盘提示词可用 `astrolabeScope` 指定范围，`full` 会写入本命、当前流年、当前流月、当前流日行运资料：
+星盘提示词可用 `astrolabeScope` 指定范围。`yearly`、`monthly`、`daily` 分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`；`full` 要求 `YYYY-MM-DD` 基准日，并写入该日所属流年、流月和流日资料。服务端不会用当前日期补齐缺参：
 
 ```bash
 curl -X POST https://aov.cc/api/v1/divination/astrolabe/prompt \
   -H "Content-Type: application/json" \
-  -d '{"name":"本人","gender":"女","year":1995,"month":5,"day":20,"hour":12,"minute":30,"latitude":39.9042,"longitude":116.4074,"timezone":8,"locationName":"北京","question":"整体人生和近期重点怎么看？","astrolabeTopic":"life","astrolabeScope":"full"}'
+  -d '{"name":"本人","gender":"女","year":1995,"month":5,"day":20,"hour":12,"minute":30,"latitude":39.9042,"longitude":116.4074,"timezone":8,"locationName":"北京","question":"整体人生和近期重点怎么看？","astrolabeTopic":"life","astrolabeScope":"full","astrolabeScopeDate":"2028-06-12"}'
 ```
 
 西占双盘接口要求 `person1`、`person2` 分别提供一份完整星盘出生资料，提示词会写入双方本命盘、跨盘相位的实际夹角与容许度、双方落宫和证据边界：
@@ -364,7 +371,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 - `/prompt` 支持 `responseMode`：`summary` 默认只返回提示词和轻量摘要；`full` 返回完整排盘和提示词；`prompt-only` 只返回提示词。
 - 八字、紫微、奇门和黄历择日排盘接口支持 `detailMode`：`full` 返回完整结构；`compact` 返回轻量结构，适合自动化或多次分页请求。
 - 八字 `promptTopic` 支持 `general`、`career`、`wealth`、`marriage`、`children`、`health`、`relationship-push`、`relationship-decision`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`home-move`、`settle-relocate`、`study-advance`、`exam-landing`、`reconciliation-decision`、`emotion`、`talent`、`growth`、`social`。
-- 八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围，支持 `natal`、`full`、`dayun`、`year`、`month`、`day`；选择 `dayun`、`year`、`month`、`day` 时可配合 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+- 八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围，支持 `natal`、`full`、`dayun`、`year`、`month`、`day`；除 `natal`、`full` 外必须提供所选层级需要的明确年限参数，工具不会自动选择当前时间或第一项。
 - 紫微 `promptTopic` 支持 `destiny`、`relationship`、`relationship-push`、`relationship-decision`、`children`、`career-wealth`、`job-change`、`startup-partnership`、`investment-partnership`、`recent`、`family`、`home-move`、`settle-relocate`、`social`、`emotion`、`health`、`study`、`study-advance`、`exam-landing`、`reconciliation-decision`、`growth`、`talent`、`life`、`chat`。
 - 紫微 `promptScope` 支持 `origin`、`full`、`decadal`、`yearly`、`monthly`、`daily`、`hourly`、`age`；`full` 会返回并写入本命、大限、流年、流月、流日、流时资料。
 - 紫微公开 API 默认只返回 `origin`（本命）范围；如果请求传入 `promptScope`，接口会返回 `origin` 加指定范围。各范围统一读取 `iztro` 原生宫位对象与运限对象，包含落宫、动态宫名、运限星曜、四化、自化、宫干飞化和三方四正，不再另建一份简化盘面。

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -45,6 +45,8 @@
 | `astrolabe_synastry_prompt`  | 双盘提示词   | 西占双盘计算并返回可直接用于 AI 解读的证据任务书                               |
 | `metaphysics_bazhai`         | 八宅排盘     | 返回命卦、宅卦、大游年方位、磁北/真北换算、测量误差与候选坐向                  |
 | `bazhai_prompt`              | 八宅提示词   | 八宅排盘并返回含测量稳定性和证据边界的 AI 解读提示词                           |
+| `metaphysics_zodiac`         | 生肖流年     | 返回生肖与流年值冲刑害破、三合六合及五行关系证据                             |
+| `zodiac_prompt`              | 生肖提示词   | 生肖流年排盘并返回含解释边界的 AI 解读提示词                                 |
 | `metaphysics_taiyi`          | 太乙年计     | 按积年与阳遁七十二局立成返回年计式盘；月、日、时计完成古籍历法链校勘后再开放     |
 | `taiyi_prompt`               | 太乙提示词   | 太乙排盘并返回可直接用于 AI 解读的提示词                                       |
 | `metaphysics_qizheng`        | 七政四余     | 返回十一星、真实距星宿界、命身十二宫、庙旺吊照与分层天文证据                   |
@@ -64,27 +66,30 @@
 4. 用户问单件事情当前能否推进、对方态度、短期成败或应期，优先调用 `liuyao_prompt`；涉及项目路径、方位、谈判、出行和时空窗口时，优先调用 `qimen_prompt`。
 5. 用户要从日期范围里选日子，调用 `almanac_prompt`；日期范围或参与人较多时使用分页参数。
 6. 用户提供一人的西方占星资料时调用 `astrolabe_prompt`；提供双方完整资料并询问关系时调用 `astrolabe_synastry_prompt`。
-7. 用户没有出生信息，只想要轻量启发、牌阵或签文时，用 `tarot_prompt` 或 `ssgw_prompt`。
-8. 用户明确要求八宅、太乙或七政四余时，使用对应的 `*_prompt` 工具；只要原始排盘则使用 `metaphysics_*`。
+7. 用户没有出生信息，只想要轻量启发、牌阵或签文时，用 `tarot_prompt`、`lenormand_prompt` 或 `ssgw_prompt`。
+8. 用户明确要求八宅、生肖犯太岁、太乙或七政四余时，使用对应的 `*_prompt` 工具；只要原始排盘则使用 `metaphysics_*`。
 
 常见问题到工具：
 
-| 用户问题类型                     | 首选工具                    | 推荐参数                                                                 |
-| -------------------------------- | --------------------------- | ------------------------------------------------------------------------ |
-| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `origin` |
-| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`，主题按事业、财运、感情等选择                    |
-| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`            |
-| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                        |
-| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、`promptScope`                                             |
-| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                            |
-| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                             |
-| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                        |
-| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                          |
-| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize` |
-| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                 |
-| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                  |
-| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                 |
-| 求签                             | `ssgw_prompt`               | `question`                                                               |
+| 用户问题类型                     | 首选工具                    | 推荐参数                                                                    |
+| -------------------------------- | --------------------------- | --------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋   | `bazi_ziwei_prompt`         | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `origin`    |
+| 今年运势、当前阶段、某年趋势     | `bazi_ziwei_prompt`         | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
+| 换工作、创业、合伙、投资         | `bazi_ziwei_prompt`         | `job-change`、`startup-partnership`、`investment-partnership`               |
+| 八字格局、用神、大运流年         | `bazi_prompt`               | `promptTopic`、`baziFortuneScope`                                           |
+| 紫微宫位、四化、运限             | `ziwei_prompt`              | `promptTopic`、`promptScope`                                                |
+| 一事一问、短期成败、应期         | `liuyao_prompt`             | `question`、可选 `customDate`                                               |
+| 项目推进、方向、方位、谈判       | `qimen_prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
+| 临时小事快速判断                 | `xiaoliuren_prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
+| 生肖犯太岁、流年贵人             | `zodiac_prompt`             | `zodiac`、`year` 或 `yearGanZhi`                                             |
+| 时间或数字象意判断               | `meihua_prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
+| 传统复杂事项推演                 | `liuren_prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
+| 结婚、搬家、开业、签约、安葬择日 | `almanac_prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
+| 星盘本命和行运                   | `astrolabe_prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
+| 西占双方关系、合作或婚恋互动     | `astrolabe_synastry_prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
+| 牌阵启发                         | `tarot_prompt`              | `spreadType`、`question`                                                    |
+| 雷诺曼关系或选择牌阵             | `lenormand_prompt`          | `spreadType`、`question`                                                    |
+| 求签                             | `ssgw_prompt`               | `question`                                                                  |
 
 出生时辰未知时，不要自行补时辰。八字可以保守分析；紫微和八字紫微合参需要时辰，优先请用户补足后再调用。
 
@@ -159,7 +164,11 @@ npm run mcp
 
 `bazi_prompt` 可通过 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。
 
-选择 `dayun`、`year`、`month`、`day` 时，可配套传入 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+选择 `dayun` 时必须传 `baziFortuneCycleIndex`。选择 `year`、`month`、`day` 时必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`；交运年份可同时传 `baziFortuneCycleIndex` 消除前后两步大运重叠歧义。工具不会自动选择当前年或第一项。
+
+### 星盘行运提示词参数
+
+`astrolabe_prompt` 的 `yearly`、`monthly`、`daily` 范围分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`。`full` 也必须传 `YYYY-MM-DD` 基准日，用于生成同一基准下的本命、流年、流月和流日资料；工具不会读取系统当前日期补齐缺参。
 
 ### 起卦与排盘时间参数
 

--- a/mcp/src/tools/astrolabe.ts
+++ b/mcp/src/tools/astrolabe.ts
@@ -4,7 +4,10 @@ import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
 import { analyzeAstrolabeSynastry } from 'mingyu-core/divination/astrolabe-synastry';
 import type { AstrolabeBirthInput } from 'mingyu-core/types';
 import { ASTROLABE_PROMPT_TOPICS } from '../../../src/lib/astrolabe-prompts.js';
-import { buildAstrolabeScopeContext } from '../../../src/lib/astrolabe-scope.js';
+import {
+  buildAstrolabeFullScopeContexts,
+  buildAstrolabeScopeContext,
+} from '../../../src/lib/astrolabe-scope.js';
 import { buildAstrolabeSynastryPrompt } from '../../../src/lib/astrolabe-synastry-prompt.js';
 import type { AstrolabeData } from '../../../src/types/divination.js';
 import { resultOutputSchema } from '../schemas.js';
@@ -58,7 +61,9 @@ const astrolabePromptSchema = extendPromptSchema(
     astrolabeScopeDate: z
       .string()
       .optional()
-      .describe('星盘行运日期；yearly 用年份，monthly 用 年-月，daily 用 年-月-日'),
+      .describe(
+        '星盘行运日期；full 和 daily 用 YYYY-MM-DD，yearly 用 YYYY，monthly 用 YYYY-MM；除 natal 外必填',
+      ),
     astrolabeScopeText: z
       .string()
       .optional()
@@ -126,12 +131,13 @@ function buildAstrolabeSynastryResult(args: z.infer<typeof astrolabeSynastrySche
   };
 }
 
-function buildAstrolabeFullScopePromptText(data: AstrolabeData) {
+function buildAstrolabeFullScopePromptText(data: AstrolabeData, referenceDateStr: string) {
+  const fullContexts = buildAstrolabeFullScopeContexts(data, referenceDateStr);
   const contexts = [
-    buildAstrolabeScopeContext(data, 'natal', ''),
-    buildAstrolabeScopeContext(data, 'yearly', ''),
-    buildAstrolabeScopeContext(data, 'monthly', ''),
-    buildAstrolabeScopeContext(data, 'daily', ''),
+    fullContexts.natal,
+    fullContexts.yearly,
+    fullContexts.monthly,
+    fullContexts.daily,
   ];
   const lines = contexts
     .map((context) => context.promptText)
@@ -149,11 +155,19 @@ function buildAstrolabePromptScopeText(
   if (customText) return customText;
 
   const scope = args.astrolabeScope ?? 'natal';
+  const dateStr = scope === 'natal' ? '' : requireAstrolabeScopeDate(args.astrolabeScopeDate);
   if (scope === 'full') {
-    return buildAstrolabeFullScopePromptText(result);
+    return buildAstrolabeFullScopePromptText(result, dateStr);
   }
 
-  return buildAstrolabeScopeContext(result, scope, args.astrolabeScopeDate ?? '').promptText;
+  return buildAstrolabeScopeContext(result, scope, dateStr).promptText;
+}
+
+function requireAstrolabeScopeDate(dateStr: string | undefined) {
+  if (!dateStr?.trim()) {
+    throw new Error('除 natal 外必须提供 astrolabeScopeDate。');
+  }
+  return dateStr;
 }
 
 function buildAstrolabeScopeEvidence(
@@ -164,19 +178,16 @@ function buildAstrolabeScopeEvidence(
   if (customText) return { scope: 'custom' as const, promptText: customText };
 
   const scope = args.astrolabeScope ?? 'natal';
+  const dateStr = scope === 'natal' ? '' : requireAstrolabeScopeDate(args.astrolabeScopeDate);
   if (scope === 'full') {
     return {
       scope: 'full' as const,
-      contexts: {
-        natal: buildAstrolabeScopeContext(result, 'natal', ''),
-        yearly: buildAstrolabeScopeContext(result, 'yearly', ''),
-        monthly: buildAstrolabeScopeContext(result, 'monthly', ''),
-        daily: buildAstrolabeScopeContext(result, 'daily', ''),
-      },
+      referenceDate: dateStr,
+      contexts: buildAstrolabeFullScopeContexts(result, dateStr),
     };
   }
 
-  return buildAstrolabeScopeContext(result, scope, args.astrolabeScopeDate ?? '');
+  return buildAstrolabeScopeContext(result, scope, dateStr);
 }
 
 export function registerAstrolabeTool(server: McpServer) {

--- a/mcp/src/tools/bazi.ts
+++ b/mcp/src/tools/bazi.ts
@@ -97,10 +97,13 @@ const baziPromptSchema = baziSchema.extend({
     .describe(
       '八字命限范围：natal=本命, full=完整输出版, dayun=大运, year=流年, month=流月, day=流日',
     ),
-  baziFortuneCycleIndex: z.number().optional().describe('大运序号，从 0 开始'),
-  baziFortuneYear: z.number().optional().describe('指定流年年份'),
-  baziFortuneMonth: z.number().optional().describe('指定流月序号'),
-  baziFortuneDay: z.number().optional().describe('指定流日序号'),
+  baziFortuneCycleIndex: z
+    .number()
+    .optional()
+    .describe('大运序号，从 0 开始；选择大运时必填，交运年建议同时传入'),
+  baziFortuneYear: z.number().optional().describe('指定流年年份；选择流年及以下范围时必填'),
+  baziFortuneMonth: z.number().optional().describe('指定流月序号；选择流月及以下范围时必填'),
+  baziFortuneDay: z.number().optional().describe('指定流日序号；选择流日时必填'),
 });
 
 export function buildBaziPerson(args: z.infer<typeof baziSchema>): Person {
@@ -201,14 +204,29 @@ export function registerBaziTool(server: McpServer) {
       try {
         const person = buildBaziPerson(args);
         const result = baziCalculator.calculateBazi(person);
+        const fortuneScope = args.baziFortuneScope ?? 'natal';
+        const requiresCycle = fortuneScope === 'dayun';
+        const requiresYear = ['year', 'month', 'day'].includes(fortuneScope);
+        const requiresMonth = fortuneScope === 'month' || fortuneScope === 'day';
+        const requiresDay = fortuneScope === 'day';
+        if (requiresCycle && args.baziFortuneCycleIndex === undefined) {
+          throw new Error('选择大运时必须提供 baziFortuneCycleIndex。');
+        }
+        if (requiresYear && args.baziFortuneYear === undefined) {
+          throw new Error('选择流年、流月或流日时必须提供 baziFortuneYear。');
+        }
+        if (requiresMonth && args.baziFortuneMonth === undefined) {
+          throw new Error('选择流月或流日时必须提供 baziFortuneMonth。');
+        }
+        if (requiresDay && args.baziFortuneDay === undefined) {
+          throw new Error('选择流日时必须提供 baziFortuneDay。');
+        }
         const fortuneSelectionContext = buildFortuneSelectionContext(result, {
-          scope: args.baziFortuneScope ?? 'natal',
+          scope: fortuneScope,
           cycleIndex:
-            args.baziFortuneScope &&
-            args.baziFortuneScope !== 'natal' &&
-            args.baziFortuneScope !== 'full'
+            args.baziFortuneCycleIndex !== undefined
               ? readMcpIntegerLikeInRange(
-                  args.baziFortuneCycleIndex ?? 0,
+                  args.baziFortuneCycleIndex,
                   'baziFortuneCycleIndex',
                   0,
                   99,

--- a/packages/core/src/bazi/fortuneSelection/helpers/resolvers.ts
+++ b/packages/core/src/bazi/fortuneSelection/helpers/resolvers.ts
@@ -1,10 +1,5 @@
 import type { BaziChartResult, LiunianInfo, LuckCycle } from '../../baziTypes';
-import {
-  getBaziDayIndexByDate,
-  getBaziMonthIndexByDate,
-  getMonthDaysInfo,
-  getYearInfo,
-} from '../../calendarTool';
+import { getMonthDaysInfo, getYearInfo } from '../../calendarTool';
 import type { BaziFortuneSelectionValue } from './types';
 
 export function formatCycleLabel(cycle: LuckCycle) {
@@ -22,12 +17,12 @@ export function formatYearLabel(yearInfo: LiunianInfo) {
 export function resolveCycleIndex(result: BaziChartResult, selection: BaziFortuneSelectionValue) {
   if (!result.luckInfo.cycles.length) return -1;
 
-  if (
-    typeof selection.cycleIndex === 'number' &&
-    selection.cycleIndex >= 0 &&
-    selection.cycleIndex < result.luckInfo.cycles.length
-  ) {
-    return selection.cycleIndex;
+  if (selection.cycleIndex !== undefined) {
+    return Number.isInteger(selection.cycleIndex) &&
+      selection.cycleIndex >= 0 &&
+      selection.cycleIndex < result.luckInfo.cycles.length
+      ? selection.cycleIndex
+      : -1;
   }
 
   if (typeof selection.year === 'number') {
@@ -43,15 +38,7 @@ export function resolveCycleIndex(result: BaziChartResult, selection: BaziFortun
     }
   }
 
-  const currentYear = new Date().getFullYear();
-  let currentCycleIndex = -1;
-  for (let i = result.luckInfo.cycles.length - 1; i >= 0; i -= 1) {
-    if (result.luckInfo.cycles[i].years.some((item) => item.year === currentYear)) {
-      currentCycleIndex = i;
-      break;
-    }
-  }
-  return currentCycleIndex >= 0 ? currentCycleIndex : 0;
+  return -1;
 }
 
 export function resolveSelectedYear(
@@ -67,9 +54,7 @@ export function resolveSelectedYear(
     return selection.year;
   }
 
-  const currentYear = new Date().getFullYear();
-  const currentItem = cycle.years.find((item) => item.year === currentYear);
-  return currentItem?.year ?? cycle.years[0]?.year;
+  return undefined;
 }
 
 export function resolveSelectedMonth(selection: BaziFortuneSelectionValue) {
@@ -84,7 +69,7 @@ export function resolveSelectedMonth(selection: BaziFortuneSelectionValue) {
     return selection.month;
   }
 
-  return getBaziMonthIndexByDate(selection.year, new Date()) ?? 1;
+  return undefined;
 }
 
 export function resolveSelectedDay(
@@ -103,5 +88,5 @@ export function resolveSelectedDay(
     return selection.day;
   }
 
-  return getBaziDayIndexByDate(year, month, new Date()) ?? 1;
+  return undefined;
 }

--- a/packages/core/src/bazi/fortuneSelection/index.ts
+++ b/packages/core/src/bazi/fortuneSelection/index.ts
@@ -235,38 +235,37 @@ export function normalizeFortuneSelection(
   const cycle = result.luckInfo.cycles[cycleIndex];
 
   if (!cycle) {
-    return { scope: 'natal' };
+    throw new Error(
+      selection.scope === 'dayun'
+        ? '选择大运时必须提供有效的大运序号。'
+        : '选择流年、流月或流日时必须提供有效的大运序号，或提供可定位大运的流年年份。',
+    );
   }
-
-  const year = resolveSelectedYear(cycle, selection);
 
   if (selection.scope === 'dayun') {
     return {
       scope: 'dayun',
       cycleIndex,
-      year,
     };
   }
 
+  const year = resolveSelectedYear(cycle, selection);
   if (!year) {
-    return {
-      scope: 'dayun',
-      cycleIndex,
-    };
+    throw new Error('所选范围必须提供属于该大运的有效流年年份。');
   }
-
-  const month = resolveSelectedMonth(selection);
 
   if (selection.scope === 'year') {
     return {
       scope: 'year',
       cycleIndex,
       year,
-      month,
     };
   }
 
-  const day = resolveSelectedDay(year, month, selection);
+  const month = resolveSelectedMonth(selection);
+  if (!month) {
+    throw new Error('选择流月或流日时必须提供有效的流月序号。');
+  }
 
   if (selection.scope === 'month') {
     return {
@@ -274,8 +273,12 @@ export function normalizeFortuneSelection(
       cycleIndex,
       year,
       month,
-      day,
     };
+  }
+
+  const day = resolveSelectedDay(year, month, selection);
+  if (!day) {
+    throw new Error('选择流日时必须提供该节令月内的有效流日序号。');
   }
 
   return {

--- a/packages/core/src/divination/algorithms/astrolabe.ts
+++ b/packages/core/src/divination/algorithms/astrolabe.ts
@@ -364,6 +364,8 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
         locationName.length > 0
           ? `${locationName}（${latitude.toFixed(4)}, ${longitude.toFixed(4)}）`
           : `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`,
+      latitude,
+      longitude,
       timezone,
       timeZoneId: input.timeZoneId,
       timezoneStatus: timezoneEvidence?.status,

--- a/packages/core/src/divination/astrolabe-scope.ts
+++ b/packages/core/src/divination/astrolabe-scope.ts
@@ -356,6 +356,10 @@ function formatDateStr(
   return '';
 }
 
+function formatAnchorDate(date: { year: number; month: number; day: number }) {
+  return `${date.year}-${String(date.month).padStart(2, '0')}-${String(date.day).padStart(2, '0')} 12:00`;
+}
+
 function formatAstrolabePlanetPosition(
   planet: Pick<ChartPlanet, 'signName' | 'degree' | 'minute'>,
 ) {
@@ -1847,7 +1851,7 @@ export function buildAstrolabeScopeContext(
     displayLabel: `${scopeLabel}${normalizedDateStr}`,
     promptText: [
       `分析对象：${scopeLabel}${normalizedDateStr}。`,
-      `取样时间：${anchorDate}（按出生地时区${timezoneLabel}的中午取样，用于计算行运行星触发）。`,
+      `行运基准：${anchorDate}（按出生地时区${timezoneLabel}的中午计算行运行星触发）。`,
       houseRulerChain,
       transitEvidence,
       transitHouseEvidence,

--- a/packages/core/src/divination/astrolabe-scope.ts
+++ b/packages/core/src/divination/astrolabe-scope.ts
@@ -28,6 +28,13 @@ export type AstrolabeScopeContext = {
   solarArcEvidence?: SolarArcEvidence;
 };
 
+export type AstrolabeFullScopeContexts = {
+  natal: AstrolabeScopeContext;
+  yearly: AstrolabeScopeContext;
+  monthly: AstrolabeScopeContext;
+  daily: AstrolabeScopeContext;
+};
+
 export type AstrolabeAdvancedTechnique = '太阳返照' | '次限推进' | '太阳弧';
 
 export interface AstrolabeAdvancedCalculationStep {
@@ -302,19 +309,6 @@ function parseDateParts(dateStr: string) {
   return { year, month, day };
 }
 
-function getCurrentLocalDate() {
-  const now = new Date();
-  return {
-    year: now.getFullYear(),
-    month: now.getMonth() + 1,
-    day: now.getDate(),
-  };
-}
-
-function daysInMonth(year: number, month: number) {
-  return daysInAstrolabeScopeMonth(year, month);
-}
-
 function daysInAstrolabeScopeMonth(year: number, month: number) {
   if (!Number.isInteger(year) || year < 1900 || year > 2200) {
     throw new Error('年份需在 1900-2200 之间。');
@@ -327,17 +321,21 @@ function daysInAstrolabeScopeMonth(year: number, month: number) {
 }
 
 function normalizeTargetDate(scope: AstrolabeScopeMode, dateStr: string) {
-  const current = getCurrentLocalDate();
+  const pattern =
+    scope === 'yearly' ? /^\d{4}$/ : scope === 'monthly' ? /^\d{4}-\d{2}$/ : /^\d{4}-\d{2}-\d{2}$/;
+  const expected = scope === 'yearly' ? 'YYYY' : scope === 'monthly' ? 'YYYY-MM' : 'YYYY-MM-DD';
+  if (!pattern.test(dateStr.trim())) {
+    throw new Error(`${SCOPE_LABEL_MAP[scope]}必须提供 ${expected} 格式的明确日期。`);
+  }
+
   const parsed = parseDateParts(dateStr);
-  const year = parsed?.year ?? current.year;
-  const month = scope === 'yearly' ? 7 : Math.min(Math.max(parsed?.month ?? current.month, 1), 12);
-  const maxDay = daysInMonth(year, month);
-  const day =
-    scope === 'yearly'
-      ? Math.min(1, maxDay)
-      : scope === 'monthly'
-        ? Math.min(15, maxDay)
-        : Math.min(Math.max(parsed?.day ?? current.day, 1), maxDay);
+  if (!parsed) {
+    throw new Error(`${SCOPE_LABEL_MAP[scope]}日期无效或超出 1900-2200 年范围。`);
+  }
+
+  const year = parsed.year;
+  const month = scope === 'yearly' ? 7 : parsed.month!;
+  const day = scope === 'yearly' ? 1 : scope === 'monthly' ? 15 : parsed.day!;
 
   return { year, month, day };
 }
@@ -480,19 +478,30 @@ function parseBirthDateTime(data: AstrolabeData) {
   };
 }
 
+function resolveScopeTimezone(
+  data: AstrolabeData,
+  date: { year: number; month: number; day: number; hour: number; minute: number },
+) {
+  if (data.birth.timeZoneId) {
+    return resolveHistoricalTimezone({
+      ...date,
+      second: 0,
+      timeZoneId: data.birth.timeZoneId,
+      fixedOffsetHours: data.birth.timezone,
+    }).resolvedOffsetHours;
+  }
+  if (!Number.isFinite(data.birth.timezone)) {
+    throw new Error('星盘缺少有效时区，无法计算行运。');
+  }
+  return data.birth.timezone;
+}
+
 function calculateScopePlanets(
   data: AstrolabeData,
   date: { year: number; month: number; day: number; hour: number; minute: number },
 ) {
   const coordinates = parseBirthCoordinates(data);
-  const timezone = data.birth.timeZoneId
-    ? resolveHistoricalTimezone({
-        ...date,
-        second: 0,
-        timeZoneId: data.birth.timeZoneId,
-        fixedOffsetHours: data.birth.timezone,
-      }).resolvedOffsetHours
-    : data.birth.timezone;
+  const timezone = resolveScopeTimezone(data, date);
   return calculatePlanets(
     {
       ...date,
@@ -1254,10 +1263,19 @@ export function calculateSolarReturnEvidence(
   const techniqueKey = advancedTechniqueKey(technique);
   const birth = parseBirthDateTime(data);
   const natalSun = data.planets.find((planet) => planet.name === 'Sun');
+  const targetTimezone = birth
+    ? resolveScopeTimezone(data, {
+        year: targetYear,
+        month: birth.month,
+        day: Math.min(birth.day, daysInAstrolabeScopeMonth(targetYear, birth.month)),
+        hour: birth.hour,
+        minute: birth.minute,
+      })
+    : data.birth.timezone;
   const baseEvidence = {
     key: `${techniqueKey}:${targetYear}`,
     targetYear,
-    timezone: data.birth.timezone,
+    timezone: targetTimezone,
     searchWindowHours: 48,
     coarseStepHours: 2,
     refinementToleranceMinutes: 1,
@@ -1614,15 +1632,31 @@ function buildHouseRulerChainEvidence(data: AstrolabeData) {
 }
 
 function parseBirthCoordinates(data: AstrolabeData) {
-  const matched = /(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/.exec(data.birth.location);
-  if (!matched) {
-    return { latitude: 0, longitude: 0 };
+  if (
+    typeof data.birth.latitude === 'number' &&
+    Number.isFinite(data.birth.latitude) &&
+    data.birth.latitude >= -90 &&
+    data.birth.latitude <= 90 &&
+    typeof data.birth.longitude === 'number' &&
+    Number.isFinite(data.birth.longitude) &&
+    data.birth.longitude >= -180 &&
+    data.birth.longitude <= 180
+  ) {
+    return { latitude: data.birth.latitude, longitude: data.birth.longitude };
   }
 
-  return {
-    latitude: Number(matched[1]),
-    longitude: Number(matched[2]),
-  };
+  const matched = /(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)/.exec(data.birth.location);
+  if (!matched) {
+    throw new Error('星盘缺少有效出生地经纬度，无法计算行运。');
+  }
+
+  const latitude = Number(matched[1]);
+  const longitude = Number(matched[2]);
+  if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+    throw new Error('星盘出生地经纬度超出有效范围，无法计算行运。');
+  }
+
+  return { latitude, longitude };
 }
 
 function getTransitBodiesForScope(scope: AstrolabeScopeMode) {
@@ -1639,100 +1673,78 @@ function buildTransitHouseEvidence(
   data: AstrolabeData,
   scope: AstrolabeScopeMode,
   target: { year: number; month: number; day: number },
+  timezone: number,
 ) {
   const cusps = getNatalHouseCusps(data);
   if (!cusps) {
     return '行运落宫：本命宫头资料不足。';
   }
 
-  try {
-    const coordinates = parseBirthCoordinates(data);
-    const planets = calculatePlanets(
-      {
-        year: target.year,
-        month: target.month,
-        day: target.day,
-        hour: 12,
-        minute: 0,
-        second: 0,
-        timezone: 8,
-        latitude: coordinates.latitude,
-        longitude: coordinates.longitude,
-      },
-      {
-        houseSystem: 'placidus',
-        includeAsteroids: false,
-        includeChiron: false,
-        includeLilith: false,
-        includeNodes: false,
-        includeLots: false,
-      },
-    );
-    const allowedBodies = getTransitBodiesForScope(scope);
-    const lines = planets
-      .filter((planet) => allowedBodies.has(planet.name))
-      .map((planet) => {
-        const natalHouse = getNatalHouseByLongitude(planet.longitude, cusps);
-        const label = CELESTIAL_BODY_LABELS[planet.name] ?? planet.name;
-        const position = formatAstrolabePlanetPosition(planet);
-        const retrograde = planet.isRetrograde ? '，逆行' : '';
-        return natalHouse
-          ? `${label}${position}${retrograde}落本命第${natalHouse}宫`
-          : `${label}${position}${retrograde}未能定位本命落宫`;
-      });
+  const planets = calculateScopePlanets(data, {
+    ...target,
+    hour: 12,
+    minute: 0,
+  });
+  const allowedBodies = getTransitBodiesForScope(scope);
+  const lines = planets
+    .filter((planet) => allowedBodies.has(planet.name))
+    .map((planet) => {
+      const natalHouse = getNatalHouseByLongitude(planet.longitude, cusps);
+      const label = CELESTIAL_BODY_LABELS[planet.name] ?? planet.name;
+      const position = formatAstrolabePlanetPosition(planet);
+      const retrograde = planet.isRetrograde ? '，逆行' : '';
+      return natalHouse
+        ? `${label}${position}${retrograde}落本命第${natalHouse}宫`
+        : `${label}${position}${retrograde}未能定位本命落宫`;
+    });
 
-    return lines.length ? `行运落宫：${lines.join('；')}。` : '行运落宫：未取得可用行运行星位置。';
-  } catch {
-    return '行运落宫：计算失败。';
+  if (!lines.length) {
+    throw new Error('未取得可用行运行星位置，无法计算行运落宫。');
   }
+  return `行运落宫：取样时区UTC${timezone >= 0 ? '+' : ''}${timezone}；${lines.join('；')}。`;
 }
 
 function buildTransitEvidence(
   data: AstrolabeData,
   target: { year: number; month: number; day: number },
+  timezone: number,
 ) {
   const natalPoints = buildNatalPoints(data);
   if (natalPoints.length < 3) {
     return '主要行运相位：本命点经度资料不足。';
   }
 
-  try {
-    const julianDate = time.toJulianDate({
-      year: target.year,
-      month: target.month,
-      day: target.day,
-      hour: 12,
-      minute: 0,
-      second: 0,
-      timezone: 8,
-    });
-    const result = calculateTransits(natalPoints, julianDate, {
-      aspectTypes: [
-        AspectType.Conjunction,
-        AspectType.Sextile,
-        AspectType.Square,
-        AspectType.Trine,
-        AspectType.Opposition,
-      ],
-      transitingBodies: TRANSITING_BODIES,
-      minimumStrength: 35,
-      includeOutOfSign: true,
-    });
-    const transitLines = result.transits
-      .sort(
-        (first, second) => second.strength - first.strength || first.deviation - second.deviation,
-      )
-      .slice(0, 10)
-      .map(formatTransitLine);
+  const julianDate = time.toJulianDate({
+    year: target.year,
+    month: target.month,
+    day: target.day,
+    hour: 12,
+    minute: 0,
+    second: 0,
+    timezone,
+  });
+  const result = calculateTransits(natalPoints, julianDate, {
+    aspectTypes: [
+      AspectType.Conjunction,
+      AspectType.Sextile,
+      AspectType.Square,
+      AspectType.Trine,
+      AspectType.Opposition,
+    ],
+    transitingBodies: TRANSITING_BODIES,
+    minimumStrength: 35,
+    includeOutOfSign: true,
+  });
+  const transitLines = result.transits
+    .sort((first, second) => second.strength - first.strength || first.deviation - second.deviation)
+    .slice(0, 10)
+    .map(formatTransitLine);
 
-    if (transitLines.length === 0) {
-      return '主要行运相位：所选日期未见当前容许度内的主要相位。';
-    }
-
-    return `主要行运相位：${transitLines.join('；')}。`;
-  } catch {
-    return '主要行运相位：计算失败。';
+  if (transitLines.length === 0) {
+    return '主要行运相位：所选日期未见当前容许度内的主要相位。';
   }
+
+  return `主要行运相位：${transitLines.join('；')}。`;
 }
 
 function formatAdvancedScopeFacts(params: {
@@ -1780,14 +1792,26 @@ export function buildAstrolabeScopeContext(
   }
 
   const houseRulerChain = buildHouseRulerChainEvidence(data);
-  if (scope === 'natal' || scope === 'full') {
+  if (scope === 'natal') {
     return {
       scope,
       dateStr: '',
-      displayText: scope === 'full' ? '本命盘与完整行运资料' : '仅使用本命信息',
-      displayLabel: scope === 'full' ? '完整输出版' : '本命盘',
+      displayText: '仅使用本命信息',
+      displayLabel: '本命盘',
+      promptText: ['分析对象：本命盘。', houseRulerChain].join('\n'),
+    };
+  }
+
+  if (scope === 'full') {
+    const reference = normalizeTargetDate('full', dateStr);
+    const normalizedReferenceDate = formatDateStr('daily', reference);
+    return {
+      scope,
+      dateStr: normalizedReferenceDate,
+      displayText: `本命盘与完整行运资料 · ${normalizedReferenceDate}`,
+      displayLabel: `完整输出版${normalizedReferenceDate}`,
       promptText: [
-        scope === 'full' ? '分析对象：本命盘与完整行运资料。' : '分析对象：本命盘。',
+        `分析对象：本命盘与以${normalizedReferenceDate}为基准的完整行运资料。`,
         houseRulerChain,
       ].join('\n'),
     };
@@ -1797,8 +1821,13 @@ export function buildAstrolabeScopeContext(
   const normalizedDateStr = formatDateStr(scope, target);
   const scopeLabel = SCOPE_LABEL_MAP[scope];
   const displayText = `${scopeLabel} · ${normalizedDateStr}`;
-  const transitEvidence = buildTransitEvidence(data, target);
-  const transitHouseEvidence = buildTransitHouseEvidence(data, scope, target);
+  const anchorDate = formatAnchorDate(target);
+  const targetTimezone = resolveScopeTimezone(data, { ...target, hour: 12, minute: 0 });
+  const timezoneLabel = data.birth.timeZoneId
+    ? `${data.birth.timeZoneId}（UTC${targetTimezone >= 0 ? '+' : ''}${targetTimezone}）`
+    : `UTC${targetTimezone >= 0 ? '+' : ''}${targetTimezone}`;
+  const transitEvidence = buildTransitEvidence(data, target, targetTimezone);
+  const transitHouseEvidence = buildTransitHouseEvidence(data, scope, target, targetTimezone);
   const solarReturnEvidence =
     scope === 'yearly' ? calculateSolarReturnEvidence(data, target.year) : undefined;
   const secondaryProgressionEvidence =
@@ -1818,6 +1847,7 @@ export function buildAstrolabeScopeContext(
     displayLabel: `${scopeLabel}${normalizedDateStr}`,
     promptText: [
       `分析对象：${scopeLabel}${normalizedDateStr}。`,
+      `取样时间：${anchorDate}（按出生地时区${timezoneLabel}的中午取样，用于计算行运行星触发）。`,
       houseRulerChain,
       transitEvidence,
       transitHouseEvidence,
@@ -1826,6 +1856,23 @@ export function buildAstrolabeScopeContext(
     solarReturnEvidence,
     secondaryProgressionEvidence,
     solarArcEvidence,
+  };
+}
+
+export function buildAstrolabeFullScopeContexts(
+  data: AstrolabeData,
+  referenceDateStr: string,
+): AstrolabeFullScopeContexts {
+  const reference = normalizeTargetDate('full', referenceDateStr);
+  const dailyDate = formatDateStr('daily', reference);
+  const monthlyDate = formatDateStr('monthly', reference);
+  const yearlyDate = formatDateStr('yearly', reference);
+
+  return {
+    natal: buildAstrolabeScopeContext(data, 'natal', ''),
+    yearly: buildAstrolabeScopeContext(data, 'yearly', yearlyDate),
+    monthly: buildAstrolabeScopeContext(data, 'monthly', monthlyDate),
+    daily: buildAstrolabeScopeContext(data, 'daily', dailyDate),
   };
 }
 

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -1116,6 +1116,8 @@ export interface AstrolabeData {
     gender: AlmanacParticipantGender;
     dateTime: string;
     location: string;
+    latitude?: number;
+    longitude?: number;
     timezone: number;
     timeZoneId?: string;
     timezoneStatus?: 'unique' | 'ambiguous';

--- a/public/skills/aov-mingyu-api/SKILL.md
+++ b/public/skills/aov-mingyu-api/SKILL.md
@@ -57,27 +57,30 @@ description: 通过 aov.cc 公开 API 调用真太阳时换算、命理、占卜
 - 用户问一件事现在能不能成、要不要推进、对方态度、短期应期：优先用六爻 `POST /divination/liuyao/prompt`；涉及方位、项目路径、谈判、出行和时空窗口时优先用奇门 `POST /divination/qimen/prompt`。
 - 用户要从日期范围里挑日子：调用 `POST /divination/almanac/prompt`，日期多或参与人多时分页。
 - 用户提供一人的西方星盘资料：调用 `POST /divination/astrolabe/prompt`；提供双方完整资料并询问关系：调用 `POST /divination/astrolabe/synastry/prompt`。
-- 用户没有出生信息，只想要轻量启发、牌阵或签文：调用塔罗或三山国王灵签提示词接口。
-- 用户明确要求八宅、太乙或七政四余：调用对应的 `POST /metaphysics/{method}/prompt`；只要结构化排盘时改用 `/calculate`。
+- 用户没有出生信息，只想要轻量启发、牌阵或签文：调用塔罗、雷诺曼或三山国王灵签提示词接口。
+- 用户明确要求八宅、生肖犯太岁、太乙或七政四余：调用对应的 `POST /metaphysics/{method}/prompt`；只要结构化排盘时改用 `/calculate`。
 
 问题到接口速查：
 
-| 问题类型                       | 首选接口                                     | 关键参数                                                                   |
-| ------------------------------ | -------------------------------------------- | -------------------------------------------------------------------------- |
-| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `"origin"` |
-| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题按事业、财运、感情等选择                      |
-| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`              |
-| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                          |
-| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、`promptScope`                                               |
-| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                              |
-| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                               |
-| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                          |
-| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                            |
-| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`   |
-| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                   |
-| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                    |
-| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                   |
-| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                 |
+| 问题类型                       | 首选接口                                     | 关键参数                                                                    |
+| ------------------------------ | -------------------------------------------- | --------------------------------------------------------------------------- |
+| 整体人生、长期事业、财运、婚恋 | `POST /bazi-ziwei/prompt`                    | `baziPromptTopic`、`ziweiPromptTopic`、`promptScope: "full"` 或 `"origin"`  |
+| 今年运势、当前阶段、某年趋势   | `POST /bazi-ziwei/prompt`                    | `promptScope: "yearly"`，主题按事业、财运、感情等选择                       |
+| 换工作、创业、合伙、投资       | `POST /bazi-ziwei/prompt`                    | `job-change`、`startup-partnership`、`investment-partnership`               |
+| 八字格局、用神、大运流年       | `POST /bazi/prompt`                          | `promptTopic`、`baziFortuneScope`                                           |
+| 紫微宫位、四化、运限           | `POST /ziwei/prompt`                         | `promptTopic`、`promptScope`                                                |
+| 一事一问、短期成败、应期       | `POST /divination/liuyao/prompt`             | `question`、可选 `customDate`                                               |
+| 项目推进、方向、方位、谈判     | `POST /divination/qimen/prompt`              | `question`、可选 `qimenMethod`、`customDate`                                |
+| 临时小事快速判断               | `POST /divination/xiaoliuren/prompt`         | `question`、可选 `xiaoliurenMethod`、`xiaoliurenSchool`、`xiaoliurenNumber` |
+| 时间或数字象意判断             | `POST /divination/meihua/prompt`             | `question`、可选 `method`、`number`、`customDate`                           |
+| 传统复杂事项推演               | `POST /divination/liuren/prompt`             | `question`、可选 `liurenTemplate`、`customDate`                             |
+| 结婚、搬家、开业、签约、安葬   | `POST /divination/almanac/prompt`            | `topic`、`startDate`、`endDate`、可选 `participants`、`page`、`pageSize`    |
+| 星盘本命和行运                 | `POST /divination/astrolabe/prompt`          | 出生时间地点、经纬度、`astrolabeTopic`、`astrolabeScope`                    |
+| 西占双方关系、合作或婚恋互动   | `POST /divination/astrolabe/synastry/prompt` | `person1`、`person2` 分别提供完整出生时间、经纬度和时区                     |
+| 牌阵启发                       | `POST /divination/tarot/prompt`              | `spreadType`、`question`                                                    |
+| 雷诺曼关系或选择牌阵           | `POST /divination/lenormand/prompt`          | `spreadType`、`question`                                                    |
+| 生肖犯太岁、流年贵人           | `POST /metaphysics/zodiac/prompt`            | `zodiac`、`year` 或 `yearGanZhi`                                            |
+| 求签                           | `POST /divination/ssgw/prompt`               | `question`                                                                  |
 
 参数默认建议：
 
@@ -309,7 +312,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 八字 `promptTopic` 支持以下主题：
 `general`（综合）、`recent`（近期）、`career`（事业）、`job-change`（跳槽）、`startup-partnership`（创业合作）、`investment-partnership`（投资合作）、`wealth`（财运）、`marriage`（婚恋）、`relationship-push`（感情推进）、`relationship-decision`（关系去留）、`reconciliation-decision`（复合判断）、`children`（子女）、`family`（家庭）、`home-move`（搬家置业）、`settle-relocate`（定居换城）、`social`（人际合作）、`emotion`（情绪心理）、`health`（健康）、`parents`（父母）、`study`（学业）、`study-advance`（考证进修）、`exam-landing`（考试上岸）、`growth`（成长方向）、`talent`（天赋特质）。
 
-八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。选择 `dayun`、`year`、`month`、`day` 时，可配套传入 `baziFortuneCycleIndex`、`baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`。
+八字 `/bazi/prompt` 可传 `baziFortuneScope` 指定命限范围：`natal`（本命）、`full`（完整输出版）、`dayun`（大运）、`year`（流年）、`month`（流月）、`day`（流日）。`full` 会写入完整大运与逐年流年，不需要再传具体年限参数。选择 `dayun` 时必须传 `baziFortuneCycleIndex`；选择 `year`、`month`、`day` 时必须依次传入对应层级的 `baziFortuneYear`、`baziFortuneMonth`、`baziFortuneDay`，交运年份可同时传 `baziFortuneCycleIndex` 消除重叠歧义。工具不会自动选择当前时间或第一项。
 
 紫微 `promptTopic` 支持以下主题：
 `destiny`（命局）、`relationship`（感情）、`relationship-push`（感情推进）、`relationship-decision`（关系去留）、`career-wealth`（事业财运）、`job-change`（工作变动）、`startup-partnership`（创业合作）、`investment-partnership`（投资合作）、`recent`（近期趋势）、`family`（六亲家庭）、`home-move`（搬家置业）、`settle-relocate`（定居换城）、`social`（人际合作）、`emotion`（情绪心理）、`health`（健康养护）、`study`（学业成长）、`study-advance`（考证进修）、`exam-landing`（考试上岸）、`growth`（成长方向）、`talent`（天赋特质）、`reconciliation-decision`（复合判断）、`life`（人生解析）、`chat`（自由聊天）。
@@ -349,7 +352,8 @@ Python `urllib` 默认 `User-Agent` 可能被 Cloudflare 拦截；Python 调用�
 - 黄历择日 `topic`：`marriage`（嫁娶）、`move`（搬家）、`opening`（开业）、`contract`（签约）、`travel`（出行）、`medical`（求医）、`study`（求学）、`burial`（安葬修坟）、`renovation`（修造动土）、`custom`（自定义）。
 - 黄历择日 `startDate`、`endDate`：日期范围字符串，一次最多 31 天。`participants`：参与者数组，每人包含 `id`、`name`、`gender`、`year`、`month`、`day`、`timeIndex`、`dateType`、`isLeapMonth`，一次最多 30 位；更多日期或参与人请拆成多次请求。
 - 黄历择日 `page`、`pageSize`：分页参数，`pageSize` 最大 31。不传分页时返回全部日期；传分页后只返回当前页并带 `pagination`。`page` 超过总页数会返回 400，请按 `pagination.totalPages` 继续请求。
-- 星盘 `year`、`month`、`day`、`hour`、`minute`：出生时间。`latitude`、`longitude`：经纬度。`timezone`：时区偏移。`locationName`：地点名称。可传 `useTrueSolarTime` 附带真太阳时参考证据，但不改变现代星历计算时刻；提示词接口可传 `astrolabeTopic`、`astrolabeScope`、`astrolabeScopeDate` 和 `astrolabeScopeText`。`astrolabeScope` 支持 `natal`、`full`、`yearly`、`monthly`、`daily`；`full` 会写入本命、当前流年、当前流月、当前流日行运资料；传入 `astrolabeScopeText` 时以自定义文本为准。
+- 雷诺曼 `spreadType`：`single`（单牌）、`three`（三牌）、`five`（五牌十字阵）、`relationship`（关系）、`decision`（选择）、`nine`（九宫）、`element`（元素牌阵）、`grandTableau`（大桌牌阵）。
+- 星盘 `year`、`month`、`day`、`hour`、`minute`：出生时间。`latitude`、`longitude`：经纬度。`timezone`：时区偏移。`locationName`：地点名称。可传 `useTrueSolarTime` 启用真太阳时校正；提示词接口可传 `astrolabeTopic`、`astrolabeScope`、`astrolabeScopeDate` 和 `astrolabeScopeText`。`astrolabeScope` 支持 `natal`、`full`、`yearly`、`monthly`、`daily`；`yearly`、`monthly`、`daily` 分别要求 `YYYY`、`YYYY-MM`、`YYYY-MM-DD` 格式的 `astrolabeScopeDate`，`full` 也必须提供 `YYYY-MM-DD` 基准日并写入该日所属的本命、流年、流月、流日资料；传入 `astrolabeScopeText` 时以自定义文本为准。
 
 AI 接口参数：
 

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -49,7 +49,7 @@ import {
 } from 'mingyu-core/foundation';
 import { buildDivinationPrompt } from '../divination/engine';
 import { getDivinationSummaryBlocks } from '../divination/summary';
-import { buildAstrolabeScopeContext } from '../astrolabe-scope';
+import { buildAstrolabeFullScopeContexts, buildAstrolabeScopeContext } from '../astrolabe-scope';
 import { buildAstrolabeSynastryPrompt } from '../astrolabe-synastry-prompt';
 import { getCompatibilityPrompt, type CompatType } from '../../utils/ai/aiPrompts';
 import {
@@ -339,7 +339,8 @@ const DIVINATION_REQUEST_PROPERTIES = {
   },
   astrolabeScopeDate: {
     type: 'string',
-    description: '星盘行运日期；yearly 用年份，monthly 用 年-月，daily 用 年-月-日。',
+    description:
+      '星盘行运日期；full 和 daily 用 YYYY-MM-DD，yearly 用 YYYY，monthly 用 YYYY-MM。除 natal 外均必填。',
   },
   astrolabeScopeText: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
   promptMode: { enum: [...PROMPT_MODES] },
@@ -1182,20 +1183,24 @@ export function getPublicApiOpenApiDocument(
                 baziFortuneCycleIndex: {
                   type: 'integer',
                   minimum: 0,
-                  description: '大运序号，从 0 开始；选择大运、流年、流月或流日时可传。',
+                  description:
+                    '大运序号，从 0 开始；选择大运时必填，选择流年、流月或流日时可与年份一起传入以消除交运年歧义。',
                 },
-                baziFortuneYear: { type: 'integer', description: '指定流年年份。' },
+                baziFortuneYear: {
+                  type: 'integer',
+                  description: '指定流年年份；选择流年、流月或流日时必填。',
+                },
                 baziFortuneMonth: {
                   type: 'integer',
                   minimum: 1,
                   maximum: 12,
-                  description: '指定流月序号。',
+                  description: '指定流月序号；选择流月或流日时必填。',
                 },
                 baziFortuneDay: {
                   type: 'integer',
                   minimum: 1,
                   maximum: 31,
-                  description: '指定流日序号。',
+                  description: '指定流日序号；选择流日时必填。',
                 },
                 responseMode: DIVINATION_REQUEST_PROPERTIES.responseMode,
                 school: {
@@ -2203,26 +2208,34 @@ function readShenShaVariants(input: JsonRecord): Partial<ShenShaVariantConfig> |
 
 function buildBaziFortuneContextFromInput(result: BaziChartResult, input: JsonRecord) {
   const scope = readEnum(input, 'baziFortuneScope', BAZI_FORTUNE_SCOPES, 'natal');
-  const readOptionalInteger = (key: string, min: number, max: number) =>
-    input[key] === undefined ? undefined : readInteger(input, key, min, max);
   const selection: BaziFortuneSelectionValue = {
     scope,
     cycleIndex:
       scope === 'natal' || scope === 'full'
         ? undefined
-        : readInteger(input, 'baziFortuneCycleIndex', 0, 99, 0),
+        : scope === 'dayun' || input.baziFortuneCycleIndex !== undefined
+          ? readInteger(input, 'baziFortuneCycleIndex', 0, 99)
+          : undefined,
     year:
       scope === 'year' || scope === 'month' || scope === 'day'
-        ? readOptionalInteger('baziFortuneYear', 1900, 2200)
+        ? readInteger(input, 'baziFortuneYear', 1900, 2200)
         : undefined,
     month:
       scope === 'month' || scope === 'day'
-        ? readOptionalInteger('baziFortuneMonth', 1, 12)
+        ? readInteger(input, 'baziFortuneMonth', 1, 12)
         : undefined,
-    day: scope === 'day' ? readOptionalInteger('baziFortuneDay', 1, 31) : undefined,
+    day: scope === 'day' ? readInteger(input, 'baziFortuneDay', 1, 31) : undefined,
   };
 
-  return buildFortuneSelectionContext(result, selection);
+  try {
+    return buildFortuneSelectionContext(result, selection);
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '八字年限参数无效。',
+    );
+  }
 }
 
 function buildBaziPrompt(input: JsonRecord) {
@@ -2772,12 +2785,13 @@ function buildAstrolabeSynastryPromptApi(input: JsonRecord) {
   });
 }
 
-function buildAstrolabeFullScopePromptText(data: AstrolabeData) {
+function buildAstrolabeFullScopePromptText(data: AstrolabeData, referenceDateStr: string) {
+  const fullContexts = buildAstrolabeFullScopeContexts(data, referenceDateStr);
   const contexts = [
-    buildAstrolabeScopeContext(data, 'natal', ''),
-    buildAstrolabeScopeContext(data, 'yearly', ''),
-    buildAstrolabeScopeContext(data, 'monthly', ''),
-    buildAstrolabeScopeContext(data, 'daily', ''),
+    fullContexts.natal,
+    fullContexts.yearly,
+    fullContexts.monthly,
+    fullContexts.daily,
   ];
   const lines = contexts
     .map((context) => context.promptText)
@@ -2797,13 +2811,21 @@ function buildAstrolabePromptScopeText(input: JsonRecord, data: AstrolabeData) {
     ASTROLABE_PROMPT_SCOPES,
     'natal',
   ) as (typeof ASTROLABE_PROMPT_SCOPES)[number];
+  const dateStr = scope === 'natal' ? '' : readRequiredString(input, 'astrolabeScopeDate');
 
-  if (scope === 'full') {
-    return buildAstrolabeFullScopePromptText(data);
+  try {
+    if (scope === 'full') {
+      return buildAstrolabeFullScopePromptText(data, dateStr);
+    }
+
+    return buildAstrolabeScopeContext(data, scope, dateStr).promptText;
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '星盘行运日期无效。',
+    );
   }
-
-  const dateStr = readString(input, 'astrolabeScopeDate', '');
-  return buildAstrolabeScopeContext(data, scope, dateStr).promptText;
 }
 
 function buildAstrolabeScopeEvidence(input: JsonRecord, data: AstrolabeData) {
@@ -2818,19 +2840,24 @@ function buildAstrolabeScopeEvidence(input: JsonRecord, data: AstrolabeData) {
     ASTROLABE_PROMPT_SCOPES,
     'natal',
   ) as (typeof ASTROLABE_PROMPT_SCOPES)[number];
-  if (scope === 'full') {
-    return {
-      scope: 'full' as const,
-      contexts: {
-        natal: buildAstrolabeScopeContext(data, 'natal', ''),
-        yearly: buildAstrolabeScopeContext(data, 'yearly', ''),
-        monthly: buildAstrolabeScopeContext(data, 'monthly', ''),
-        daily: buildAstrolabeScopeContext(data, 'daily', ''),
-      },
-    };
-  }
+  const dateStr = scope === 'natal' ? '' : readRequiredString(input, 'astrolabeScopeDate');
+  try {
+    if (scope === 'full') {
+      return {
+        scope: 'full' as const,
+        referenceDate: dateStr,
+        contexts: buildAstrolabeFullScopeContexts(data, dateStr),
+      };
+    }
 
-  return buildAstrolabeScopeContext(data, scope, readString(input, 'astrolabeScopeDate', ''));
+    return buildAstrolabeScopeContext(data, scope, dateStr);
+  } catch (error) {
+    throw new ApiError(
+      400,
+      'BAD_REQUEST',
+      error instanceof Error ? error.message : '星盘行运日期无效。',
+    );
+  }
 }
 
 function buildDivinationPromptResult(

--- a/src/lib/query-state.ts
+++ b/src/lib/query-state.ts
@@ -645,8 +645,12 @@ function normalizeZiweiScopeDate(scope: ZiweiScopeMode, dateStr: string) {
 }
 
 function normalizeAstrolabeScopeDate(scope: AstrolabeScopeMode, dateStr: string) {
-  if (scope === 'natal' || scope === 'full' || !dateStr) {
+  if (scope === 'natal' || !dateStr) {
     return '';
+  }
+
+  if (scope === 'full') {
+    return parseScopeDateParts(dateStr) ? dateStr : '';
   }
 
   if (scope === 'yearly') {
@@ -679,6 +683,9 @@ function normalizePromptState(prompt: QueryPromptState): QueryPromptState {
     normalized.astrolabeScope,
     normalized.astrolabeScopeDate,
   );
+  if (normalized.astrolabeScope !== 'natal' && !normalized.astrolabeScopeDate) {
+    normalized.astrolabeScope = 'natal';
+  }
 
   if (normalized.baziFortuneScope === 'natal' || normalized.baziFortuneScope === 'full') {
     normalized.baziFortuneCycleIndex = '';

--- a/src/pages/ResultPage/components/AstrolabeScopeModal.tsx
+++ b/src/pages/ResultPage/components/AstrolabeScopeModal.tsx
@@ -350,7 +350,11 @@ export function AstrolabeScopeModal(props: {
               onClick={() => {
                 onApply(
                   draftScope,
-                  draftScope === 'natal' || draftScope === 'full' ? '' : draftScopeDateStr,
+                  draftScope === 'natal'
+                    ? ''
+                    : draftScope === 'full'
+                      ? formatDateByScope('daily', draftYear, draftMonth, normalizedDraftDay)
+                      : draftScopeDateStr,
                 );
                 onClose();
               }}

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -14,7 +14,7 @@ import {
   type QueryPromptState,
   type ResultTabKey,
 } from '@/lib/query-state';
-import { buildAstrolabeScopeContext } from '@/lib/astrolabe-scope';
+import { buildAstrolabeFullScopeContexts, buildAstrolabeScopeContext } from '@/lib/astrolabe-scope';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
 import { shouldUsePhoneLayout } from '@/lib/responsive-layout';
 import { PageTopbar } from '@/components/PageTopbar';
@@ -499,7 +499,11 @@ export function ResultPage() {
       return { scope: 'natal' as const };
     }
 
-    return baziFortuneSelectionModule.normalizeFortuneSelection(baziResult, baziFortuneSelection);
+    try {
+      return baziFortuneSelectionModule.normalizeFortuneSelection(baziResult, baziFortuneSelection);
+    } catch {
+      return { scope: 'natal' as const };
+    }
   }, [baziFortuneSelection, baziFortuneSelectionModule, baziResult]);
   const baziFortuneContext = useMemo(() => {
     if (!baziResult || !baziFortuneSelectionModule) {
@@ -518,9 +522,9 @@ export function ResultPage() {
     [baziResult, currentScopeDate],
   );
   const baziFortunePreset: FortuneScopePreset =
-    promptState.baziFortuneScope === 'natal'
+    normalizedBaziFortuneSelection.scope === 'natal'
       ? 'default'
-      : promptState.baziFortuneScope === 'full'
+      : normalizedBaziFortuneSelection.scope === 'full'
         ? 'all'
         : recentBaziFortuneSelection &&
             isSameBaziFortuneSelection(normalizedBaziFortuneSelection, recentBaziFortuneSelection)
@@ -597,7 +601,7 @@ export function ResultPage() {
     }
     updatePromptState({
       astrolabeScope: value === 'all' ? 'full' : value === 'recent' ? 'monthly' : 'natal',
-      astrolabeScopeDate: value === 'recent' ? currentDateStr : '',
+      astrolabeScopeDate: value === 'recent' || value === 'all' ? currentDateStr : '',
     });
   }
 
@@ -694,13 +698,10 @@ export function ResultPage() {
       return null;
     }
 
-    return buildAstrolabeFullScopePromptText({
-      natal: buildAstrolabeScopeContext(astrolabeCalculation.data, 'natal', ''),
-      yearly: buildAstrolabeScopeContext(astrolabeCalculation.data, 'yearly', ''),
-      monthly: buildAstrolabeScopeContext(astrolabeCalculation.data, 'monthly', ''),
-      daily: buildAstrolabeScopeContext(astrolabeCalculation.data, 'daily', ''),
-    });
-  }, [astrolabeCalculation.data, promptState.astrolabeScope]);
+    return buildAstrolabeFullScopePromptText(
+      buildAstrolabeFullScopeContexts(astrolabeCalculation.data, promptState.astrolabeScopeDate),
+    );
+  }, [astrolabeCalculation.data, promptState.astrolabeScope, promptState.astrolabeScopeDate]);
 
   const activeBaziQuestionScopeLabel = useMemo(() => {
     if (activeBaziShortcutMode === '自定义' || activeBaziShortcutMode === '问题灵感') {
@@ -1927,7 +1928,7 @@ export function ResultPage() {
         <Suspense fallback={<BaziFortuneLoadingModal />}>
           <LazyBaziFortuneModal
             result={baziResult}
-            selection={baziFortuneSelection}
+            selection={normalizedBaziFortuneSelection}
             onClose={() => setIsBaziFortuneModalOpen(false)}
             onApply={applyBaziFortuneSelection}
           />

--- a/tests/astrolabe-scope.test.ts
+++ b/tests/astrolabe-scope.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildAstrolabeFullScopeContexts,
   buildAstrolabeScopeContext,
   calculateSecondaryProgressionEvidence,
   calculateSolarArcEvidence,
@@ -87,10 +88,15 @@ test('星盘完整输出版显示完整行运资料摘要', () => {
   const context = buildAstrolabeScopeContext(astrolabeData, 'full', '2028-06-01');
 
   assert.equal(context.scope, 'full');
-  assert.equal(context.displayText, '本命盘与完整行运资料');
-  assert.equal(context.dateStr, '');
-  assert.match(context.promptText, /分析对象：本命盘与完整行运资料。/);
+  assert.equal(context.displayText, '本命盘与完整行运资料 · 2028-06-01');
+  assert.equal(context.dateStr, '2028-06-01');
+  assert.match(context.promptText, /以2028-06-01为基准的完整行运资料/);
   assert.match(context.promptText, /本命宫主星：第1宫/);
+
+  const contexts = buildAstrolabeFullScopeContexts(astrolabeData, '2028-06-01');
+  assert.equal(contexts.yearly.dateStr, '2028');
+  assert.equal(contexts.monthly.dateStr, '2028-06');
+  assert.equal(contexts.daily.dateStr, '2028-06-01');
 });
 
 test('星盘流年分析对象会生成行运证据和展示文本', () => {
@@ -233,12 +239,24 @@ test('星盘流月与流日沿用同一选择器语义并写入对应行运资�
   assert.doesNotMatch(`${monthContext.promptText}\n${dayContext.promptText}`, /不得|时间边界|证据/);
 });
 
-test('星盘范围日期不存在时不应夹到另一天', () => {
-  const invalidDayContext = buildAstrolabeScopeContext(astrolabeData, 'daily', '2028-02-31');
-  const invalidMonthContext = buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-13');
-
-  assert.notEqual(invalidDayContext.dateStr, '2028-02-29');
-  assert.notEqual(invalidMonthContext.dateStr, '2028-12');
+test('星盘行运范围应拒绝缺失、错格式和不存在的日期', () => {
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'daily', '2028-02-31'),
+    /流日日期无效/,
+  );
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-13'),
+    /流月日期无效/,
+  );
+  assert.throws(() => buildAstrolabeScopeContext(astrolabeData, 'yearly', ''), /流年必须提供 YYYY/);
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'monthly', '2028-6'),
+    /流月必须提供 YYYY-MM/,
+  );
+  assert.throws(
+    () => buildAstrolabeScopeContext(astrolabeData, 'full', ''),
+    /完整输出必须提供 YYYY-MM-DD/,
+  );
 });
 
 test('星盘行运范围应支持 2100 年以后的有效年份', () => {
@@ -284,4 +302,37 @@ test('星盘资料缺少宫头经度时应禁止行运落宫证据', () => {
 
   assert.match(context.promptText, /行运落宫：本命宫头资料不足/);
   assert.doesNotThrow(() => buildAstrolabeScopeContext(incompleteData, 'daily', '2028-06-12'));
+});
+
+test('星盘行运应使用目标日期的出生地时区而不是固定北京时间', () => {
+  const newYorkData = generateAstrolabe({
+    name: '本人',
+    gender: '女',
+    year: '1995',
+    month: '5',
+    day: '20',
+    hour: '12',
+    minute: '30',
+    latitude: '40.7128',
+    longitude: '-74.0060',
+    timeZoneId: 'America/New_York',
+    locationName: '纽约',
+  });
+  const context = buildAstrolabeScopeContext(newYorkData, 'daily', '2028-07-12');
+
+  assert.match(context.promptText, /America\/New_York（UTC-4）/);
+  assert.match(context.promptText, /行运落宫：取样时区UTC-4/);
+  assert.doesNotMatch(context.promptText, /按北京时间|取样时区UTC\+8/);
+});
+
+test('星盘行运缺少真实经纬度时不得静默使用零度坐标', () => {
+  const incompleteData = structuredClone(astrolabeData) as AstrolabeData;
+  delete incompleteData.birth.latitude;
+  delete incompleteData.birth.longitude;
+  incompleteData.birth.location = '未知地点';
+
+  assert.throws(
+    () => buildAstrolabeScopeContext(incompleteData, 'daily', '2028-06-12'),
+    /缺少有效出生地经纬度/,
+  );
 });

--- a/tests/bazi-ai-prompt.test.ts
+++ b/tests/bazi-ai-prompt.test.ts
@@ -120,6 +120,7 @@ test('八字提示词写入年限选择后应保留岁运资料并省略控制�
   const fortuneContext = buildFortuneSelectionContext(result, {
     scope: 'year',
     cycleIndex: 0,
+    year: 1990,
   });
 
   assert.ok(fortuneContext);

--- a/tests/fortune-selection.test.ts
+++ b/tests/fortune-selection.test.ts
@@ -264,3 +264,50 @@ test('交运年份默认应归到后一步大运，而不是继续挂在童运�
   assert.equal(normalized.cycleIndex, 1);
   assert.equal(result.luckInfo.cycles[normalized.cycleIndex ?? -1]?.ganZhi, '乙亥');
 });
+
+test('核心运限选择不得把缺失字段静默替换成当前时间或第一项', () => {
+  const result = createMockResult();
+
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'dayun' }),
+    /必须提供有效的大运序号/,
+  );
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'year', cycleIndex: 0 }),
+    /必须提供属于该大运的有效流年年份/,
+  );
+  assert.throws(
+    () =>
+      normalizeFortuneSelection(result, {
+        scope: 'month',
+        cycleIndex: 0,
+        year: 2008,
+      }),
+    /必须提供有效的流月序号/,
+  );
+  assert.throws(
+    () =>
+      normalizeFortuneSelection(result, {
+        scope: 'day',
+        cycleIndex: 0,
+        year: 2008,
+        month: 1,
+      }),
+    /必须提供该节令月内的有效流日序号/,
+  );
+});
+
+test('明确流年可定位所属大运，但冲突的大运序号必须拒绝', () => {
+  const result = createMockResult();
+  const inferred = normalizeFortuneSelection(result, { scope: 'year', year: 2009 });
+
+  assert.deepEqual(inferred, {
+    scope: 'year',
+    cycleIndex: 0,
+    year: 2009,
+  });
+  assert.throws(
+    () => normalizeFortuneSelection(result, { scope: 'year', cycleIndex: 99, year: 2009 }),
+    /必须提供有效的大运序号/,
+  );
+});

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -1223,6 +1223,7 @@ test('MCP 八字年限提示词应返回逐层岁运触发证据', async () => {
         promptTopic: 'career',
         baziFortuneScope: 'year',
         baziFortuneCycleIndex: 1,
+        baziFortuneYear: 1998,
       },
     });
 
@@ -1272,9 +1273,52 @@ test('MCP 八字年限提示词应返回逐层岁运触发证据', async () => {
     assert.ok(triggerEvidence?.limitationFacts?.some((item) => item.type === '层级应期边界'));
     assertEvidenceOwnerReferences(triggerEvidence);
     const prompt = String(response.structuredContent?.prompt);
-    assert.match(prompt, /【分析对象】[\s\S]*分析对象：1997年流年/);
+    assert.match(prompt, /【分析对象】[\s\S]*分析对象：1998年流年/);
     assert.match(prompt, /【岁运重点】[\s\S]*主要触发：/);
     assert.doesNotMatch(prompt, /结构化证据|计算链|证据汇总|解释限制|证据边界/);
+  });
+});
+
+test('MCP 八字和星盘年限缺少明确层级参数时应返回业务错误', async () => {
+  await withMcpClient(async (client) => {
+    const bazi = await client.callTool({
+      name: 'bazi_prompt',
+      arguments: {
+        gender: 'male',
+        year: 1990,
+        month: 5,
+        day: 15,
+        timeIndex: 1,
+        dateType: 'solar',
+        question: '请分析指定流年。',
+        baziFortuneScope: 'year',
+        baziFortuneCycleIndex: 1,
+      },
+    });
+    assert.equal(bazi.isError, true);
+    const baziText = bazi.content[0]?.type === 'text' ? bazi.content[0].text : '';
+    assert.match(baziText, /baziFortuneYear/);
+
+    const astrolabe = await client.callTool({
+      name: 'astrolabe_prompt',
+      arguments: {
+        name: '本人',
+        gender: '女',
+        year: 1995,
+        month: 5,
+        day: 20,
+        hour: 12,
+        minute: 30,
+        latitude: 39.9042,
+        longitude: 116.4074,
+        timezone: 8,
+        question: '请分析完整行运。',
+        astrolabeScope: 'full',
+      },
+    });
+    assert.equal(astrolabe.isError, true);
+    const astrolabeText = astrolabe.content[0]?.type === 'text' ? astrolabe.content[0].text : '';
+    assert.match(astrolabeText, /astrolabeScopeDate/);
   });
 });
 

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -1471,6 +1471,7 @@ test('公开 API 八字年限提示词保留岁运资料但不拼接工程证据
       promptTopic: 'career',
       baziFortuneScope: 'year',
       baziFortuneCycleIndex: 1,
+      baziFortuneYear: 1998,
     }),
   });
 
@@ -2831,6 +2832,39 @@ test('公开 API 奇门默认转盘，可通过 qimenMethod 请求飞盘', async
   );
 });
 
+test('公开 API 八字年限范围缺少必要层级参数时应拒绝而非套用第一项', async () => {
+  const base = {
+    gender: 'male',
+    year: 1990,
+    month: 5,
+    day: 15,
+    timeIndex: 1,
+    dateType: 'solar',
+    question: '请分析指定年限。',
+  };
+  const cases = [
+    { ...base, baziFortuneScope: 'dayun' },
+    { ...base, baziFortuneScope: 'year', baziFortuneCycleIndex: 1 },
+    { ...base, baziFortuneScope: 'month', baziFortuneYear: 1998 },
+    {
+      ...base,
+      baziFortuneScope: 'day',
+      baziFortuneYear: 1998,
+      baziFortuneMonth: 1,
+    },
+  ];
+
+  for (const payload of cases) {
+    const { response, body } = await callApi('bazi/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 400, JSON.stringify(payload));
+    assert.equal(body.error.code, 'BAD_REQUEST');
+  }
+});
+
 test('公开 API 奇门排盘支持轻量模式，便于调用方按需拆分请求', async () => {
   const customDate = '2025-01-01T08:00:00+08:00';
   const fullResult = await callApi('divination/qimen', {
@@ -3277,6 +3311,7 @@ test('公开 API 星盘提示词支持完整输出版行运资料', async () => 
       question: '整体人生和近期重点怎么看？',
       astrolabeTopic: 'life',
       astrolabeScope: 'full',
+      astrolabeScopeDate: '2028-06-12',
       responseMode: 'prompt-only',
     }),
   });
@@ -3343,6 +3378,38 @@ test('公开 API 星盘提示词支持完整输出版行运资料', async () => 
       ),
     );
     assert.match(evidence.promptText, /证据汇总：/);
+  }
+});
+
+test('公开 API 星盘非本命范围必须提供匹配范围的明确日期', async () => {
+  const base = {
+    name: '本人',
+    gender: '女',
+    year: 1995,
+    month: 5,
+    day: 20,
+    hour: 12,
+    minute: 30,
+    latitude: 39.9042,
+    longitude: 116.4074,
+    timezone: 8,
+    question: '请分析指定行运。',
+  };
+  const cases = [
+    { ...base, astrolabeScope: 'full' },
+    { ...base, astrolabeScope: 'yearly', astrolabeScopeDate: '2028-06' },
+    { ...base, astrolabeScope: 'monthly', astrolabeScopeDate: '2028-13' },
+    { ...base, astrolabeScope: 'daily', astrolabeScopeDate: '2028-02-31' },
+  ];
+
+  for (const payload of cases) {
+    const { response, body } = await callApi('divination/astrolabe/prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(response.status, 400, JSON.stringify(payload));
+    assert.equal(body.error.code, 'BAD_REQUEST');
   }
 });
 

--- a/tests/query-state-defaults.test.ts
+++ b/tests/query-state-defaults.test.ts
@@ -467,20 +467,20 @@ test('星盘提示词指定年限日期会写入并从地址栏恢复', () => {
   assert.equal(parsed.astrolabeScopeDate, '2028-06');
 });
 
-test('星盘提示词完整输出版会写入并清空日期', () => {
+test('星盘提示词完整输出版会写入并恢复明确基准日', () => {
   const search = buildResultSearch(defaultInputState, {
     ...defaultPromptState,
     promptSource: 'astrolabe',
     astrolabeScope: 'full',
-    astrolabeScopeDate: '2028-06',
+    astrolabeScopeDate: '2028-06-12',
   });
 
   assert.match(search, /as=full/);
-  assert.doesNotMatch(search, /asd=2028-06/);
+  assert.match(search, /asd=2028-06-12/);
 
   const parsed = parsePromptState(new URLSearchParams(search));
   assert.equal(parsed.astrolabeScope, 'full');
-  assert.equal(parsed.astrolabeScopeDate, '');
+  assert.equal(parsed.astrolabeScopeDate, '2028-06-12');
 });
 
 test('七政四余和八宅提示词来源可从地址栏恢复', () => {
@@ -551,7 +551,15 @@ test('星盘提示词范围日期应按范围校验并清空非法日期', () =>
       }),
     );
 
-    assert.equal(parsed.astrolabeScope, scope);
+    assert.equal(parsed.astrolabeScope, 'natal');
+    assert.equal(parsed.astrolabeScopeDate, '');
+  }
+});
+
+test('星盘非本命范围缺少日期时应整体回到本命而不是等待核心补当前日期', () => {
+  for (const scope of ['full', 'yearly', 'monthly', 'daily'] as const) {
+    const parsed = parsePromptState(new URLSearchParams({ astrolabeScope: scope }));
+    assert.equal(parsed.astrolabeScope, 'natal');
     assert.equal(parsed.astrolabeScopeDate, '');
   }
 });


### PR DESCRIPTION
## 目标
从三个历史审查 PR 中筛选可独立验证、与现有代码兼容的改动，收紧公开接口和 MCP 工具的隐式输入，并统一星盘行运日期与出生地时区基准。

## 主要修改
- 将八字大运、流年、流月、流日参数改为明确必填，禁止静默回退到当前日期或默认值。
- 要求星盘行运提供明确日期；`full` 范围必须提供基准日期。
- 星盘行运按目标日期对应的出生地时区计算，补充 API、MCP README 和公开 Skill 文档说明。
- 修正提示词中的内部“取样时间”表述，统一为用户可理解的“行运基准”。
- 补充并更新相关回归测试。

## 来源审查
- #176：仅引入其中可独立验证的输入校验和星盘基准改动。
- #181：未整体引入长期审查链，避免把未完成的审查流程混入正式代码。
- #187：未引入大规模删除未校验能力的方案，避免扩大本次变更范围和兼容风险。

## 验证
- `pnpm test`：1460/1460
- `pnpm test:e2e`：37/37
- `pnpm prompt:check`：226/226
- `pnpm exec tsc --noEmit -p tsconfig.app.json`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

构建仅保留已有的 `astronomy-engine` default export 警告及前端 chunk 体积提示。

## 风险与兼容性
这是对隐式输入的收紧：调用方需要补齐原本可能被默认填充的日期或行运基准；不包含大规模删除能力、公共历史重写或其他无关重构。