### PR TITLE
统一传统占卜盘面展示

### DIFF
--- a/src/components/DivinationPanel/DivinationResult.tsx
+++ b/src/components/DivinationPanel/DivinationResult.tsx
@@ -2,17 +2,9 @@ import { useMemo } from 'react';
 import type { DivinationDraft } from '@/lib/divination/engine';
 import type { DivinationSession } from '@/lib/divination/engine';
 import type { DivinationSummaryBlocks } from '@/lib/divination/summary';
-import type {
-  AstrolabeData,
-  JinkoujueData,
-  LiurenData,
-  LiurenPlateItem,
-  LiurenTransmission,
-  XiaoliurenData,
-  XiaoliurenPalaceDetail,
-} from '@/types/divination';
-import { AstrolabeChart } from '@/components/AstrolabeChart';
+import type { LiurenData, LiurenPlateItem, LiurenTransmission } from '@/types/divination';
 import { AiChatPanel } from '@/components/AiChatPanel';
+import { TraditionalDivinationBoard } from '@/components/DivinationPanel/TraditionalDivinationBoard';
 import { useAiSettings } from '@/hooks/useAiSettings';
 import { buildAiRequestConfig } from '@/lib/ai/settings';
 
@@ -50,56 +42,6 @@ function findLiurenTransmissionStage(
   branch: string,
 ): LiurenTransmission['stage'] | null {
   return transmissions.find((item) => item.branch === branch)?.stage || null;
-}
-
-function XiaoliurenPalaceCard(props: {
-  label: string;
-  detail: XiaoliurenPalaceDetail;
-  primary?: boolean;
-}) {
-  const { label, detail, primary = false } = props;
-
-  return (
-    <article className="xiaoliuren-stage-card">
-      <div className="xiaoliuren-stage-head">
-        <span>{label}</span>
-        <strong>{detail.name}</strong>
-      </div>
-      {primary ? <p>{detail.verse}</p> : <small>顺数中间位置</small>}
-    </article>
-  );
-}
-
-function XiaoliurenBoard({ data }: { data: XiaoliurenData }) {
-  return (
-    <div className="divination-extra-panel xiaoliuren-board">
-      <div className="divination-extra-head">
-        <strong>小六壬时间课</strong>
-        <span>
-          农历{data.isLeapMonth ? '闰' : ''}
-          {data.lunarMonth}月{data.lunarDay}日 · {data.hourLabel}
-        </span>
-      </div>
-
-      <div className="xiaoliuren-card-grid">
-        <XiaoliurenPalaceCard label="月宫" detail={data.sequence.month} />
-        <XiaoliurenPalaceCard label="日宫" detail={data.sequence.day} />
-        <XiaoliurenPalaceCard label="时宫" detail={data.sequence.hour} primary />
-      </div>
-
-      <div className="xiaoliuren-overview-grid">
-        <div className="xiaoliuren-overview-item">
-          <span>占得宫</span>
-          <strong>{data.primary.name}</strong>
-        </div>
-        <div className="xiaoliuren-overview-item">
-          <span>历法口径</span>
-          <strong>{data.calculation.dayBoundary}</strong>
-          <p>{data.calculation.leapMonthRule}</p>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function LiurenPlateCell({ data, item }: { data: LiurenData; item: LiurenPlateItem }) {
@@ -197,9 +139,9 @@ function LiurenBoard({ data }: { data: LiurenData }) {
     .join(' → ');
 
   return (
-    <div className="divination-extra-panel liuren-board">
+    <div className="divination-extra-panel traditional-board liuren-board">
       <div className="divination-extra-head">
-        <strong>大六壬参考盘</strong>
+        <strong>大六壬天地盘</strong>
         <span>
           {data.ganzhi.day}日 · {data.ganzhi.hour}时
         </span>
@@ -322,6 +264,8 @@ export function DivinationResult({
         <div className="divination-random-note">本次随机到：{methodLabelMap[session.method]}</div>
       ) : null}
 
+      <TraditionalDivinationBoard session={session} />
+
       {!isLiurenResult ? (
         <>
           <div className="divination-tag-cloud">
@@ -340,58 +284,6 @@ export function DivinationResult({
             ))}
           </div>
         </>
-      ) : null}
-
-      {session.method === 'astrolabe' ? (
-        <AstrolabeChart data={session.data as AstrolabeData} />
-      ) : null}
-
-      {session.method === 'jinkoujue' ? (
-        <div className="divination-extra-panel">
-          <div className="divination-extra-title">金口诀四位</div>
-          {(() => {
-            const jinkoujue = session.data as JinkoujueData;
-            return (
-              <>
-                <div className="xiaoliuren-overview-grid">
-                  <div className="xiaoliuren-overview-item">
-                    <strong>地分</strong>
-                    <span>{jinkoujue.positions.diFen.branch}</span>
-                  </div>
-                  <div className="xiaoliuren-overview-item">
-                    <strong>将神</strong>
-                    <span>
-                      {jinkoujue.positions.jiangShen.stem || ''}
-                      {jinkoujue.positions.jiangShen.branch}
-                    </span>
-                  </div>
-                  <div className="xiaoliuren-overview-item">
-                    <strong>贵神</strong>
-                    <span>
-                      {jinkoujue.positions.guiShen.stem || ''}
-                      {jinkoujue.positions.guiShen.branch}乘{jinkoujue.positions.guiShen.god || ''}
-                    </span>
-                  </div>
-                  <div className="xiaoliuren-overview-item">
-                    <strong>人元</strong>
-                    <span>
-                      {jinkoujue.positions.renYuan.stem || ''}
-                      {jinkoujue.positions.renYuan.branch}
-                    </span>
-                  </div>
-                </div>
-                <div className="xiaoliuren-overview-item">
-                  <strong>阴阳发用与动爻</strong>
-                  <span>{jinkoujue.mainLine}</span>
-                </div>
-              </>
-            );
-          })()}
-        </div>
-      ) : null}
-
-      {session.method === 'xiaoliuren' ? (
-        <XiaoliurenBoard data={session.data as XiaoliurenData} />
       ) : null}
 
       {session.method === 'liuren' ? <LiurenBoard data={session.data as LiurenData} /> : null}

--- a/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
+++ b/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
@@ -1,0 +1,651 @@
+import type { ReactNode } from 'react';
+import { AstrolabeChart } from '@/components/AstrolabeChart';
+import type { DivinationSession } from '@/lib/divination/engine';
+import type {
+  AlmanacData,
+  AstrolabeData,
+  JinkoujueData,
+  LenormandData,
+  LiuyaoData,
+  MeihuaData,
+  QimenData,
+  SsgwData,
+  TaiyiResult,
+  TarotData,
+  XiaoliurenData,
+} from '@/types/divination';
+
+const QIMEN_LO_SHU_ORDER = [4, 9, 2, 3, 5, 7, 8, 1, 6];
+const TAIYI_LO_SHU_ORDER = QIMEN_LO_SHU_ORDER;
+
+function TraditionalBoardShell(props: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const { title, subtitle, children, className = '' } = props;
+  return (
+    <section className={`traditional-board ${className}`.trim()}>
+      <div className="traditional-board-head">
+        <div>
+          <span className="traditional-board-kicker">传统盘</span>
+          <h3>{title}</h3>
+        </div>
+        {subtitle ? <p>{subtitle}</p> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function TraditionalMeta(props: { items: Array<[string, string | number | undefined]> }) {
+  return (
+    <div className="traditional-meta-row">
+      {props.items
+        .filter(([, value]) => value !== undefined && value !== '')
+        .map(([label, value]) => (
+          <span key={label}>
+            <b>{label}</b>
+            {value}
+          </span>
+        ))}
+    </div>
+  );
+}
+
+function YaoLine(props: {
+  label?: string;
+  yaoType: '阳' | '阴';
+  changing?: boolean;
+  className?: string;
+}) {
+  const { label, yaoType, changing = false, className = '' } = props;
+  return (
+    <div className={`traditional-yao-line ${className}`.trim()}>
+      {label ? <span className="traditional-yao-label">{label}</span> : null}
+      <span
+        className={`traditional-yao-symbol is-${yaoType === '阴' ? 'yin' : 'yang'}${changing ? ' is-changing' : ''}`}
+        aria-label={`${yaoType}${changing ? '动爻' : ''}`}
+      >
+        <i />
+        {yaoType === '阴' ? <i /> : null}
+      </span>
+      {changing ? <em>动</em> : null}
+    </div>
+  );
+}
+
+function LiuyaoTraditionalBoard({ data }: { data: LiuyaoData }) {
+  const rows = [...data.yaosDetail].sort((a, b) => b.position - a.position);
+  const changing = data.changingYaos
+    ?.filter((item) => item.isChanging)
+    .map((item) => item.position);
+
+  return (
+    <TraditionalBoardShell
+      title={`${data.originalName}${data.changedName ? ` · 变${data.changedName}` : ''}`}
+      subtitle="纳甲六爻盘 · 上爻在上，初爻在下"
+      className="traditional-liuyao-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['卦宫', data.palace?.name ? `${data.palace.name}宫` : undefined],
+          ['卦序', data.palaceStage],
+          ['互卦', data.interName || '无'],
+          ['动爻', changing?.length ? changing.join('、') : '无'],
+          ['旬空', data.voidBranches?.join('、') || '无'],
+        ]}
+      />
+      <div className="traditional-liuyao-table" role="table" aria-label="六爻纳甲盘">
+        <div className="traditional-liuyao-head" role="row">
+          <span>爻位</span>
+          <span>六神</span>
+          <span>六亲</span>
+          <span>爻象</span>
+          <span>纳甲</span>
+          <span>状态</span>
+        </div>
+        {rows.map((yao) => {
+          const state = [
+            yao.isWorld ? '世' : '',
+            yao.isResponse ? '应' : '',
+            yao.isVoid ? '空' : '',
+            yao.isMonthBreak ? '月破' : '',
+            yao.isDayBreak ? '日破' : '',
+          ].filter(Boolean);
+          const relation = yao.changeRelations?.join('、') || yao.changeRelation || '';
+          return (
+            <div className="traditional-liuyao-row" role="row" key={yao.position}>
+              <span className="traditional-yao-position">
+                {yao.position === 1 ? '初爻' : `${yao.position}爻`}
+              </span>
+              <span>{yao.sixGod || '—'}</span>
+              <span>{yao.sixRelative || '—'}</span>
+              <YaoLine yaoType={yao.yaoType} changing={yao.isChanging} />
+              <span>
+                {yao.najiaDizhi || '—'}
+                <small>{yao.wuxing || ''}</small>
+              </span>
+              <span className="traditional-yao-status">
+                {state.length ? state.join(' · ') : '—'}
+                {relation ? <small>{relation}</small> : null}
+                {yao.changedYao ? (
+                  <small>
+                    化{yao.changedYao.dizhi}
+                    {yao.changedYao.wuxing}
+                  </small>
+                ) : null}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {data.hiddenSpirits?.length ? (
+        <div className="traditional-note-row">
+          <b>伏神</b>
+          <span>
+            {data.hiddenSpirits
+              .map(
+                (item) => `${item.sixRelative}伏${item.position}爻${item.najiaDizhi}${item.wuxing}`,
+              )
+              .join('；')}
+          </span>
+        </div>
+      ) : null}
+    </TraditionalBoardShell>
+  );
+}
+
+function MiniHexagram(props: {
+  label: string;
+  hexagram?: {
+    name: string;
+    symbol: string;
+    upper: string;
+    lower: string;
+    description: string;
+  } | null;
+  active?: boolean;
+}) {
+  const { label, hexagram, active = false } = props;
+  return (
+    <article className={`traditional-mini-hexagram${active ? ' is-active' : ''}`}>
+      <span>{label}</span>
+      {hexagram ? (
+        <>
+          <strong>{hexagram.symbol}</strong>
+          <b>{hexagram.name}</b>
+          <small>
+            {hexagram.upper}上 · {hexagram.lower}下
+          </small>
+          <p>{hexagram.description}</p>
+        </>
+      ) : (
+        <em>无</em>
+      )}
+    </article>
+  );
+}
+
+function MeihuaTraditionalBoard({ data }: { data: MeihuaData }) {
+  const rows = [...data.yaosDetail].sort((a, b) => b.position - a.position);
+  return (
+    <TraditionalBoardShell
+      title={data.mainHexagram.name}
+      subtitle="梅花易数三卦体用盘 · 主卦为本，互卦为过程，变卦为结果"
+      className="traditional-meihua-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['起卦法', data.calculation?.method],
+          ['体卦', `${data.tiGua.name}（${data.tiGua.element}）`],
+          ['用卦', `${data.yongGua.name}（${data.yongGua.element}）`],
+          ['动爻', `第${data.movingYao.position}爻`],
+          [
+            '月令',
+            data.analysis.monthBranch ? `${data.analysis.monthBranch}月` : data.analysis.season,
+          ],
+        ]}
+      />
+      <div className="traditional-hexagram-triad">
+        <MiniHexagram label="主卦·本" hexagram={data.mainHexagram} active />
+        <MiniHexagram label="互卦·过程" hexagram={data.interHexagram} />
+        <MiniHexagram label="变卦·结果" hexagram={data.changedHexagram} />
+      </div>
+      <div className="traditional-meihua-detail">
+        <div className="traditional-meihua-relation">
+          <span>体用关系</span>
+          <strong>{data.analysis.tiYongRelation}</strong>
+          <small>
+            {data.analysis.tiSeasonState} · {data.analysis.yongSeasonState}
+          </small>
+        </div>
+        <div className="traditional-meihua-relation">
+          <span>互卦关系</span>
+          <strong>
+            {data.analysis.inter1Relation} · {data.analysis.inter2Relation}
+          </strong>
+          <small>{data.analysis.changedRelation}</small>
+        </div>
+      </div>
+      <div className="traditional-meihua-yaos" role="table" aria-label="梅花六爻体用标记">
+        {rows.map((yao) => (
+          <div
+            key={yao.position}
+            className={yao.position === data.movingYao.position ? 'is-moving' : ''}
+          >
+            <span>{yao.position}爻</span>
+            <YaoLine yaoType={yao.yaoType} changing={yao.isChanging} />
+            <b>{yao.tiYong}</b>
+          </div>
+        ))}
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function XiaoliurenTraditionalBoard({ data }: { data: XiaoliurenData }) {
+  const positions = [
+    { row: 1, column: 2 },
+    { row: 1, column: 3 },
+    { row: 2, column: 3 },
+    { row: 3, column: 3 },
+    { row: 3, column: 2 },
+    { row: 3, column: 1 },
+  ];
+  return (
+    <TraditionalBoardShell
+      title="小六壬六宫盘"
+      subtitle={`农历${data.isLeapMonth ? '闰' : ''}${data.lunarMonth}月${data.lunarDay}日 · ${data.hourLabel}`}
+      className="traditional-xiaoliuren-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['月宫', data.sequence.month.name],
+          ['日宫', data.sequence.day.name],
+          ['时宫', data.sequence.hour.name],
+          ['占得', data.primary.name],
+        ]}
+      />
+      <div className="traditional-six-palace" role="img" aria-label="小六壬六宫盘">
+        {data.palaceOrder.map((palace, index) => {
+          const position = positions[index] || positions[0];
+          const sequenceLabels = [
+            data.sequence.month.name,
+            data.sequence.day.name,
+            data.sequence.hour.name,
+          ];
+          const sequenceCount = sequenceLabels.filter((item) => item === palace.name).length;
+          return (
+            <div
+              className={`traditional-six-palace-cell${palace.name === data.primary.name ? ' is-primary' : ''}`}
+              style={{ gridColumn: position.column, gridRow: position.row }}
+              key={palace.name}
+            >
+              <span>{palace.index + 1}</span>
+              <strong>{palace.name}</strong>
+              <small>{sequenceCount ? `月日时${sequenceCount}中` : palace.verse}</small>
+            </div>
+          );
+        })}
+        <div className="traditional-six-palace-center">
+          <span>月 → 日 → 时</span>
+          <strong>{data.primary.name}</strong>
+        </div>
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function JinkoujueTraditionalBoard({ data }: { data: JinkoujueData }) {
+  const positions = [
+    ['人元', data.positions.renYuan],
+    ['贵神', data.positions.guiShen],
+    ['将神', data.positions.jiangShen],
+    ['地分', data.positions.diFen],
+  ] as const;
+  return (
+    <TraditionalBoardShell
+      title="金口诀四位盘"
+      subtitle={`${data.ganzhi.day}日${data.ganzhi.hour}时 · 月将${data.monthLeader}加${data.divinationBranch}`}
+      className="traditional-jinkoujue-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['昼夜', data.dayNight],
+          ['贵人', data.noblemanBranch],
+          ['旬空', data.xunKong.join('、') || '无'],
+          ['发用', data.yinYangUse.usePosition],
+        ]}
+      />
+      <div className="traditional-jinkoujue-table" role="table" aria-label="金口诀四位盘">
+        {positions.map(([label, item]) => (
+          <div className="traditional-jinkoujue-row" key={label}>
+            <span className="traditional-jinkoujue-role">{label}</span>
+            <strong>
+              {item.stem || ''}
+              {item.branch}
+            </strong>
+            <span>{item.god ? `乘${item.god}` : item.role}</span>
+            <span>
+              {item.element} · {item.yinYang}
+            </span>
+            <small>
+              {item.seasonState}
+              {item.isVoid ? ' · 旬空' : ''}
+            </small>
+          </div>
+        ))}
+      </div>
+      <div className="traditional-note-row">
+        <b>发用</b>
+        <span>{data.mainLine}</span>
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function QimenTraditionalBoard({ data }: { data: QimenData }) {
+  const palaceMap = new Map(data.jiuGongGe.map((item) => [item.gong, item]));
+  return (
+    <TraditionalBoardShell
+      title="奇门遁甲九宫盘"
+      subtitle={`${data.isYangDun ? '阳遁' : '阴遁'}${data.juShu}局 · ${data.method === 'feipan' ? '飞盘' : '转盘'}${data.juMethod === 'zhirun' ? ' · 置闰' : ' · 拆补'}`}
+      className="traditional-qimen-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['值符', data.zhiFu],
+          ['值使', data.zhiShi],
+          ['节气', data.timeInfo.solarTerm],
+          ['旬空', data.voidBranches?.join('、') || '无'],
+          ['驿马', data.horseStar ? `${data.horseStar.branch}·${data.horseStar.name}` : '无'],
+        ]}
+      />
+      <div className="traditional-qimen-grid" role="img" aria-label="奇门遁甲九宫盘">
+        {QIMEN_LO_SHU_ORDER.map((gong) => {
+          const palace = palaceMap.get(gong);
+          if (!palace) return <div className="traditional-qimen-cell is-empty" key={gong} />;
+          const isVoid = data.voidPalaces?.some((item) => item.palace === gong);
+          const isHorse = data.horseStar?.palace === gong;
+          const isZhiFu =
+            palace.tianPan.star === data.zhiFu || palace.tianPan.companionStar === data.zhiFu;
+          const isZhiShi = palace.renPan.door === data.zhiShi;
+          return (
+            <div
+              className={`traditional-qimen-cell${gong === 5 ? ' is-center' : ''}${isVoid ? ' is-void' : ''}${isHorse ? ' is-horse' : ''}`}
+              key={gong}
+            >
+              <div className="traditional-qimen-cell-head">
+                <span>{palace.name}</span>
+                <b>{palace.direction}</b>
+              </div>
+              <div className="traditional-qimen-god">{palace.shenPan.god}</div>
+              <div className="traditional-qimen-star">
+                {palace.tianPan.star}
+                {isZhiFu ? ' · 值符' : ''}
+              </div>
+              <div className="traditional-qimen-door">
+                {palace.renPan.door}
+                {isZhiShi ? ' · 值使' : ''}
+              </div>
+              <div className="traditional-qimen-stems">
+                <span>
+                  天 {palace.tianPan.stem}
+                  {palace.tianPan.companionStem ? `/${palace.tianPan.companionStem}` : ''}
+                </span>
+                <span>地 {palace.diPan.stem}</span>
+              </div>
+              {isVoid ? <em>空</em> : null}
+              {isHorse ? <em>马</em> : null}
+            </div>
+          );
+        })}
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function getTarotSpreadClass(spreadType: string) {
+  return `is-${spreadType.replace(/[^a-z0-9-]/gi, '-')}`;
+}
+
+function TarotTraditionalBoard({ data }: { data: TarotData }) {
+  return (
+    <TraditionalBoardShell
+      title={data.spreadName}
+      subtitle={`塔罗牌阵 · ${data.cards.length}张 · 牌位按传统顺序展开`}
+      className="traditional-tarot-board"
+    >
+      <div className={`traditional-tarot-spread ${getTarotSpreadClass(data.spreadType)}`}>
+        {data.cards.map((card, index) => (
+          <article
+            className={`traditional-tarot-card${card.reversed ? ' is-reversed' : ''}`}
+            key={`${card.position}-${card.id}`}
+          >
+            <span className="traditional-card-index">{index + 1}</span>
+            <span className="traditional-card-position">{card.position}</span>
+            <strong>{card.name}</strong>
+            <b>{card.reversed ? '逆位' : '正位'}</b>
+            <small>{card.keywords.slice(0, 3).join(' · ')}</small>
+          </article>
+        ))}
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function LenormandTraditionalBoard({ data }: { data: LenormandData }) {
+  const hasCoordinates = data.cards.some((card) => card.row && card.column);
+  const isGrandTableau = data.spreadType === 'grandTableau';
+  return (
+    <TraditionalBoardShell
+      title={data.spreadName}
+      subtitle={`雷诺曼牌阵 · ${data.cards.length}张${isGrandTableau ? ' · 大 Tableau 牌阵' : ''}`}
+      className="traditional-lenormand-board"
+    >
+      <div
+        className={`traditional-lenormand-grid${hasCoordinates ? ' has-coordinates' : ''}`}
+        style={isGrandTableau ? { gridTemplateColumns: 'repeat(9, minmax(0, 1fr))' } : undefined}
+      >
+        {data.cards.map((card) => (
+          <article
+            className="traditional-lenormand-card"
+            key={`${card.position}-${card.id}`}
+            style={hasCoordinates ? { gridColumn: card.column, gridRow: card.row } : undefined}
+          >
+            <span>{card.position}</span>
+            <strong>{card.id}</strong>
+            <b>{card.name}</b>
+            {card.house ? <small>宫：{card.house}</small> : null}
+            <p>{card.keywords.slice(0, 2).join(' · ')}</p>
+          </article>
+        ))}
+      </div>
+      {data.combinations?.length ? (
+        <div className="traditional-note-row">
+          <b>组合牌义</b>
+          <span>
+            {data.combinations
+              .slice(0, 3)
+              .map((item) => `${item.card1}＋${item.card2}：${item.meaning}`)
+              .join('；')}
+          </span>
+        </div>
+      ) : null}
+    </TraditionalBoardShell>
+  );
+}
+
+function SsgwTraditionalBoard({ data }: { data: SsgwData }) {
+  const poemLines = data.poem.split(/\s*[|\n]\s*/).filter(Boolean);
+  return (
+    <TraditionalBoardShell
+      title={`第${data.number}签 · ${data.title}`}
+      subtitle={`${data.ganzhi.day}日签 · 传统签谱盘面`}
+      className="traditional-ssgw-board"
+    >
+      <div className="traditional-sign-card">
+        <div className="traditional-sign-number">{data.number}</div>
+        <div className="traditional-sign-poem">
+          {poemLines.map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </div>
+      </div>
+      {data.story ? (
+        <div className="traditional-sign-story">
+          <b>典故</b>
+          <span>{data.story}</span>
+        </div>
+      ) : null}
+      {data.details ? (
+        <div className="traditional-sign-details">
+          {Object.entries(data.details).map(([label, value]) => (
+            <div key={label}>
+              <b>{label}</b>
+              <span>{value}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </TraditionalBoardShell>
+  );
+}
+
+function AlmanacTraditionalBoard({ data }: { data: AlmanacData }) {
+  return (
+    <TraditionalBoardShell
+      title={`${data.topicLabel}择日盘`}
+      subtitle={`${data.startDate} 至 ${data.endDate} · 以候选日干支、建除、星宿和宜忌并列展示`}
+      className="traditional-almanac-board"
+    >
+      <div className="traditional-almanac-grid" role="table" aria-label="黄历择日盘">
+        {data.days.map((day) => (
+          <article className="traditional-almanac-day" key={day.date}>
+            <div className="traditional-almanac-day-head">
+              <strong>{day.date.slice(5)}</strong>
+              <span>{day.weekday}</span>
+            </div>
+            <b>
+              {day.ganzhi.day}日 · {day.dayOfficer}
+            </b>
+            <span>
+              {day.lunarDate} · {day.zodiac}年
+            </span>
+            <span>
+              {day.twelveStar} · {day.twentyEightStar}
+            </span>
+            <div className="traditional-almanac-gods">
+              {day.gods.slice(0, 3).map((god) => (
+                <em key={god}>{god}</em>
+              ))}
+            </div>
+            <div className="traditional-almanac-goodbad">
+              <p>
+                <b>宜</b>
+                {day.recommends.slice(0, 3).join('、') || '未标注'}
+              </p>
+              <p>
+                <b>忌</b>
+                {day.avoids.slice(0, 3).join('、') || '未标注'}
+              </p>
+            </div>
+            <small>{day.clash}</small>
+          </article>
+        ))}
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+function TaiyiTraditionalBoard({ data }: { data: TaiyiResult }) {
+  const markers = new Map<number, string[]>();
+  const addMarker = (palace: number, label: string) => {
+    const current = markers.get(palace) || [];
+    markers.set(palace, [...current, label]);
+  };
+  addMarker(data.taiyiPalace, '太乙');
+  addMarker(data.wenChangPalace, '文昌');
+  addMarker(data.shiJiPalace, '始击');
+  addMarker(data.jiShenPalace, '计神');
+  return (
+    <TraditionalBoardShell
+      title={`太乙神数${data.scope === 'year' ? '年计' : data.scope}`}
+      subtitle={`${data.ganZhi} · ${data.yinYang}第${data.bureau}局 · ${data.accumulatedLabel}${data.accumulatedValue}`}
+      className="traditional-taiyi-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['太乙', data.taiyiPosition],
+          ['文昌', data.wenChangPosition],
+          ['始击', data.shiJiPosition],
+          ['主算', data.lordCount],
+          ['客算', data.guestCount],
+          ['定算', data.setCount],
+        ]}
+      />
+      <div className="traditional-taiyi-grid" role="img" aria-label="太乙神数九宫盘">
+        {TAIYI_LO_SHU_ORDER.map((palace) => (
+          <div className={`traditional-taiyi-cell${palace === 5 ? ' is-center' : ''}`} key={palace}>
+            <span>{palace}宫</span>
+            <strong>{markers.get(palace)?.join(' · ') || '—'}</strong>
+            {palace === data.taiyiPalace ? (
+              <small>
+                {data.taiyiGua} · {data.taiyiDir}
+              </small>
+            ) : null}
+          </div>
+        ))}
+      </div>
+      <div className="traditional-sixteen-gods">
+        {data.sixteenGods.map((item) => (
+          <span key={`${item.branch}-${item.god}`}>
+            <b>{item.branch}</b>
+            {item.god}
+          </span>
+        ))}
+      </div>
+    </TraditionalBoardShell>
+  );
+}
+
+export function TraditionalDivinationBoard({ session }: { session: DivinationSession }) {
+  switch (session.method) {
+    case 'liuyao':
+      return <LiuyaoTraditionalBoard data={session.data as LiuyaoData} />;
+    case 'meihua':
+      return <MeihuaTraditionalBoard data={session.data as MeihuaData} />;
+    case 'xiaoliuren':
+      return <XiaoliurenTraditionalBoard data={session.data as XiaoliurenData} />;
+    case 'jinkoujue':
+      return <JinkoujueTraditionalBoard data={session.data as JinkoujueData} />;
+    case 'qimen':
+      return <QimenTraditionalBoard data={session.data as QimenData} />;
+    case 'tarot':
+      return <TarotTraditionalBoard data={session.data as TarotData} />;
+    case 'ssgw':
+      return <SsgwTraditionalBoard data={session.data as SsgwData} />;
+    case 'almanac':
+      return <AlmanacTraditionalBoard data={session.data as AlmanacData} />;
+    case 'lenormand':
+      return <LenormandTraditionalBoard data={session.data as LenormandData} />;
+    case 'astrolabe':
+      return (
+        <TraditionalBoardShell
+          title="本命星盘"
+          subtitle="黄道十二宫与主要相位盘面"
+          className="traditional-astrolabe-board"
+        >
+          <AstrolabeChart data={session.data as AstrolabeData} />
+        </TraditionalBoardShell>
+      );
+    case 'taiyi':
+      return <TaiyiTraditionalBoard data={session.data as TaiyiResult} />;
+    case 'liuren':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4478,6 +4478,859 @@ select {
   background: linear-gradient(180deg, var(--surface-base), var(--surface-soft));
 }
 
+/* 传统盘面：占卜结果统一使用有层次的盘式结构，摘要只承担说明作用。 */
+.traditional-board {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid var(--border-contrast);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--accent-soft) 42%, transparent), transparent 38%),
+    linear-gradient(180deg, var(--surface-elevated), var(--surface-muted));
+  box-shadow: var(--shadow-sm);
+}
+
+.traditional-board-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.traditional-board-head h3 {
+  margin: 3px 0 0;
+  color: var(--text-strong);
+  font-size: 20px;
+  letter-spacing: 0.04em;
+}
+
+.traditional-board-head p {
+  max-width: 48ch;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: right;
+}
+
+.traditional-board-kicker {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.traditional-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.traditional-meta-row span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  min-height: 25px;
+  padding: 4px 9px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.traditional-meta-row b,
+.traditional-note-row b {
+  color: var(--accent-deep);
+  font-weight: 700;
+}
+
+.traditional-note-row {
+  display: flex;
+  gap: 8px;
+  padding: 9px 11px;
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--accent-soft) 36%, var(--surface-base));
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.traditional-liuyao-table {
+  overflow-x: auto;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--surface-base);
+}
+
+.traditional-liuyao-head,
+.traditional-liuyao-row {
+  display: grid;
+  grid-template-columns: 48px 52px 58px 74px 84px minmax(125px, 1fr);
+  align-items: center;
+  min-width: 500px;
+  gap: 8px;
+  padding: 9px 10px;
+}
+
+.traditional-liuyao-head {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--surface-muted);
+}
+
+.traditional-liuyao-row {
+  min-height: 56px;
+  border-top: 1px solid var(--border-soft);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.traditional-liuyao-row > span:not(.traditional-yao-status) {
+  text-align: center;
+}
+
+.traditional-liuyao-row small,
+.traditional-yao-status small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+}
+
+.traditional-yao-position {
+  color: var(--text-strong);
+  font-weight: 700;
+}
+
+.traditional-yao-line {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 64px;
+}
+
+.traditional-yao-label {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-yao-symbol {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 56px;
+  height: 8px;
+  gap: 7px;
+}
+
+.traditional-yao-symbol i {
+  display: block;
+  height: 5px;
+  border-radius: 99px;
+  background: var(--text-strong);
+}
+
+.traditional-yao-symbol.is-yang i:first-child {
+  width: 56px;
+}
+
+.traditional-yao-symbol.is-yin i {
+  width: 24px;
+}
+
+.traditional-yao-symbol.is-changing i {
+  background: var(--accent-deep);
+}
+
+.traditional-yao-line em,
+.traditional-qimen-cell em {
+  color: var(--accent-deep);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 700;
+}
+
+.traditional-yao-status {
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
+.traditional-hexagram-triad {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.traditional-mini-hexagram {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  min-height: 150px;
+  padding: 12px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--surface-base);
+  text-align: center;
+}
+
+.traditional-mini-hexagram.is-active {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.traditional-mini-hexagram > span,
+.traditional-mini-hexagram > small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-mini-hexagram > strong {
+  color: var(--text-strong);
+  font-size: 43px;
+  line-height: 1;
+  font-family: 'Noto Serif SC', 'Songti SC', serif;
+}
+
+.traditional-mini-hexagram > b {
+  color: var(--accent-deep);
+  font-size: 14px;
+}
+
+.traditional-mini-hexagram > p {
+  margin: 3px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.traditional-mini-hexagram > em {
+  margin-top: 30px;
+  color: var(--text-muted);
+  font-style: normal;
+}
+
+.traditional-meihua-detail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.traditional-meihua-relation {
+  display: grid;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 11px;
+  background: var(--surface-base);
+}
+
+.traditional-meihua-relation span,
+.traditional-meihua-relation small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-meihua-relation strong {
+  color: var(--text-strong);
+}
+
+.traditional-meihua-yaos {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.traditional-meihua-yaos > div {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+  padding: 8px 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-base);
+}
+
+.traditional-meihua-yaos > div.is-moving {
+  border-color: var(--accent);
+  background: var(--accent-surface);
+}
+
+.traditional-meihua-yaos > div > span,
+.traditional-meihua-yaos > div > b {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-meihua-yaos > div > b {
+  color: var(--accent-deep);
+}
+
+.traditional-six-palace {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 5px;
+  width: min(100%, 380px);
+  aspect-ratio: 1;
+  margin: 0 auto;
+}
+
+.traditional-six-palace-cell,
+.traditional-six-palace-center {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 8px 5px;
+  border: 1px solid var(--border-soft);
+  border-radius: 11px;
+  background: var(--surface-base);
+  text-align: center;
+}
+
+.traditional-six-palace-cell.is-primary {
+  border-color: var(--accent);
+  background: var(--accent-surface);
+}
+
+.traditional-six-palace-cell > span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-six-palace-cell > strong {
+  color: var(--text-strong);
+  font-size: 16px;
+}
+
+.traditional-six-palace-cell > small {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.3;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.traditional-six-palace-center {
+  grid-column: 1 / 3;
+  grid-row: 2;
+  border-style: dashed;
+  background: color-mix(in srgb, var(--accent-soft) 30%, var(--surface-base));
+}
+
+.traditional-six-palace-center span {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-six-palace-center strong {
+  color: var(--accent-deep);
+  font-size: 20px;
+}
+
+.traditional-jinkoujue-table {
+  display: grid;
+  gap: 5px;
+}
+
+.traditional-jinkoujue-row {
+  display: grid;
+  grid-template-columns: 52px 80px minmax(80px, 1fr) minmax(80px, 1fr) 82px;
+  align-items: center;
+  gap: 9px;
+  min-height: 48px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.traditional-jinkoujue-role {
+  color: var(--accent-deep);
+  font-weight: 700;
+}
+
+.traditional-jinkoujue-row strong {
+  color: var(--text-strong);
+  font-size: 18px;
+}
+
+.traditional-jinkoujue-row small {
+  color: var(--text-muted);
+}
+
+.traditional-qimen-grid,
+.traditional-taiyi-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 5px;
+  width: min(100%, 560px);
+  margin: 0 auto;
+  aspect-ratio: 1;
+}
+
+.traditional-qimen-cell,
+.traditional-taiyi-cell {
+  position: relative;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 8px 5px;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.traditional-qimen-cell.is-center,
+.traditional-taiyi-cell.is-center {
+  background: color-mix(in srgb, var(--accent-soft) 28%, var(--surface-base));
+}
+
+.traditional-qimen-cell.is-void {
+  border-style: dashed;
+}
+
+.traditional-qimen-cell.is-horse {
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.traditional-qimen-cell-head {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-qimen-cell-head b {
+  color: var(--accent-deep);
+}
+
+.traditional-qimen-god {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.traditional-qimen-star {
+  color: var(--text-strong);
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.traditional-qimen-door {
+  color: var(--accent-deep);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.traditional-qimen-stems {
+  display: grid;
+  gap: 1px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-qimen-cell em {
+  position: absolute;
+  right: 5px;
+  bottom: 4px;
+}
+
+.traditional-tarot-spread {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(116px, 1fr));
+  gap: 9px;
+}
+
+.traditional-tarot-card {
+  position: relative;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 6px;
+  min-height: 154px;
+  padding: 18px 9px 10px;
+  border: 1px solid var(--border-contrast);
+  border-radius: 13px;
+  background: linear-gradient(160deg, var(--surface-base), var(--surface-soft));
+  color: var(--text-secondary);
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+
+.traditional-tarot-card.is-reversed {
+  background: linear-gradient(160deg, color-mix(in srgb, var(--accent-soft) 48%, var(--surface-base)), var(--surface-soft));
+}
+
+.traditional-card-index {
+  position: absolute;
+  top: 7px;
+  left: 9px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-card-position {
+  color: var(--accent-deep);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.traditional-tarot-card strong {
+  color: var(--text-strong);
+  font-size: 16px;
+}
+
+.traditional-tarot-card b {
+  color: var(--accent-deep);
+  font-size: 11px;
+}
+
+.traditional-tarot-card small {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.traditional-tarot-spread.is-celtic {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(1) {
+  grid-column: 2;
+  grid-row: 1 / 3;
+}
+
+.traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(2) {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+.traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(3) {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(4) {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(n + 5) {
+  grid-column: 4 / 6;
+}
+
+.traditional-lenormand-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
+  gap: 6px;
+}
+
+.traditional-lenormand-grid.has-coordinates {
+  grid-auto-rows: minmax(100px, auto);
+}
+
+.traditional-lenormand-card {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 3px;
+  min-height: 100px;
+  padding: 8px 5px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: var(--surface-base);
+  text-align: center;
+}
+
+.traditional-lenormand-card > span,
+.traditional-lenormand-card > small {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-lenormand-card > strong {
+  color: var(--accent-deep);
+  font-size: 13px;
+}
+
+.traditional-lenormand-card > b {
+  color: var(--text-strong);
+  font-size: 14px;
+}
+
+.traditional-lenormand-card > p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-sign-card {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+  padding: 15px;
+  border: 1px solid var(--border-contrast);
+  border-radius: 13px;
+  background: var(--surface-base);
+}
+
+.traditional-sign-number {
+  display: grid;
+  place-items: center;
+  width: 70px;
+  aspect-ratio: 1;
+  border: 1px solid var(--accent);
+  border-radius: 50%;
+  color: var(--accent-deep);
+  font-family: 'Noto Serif SC', 'Songti SC', serif;
+  font-size: 35px;
+}
+
+.traditional-sign-poem {
+  display: grid;
+  gap: 4px;
+  color: var(--text-strong);
+  font-family: 'Noto Serif SC', 'Songti SC', serif;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.traditional-sign-poem p,
+.traditional-sign-story span,
+.traditional-sign-details span {
+  margin: 0;
+}
+
+.traditional-sign-story,
+.traditional-sign-details {
+  display: grid;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.traditional-sign-story {
+  grid-template-columns: 42px minmax(0, 1fr);
+}
+
+.traditional-sign-story b,
+.traditional-sign-details b {
+  color: var(--accent-deep);
+}
+
+.traditional-sign-details {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.traditional-sign-details > div {
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+  background: var(--surface-base);
+}
+
+.traditional-almanac-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 7px;
+}
+
+.traditional-almanac-day {
+  display: grid;
+  gap: 4px;
+  min-height: 168px;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 11px;
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.traditional-almanac-day-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-soft);
+  padding-bottom: 5px;
+}
+
+.traditional-almanac-day-head strong {
+  color: var(--text-strong);
+  font-size: 17px;
+}
+
+.traditional-almanac-day-head span,
+.traditional-almanac-day > span,
+.traditional-almanac-day > small {
+  color: var(--text-muted);
+}
+
+.traditional-almanac-day > b {
+  color: var(--accent-deep);
+}
+
+.traditional-almanac-gods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.traditional-almanac-gods em {
+  padding: 2px 5px;
+  border-radius: 999px;
+  background: var(--accent-surface);
+  color: var(--accent-deep);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.traditional-almanac-goodbad {
+  display: grid;
+  gap: 2px;
+  margin-top: auto;
+}
+
+.traditional-almanac-goodbad p {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.traditional-almanac-goodbad b {
+  display: inline-block;
+  width: 20px;
+  color: var(--accent-deep);
+}
+
+.traditional-taiyi-cell > span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-taiyi-cell > strong {
+  color: var(--accent-deep);
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+.traditional-taiyi-cell > small {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.traditional-sixteen-gods {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 5px;
+}
+
+.traditional-sixteen-gods span {
+  padding: 4px 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.traditional-sixteen-gods b {
+  margin-right: 3px;
+  color: var(--accent-deep);
+}
+
+.traditional-astrolabe-board .astrolabe-chart-panel {
+  margin-top: 0;
+  padding: 0;
+}
+
+@media (max-width: 720px) {
+  .traditional-board {
+    padding: 12px;
+    border-radius: 14px;
+  }
+
+  .traditional-board-head {
+    display: grid;
+    align-items: start;
+  }
+
+  .traditional-board-head p {
+    text-align: left;
+  }
+
+  .traditional-hexagram-triad,
+  .traditional-meihua-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .traditional-meihua-yaos {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .traditional-jinkoujue-row {
+    grid-template-columns: 46px 66px minmax(80px, 1fr) 78px;
+  }
+
+  .traditional-jinkoujue-row small {
+    grid-column: 4;
+    grid-row: 1;
+  }
+
+  .traditional-tarot-spread.is-celtic {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(1),
+  .traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(2),
+  .traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(3),
+  .traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(4),
+  .traditional-tarot-spread.is-celtic .traditional-tarot-card:nth-child(n + 5) {
+    grid-column: auto;
+    grid-row: auto;
+  }
+
+  .traditional-lenormand-grid[style] {
+    grid-template-columns: repeat(9, minmax(88px, 1fr)) !important;
+    min-width: 840px;
+    overflow-x: auto;
+  }
+
+  .traditional-sign-card {
+    grid-template-columns: 1fr;
+    justify-items: center;
+  }
+
+  .traditional-sign-details {
+    grid-template-columns: 1fr;
+  }
+}
+
 .qizheng-chart-svg,
 .bazhai-compass-svg {
   width: min(430px, 100%);


### PR DESCRIPTION
## 改动内容\n- 新增统一传统盘组件，覆盖六爻、梅花、小六壬、金口诀、奇门、塔罗、雷诺曼、灵签、择日、太乙与星盘外层盘面。\n- 将结果页的传统盘展示统一接入，保留大六壬天地盘。\n- 优化移动端雷诺曼大 Tableau，保留传统九列并支持横向查看。\n\n## 验证\n- pnpm test（1460 项通过）\n- TypeScript、ESLint、Prettier、git diff --check 通过\n- pnpm build 通过\n\n## 风险\n- 仅调整结果页展示与样式，不改变占卜计算逻辑。