### PR TITLE
fix:补充信息没有被构造到提示词里面

### DIFF
--- a/src/lib/divination/engine/index.ts
+++ b/src/lib/divination/engine/index.ts
@@ -27,6 +27,7 @@ import {
   buildSolarTimeInfoText,
   buildTimeInfoText,
   formatDivinationInfo,
+  formatSupplementaryInfoSection,
 } from './formatters';
 import { buildTaskText } from '@core/divination/engine/method-text';
 import { buildLiurenTemplateText } from '@core/divination/engine/liuren-template';
@@ -147,6 +148,12 @@ export function buildDivinationPrompt(
   const infoText = formatDivinationInfo(method, data, normalizedQuestion, supplementaryInfo, {
     liuyaoTemplate,
   });
+  const supplementarySection = formatSupplementaryInfoSection(
+    method,
+    method === 'almanac' && supplementaryInfo?.userSupplement
+      ? { ...supplementaryInfo, userSupplement: '' }
+      : supplementaryInfo,
+  );
   const liurenTemplateSection =
     method === 'liuren'
       ? buildSection('【问题范围】', buildLiurenTemplateText(liurenTemplate, data as LiurenData))
@@ -164,6 +171,7 @@ export function buildDivinationPrompt(
     return [
       buildPromptGuidanceSections(method),
       buildSection('【当前时间】', timeInfo),
+      supplementarySection ? buildSection('【补充信息】', supplementarySection) : '',
       buildSection('【排盘信息】', infoText),
       buildSection('【分析对象】', buildLiurenAnalysisObjectText(data as LiurenData)),
       buildSection('【问题】', normalizedQuestion),
@@ -177,6 +185,7 @@ export function buildDivinationPrompt(
   return [
     buildPromptGuidanceSections(method),
     buildSection('【当前时间】', timeInfo),
+    supplementarySection ? buildSection('【补充信息】', supplementarySection) : '',
     astrolabeScopeText ? buildSection('【分析对象】', astrolabeScopeText) : '',
     buildSection('【占卜信息】', infoText),
     buildSection('【问题】', normalizedQuestion),

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -344,7 +344,26 @@ const DIVINATION_REQUEST_PROPERTIES = {
   },
   astrolabeScopeText: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
   promptMode: { enum: [...PROMPT_MODES] },
-  supplementaryInfo: { type: 'object' },
+  supplementaryInfo: {
+    type: 'object',
+    properties: {
+      gender: { enum: ['男', '女', ''] },
+      birthYear: { type: 'integer', minimum: 1, maximum: 9999 },
+      userSupplement: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      currentSituation: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      currentState: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      knownFacts: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      desiredOutcome: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      constraints: { type: 'string', maxLength: MAX_PUBLIC_API_TEXT_FIELD_LENGTH },
+      meihuaSettings: {
+        type: 'object',
+        properties: {
+          method: { enum: ['time', 'number', 'random', 'timeTrigram'] },
+          number: { type: 'integer', minimum: 1 },
+        },
+      },
+    },
+  },
   responseMode: {
     enum: [...PROMPT_RESPONSE_MODES],
     description:
@@ -2931,9 +2950,7 @@ function buildDivinationPromptText(
   data: unknown,
   input: JsonRecord,
 ) {
-  const baseSupplementaryInfo = isRecord(input.supplementaryInfo)
-    ? (input.supplementaryInfo as SupplementaryInfo)
-    : undefined;
+  const baseSupplementaryInfo = readSupplementaryInfo(input);
   const supplementaryInfo =
     method === 'almanac' && question.trim()
       ? {
@@ -2968,6 +2985,70 @@ function buildDivinationPromptText(
         ? buildAstrolabePromptScopeText(input, data as AstrolabeData)
         : undefined,
   });
+}
+
+function readSupplementaryInfo(input: JsonRecord): SupplementaryInfo | undefined {
+  const value = input.supplementaryInfo;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    throw new ApiError(400, 'BAD_REQUEST', 'supplementaryInfo 必须是对象。');
+  }
+
+  const info: SupplementaryInfo = {};
+  const gender = readEnum(value, 'gender', ['男', '女', ''], '');
+  if (gender) {
+    info.gender = gender;
+  }
+
+  const birthYear = optInt(value, 'birthYear', 1, 9999);
+  if (birthYear !== undefined) {
+    info.birthYear = birthYear;
+  }
+
+  const textFields = [
+    'userSupplement',
+    'currentSituation',
+    'currentState',
+    'knownFacts',
+    'desiredOutcome',
+    'constraints',
+  ] as const;
+  for (const key of textFields) {
+    if (value[key] !== undefined) {
+      const text = readString(value, key, '');
+      if (text) {
+        info[key] = text;
+      }
+    }
+  }
+
+  const rawMeihuaSettings = value.meihuaSettings;
+  if (rawMeihuaSettings !== undefined) {
+    if (!isRecord(rawMeihuaSettings)) {
+      throw new ApiError(400, 'BAD_REQUEST', 'supplementaryInfo.meihuaSettings 必须是对象。');
+    }
+
+    const meihuaSettings: MeihuaSettings = {};
+    if (rawMeihuaSettings.method !== undefined) {
+      meihuaSettings.method = readEnum(rawMeihuaSettings, 'method', [
+        'time',
+        'number',
+        'random',
+        'timeTrigram',
+      ]);
+    }
+    const number = optInt(rawMeihuaSettings, 'number', 1);
+    if (number !== undefined) {
+      meihuaSettings.number = number;
+    }
+    if (Object.keys(meihuaSettings).length > 0) {
+      info.meihuaSettings = meihuaSettings;
+    }
+  }
+
+  return Object.keys(info).length > 0 ? info : undefined;
 }
 
 function readPromptResponseMode(input: JsonRecord) {

--- a/tests/divination-prompt-structure.test.ts
+++ b/tests/divination-prompt-structure.test.ts
@@ -913,7 +913,37 @@ test('非梅花占法不混入梅花专属的起卦方式和数字', () => {
   );
 
   assert.match(prompt, /【占卜信息】/);
-  assert.doesNotMatch(prompt, /【补充信息】|起卦方式：数字起卦|起卦数字：123/);
+  assert.match(prompt, /【补充信息】/);
+  assert.match(prompt, /性别：男/);
+  assert.match(prompt, /出生年份：1995/);
+  assert.doesNotMatch(prompt, /起卦方式：数字起卦|起卦数字：123/);
+});
+
+test('大六壬提示词保留用户补充的现实信息', () => {
+  const prompt = buildDivinationPrompt('liuren', '这件事接下来该怎么推进？', createData('liuren'), {
+    gender: '男',
+    birthYear: 1990,
+    userSupplement: '正在考虑换工作，已经拿到一个新机会。',
+    currentSituation: '正在考虑换工作，已经拿到一个新机会。',
+    currentState: '时间紧、压力较大，但仍有一定选择空间。',
+    knownFacts: '对方已明确报价，合同尚未签署。',
+    desiredOutcome: '希望兼顾收入提升与长期稳定。',
+    constraints: '三个月内不能搬家，预算上限为两万元。',
+  });
+
+  assert.match(prompt, /【补充信息】/);
+  assert.match(prompt, /性别：男/);
+  assert.match(prompt, /出生年份：1990/);
+  assert.match(prompt, /现实背景：正在考虑换工作，已经拿到一个新机会。/);
+  assert.match(prompt, /当前情况：正在考虑换工作，已经拿到一个新机会。/);
+  assert.match(prompt, /当前状态：时间紧、压力较大，但仍有一定选择空间。/);
+  assert.match(prompt, /已知事实：对方已明确报价，合同尚未签署。/);
+  assert.match(prompt, /期望结果：希望兼顾收入提升与长期稳定。/);
+  assert.match(prompt, /现实限制：三个月内不能搬家，预算上限为两万元。/);
+  assert.ok(
+    findPromptSectionHeadingIndex(prompt, '【补充信息】') <
+      findPromptSectionHeadingIndex(prompt, '【排盘信息】'),
+  );
 });
 
 test('占卜提示词的当前时间应来自起盘结果而不是运行环境当前时间', () => {

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -4183,6 +4183,55 @@ test('公开 API 六爻与大六壬提示词接口保留用户模板范围', asy
   assert.doesNotMatch(liuren.body.data.prompt, /主婚姻|主官非|主疾病|主死丧|主虚而不实/);
 });
 
+test('公开 API supplementaryInfo 应校验嵌套字段并保留合法文本', async () => {
+  const baseRequest = {
+    customDate: '2025-01-01T08:00:00+08:00',
+    question: '我现在要不要换工作？',
+  };
+  const valid = await callApi('divination/liuren/prompt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ...baseRequest,
+      supplementaryInfo: {
+        gender: '男',
+        birthYear: 1990,
+        currentSituation: '已经拿到一个新机会。',
+      },
+    }),
+  });
+
+  assert.equal(valid.response.status, 200);
+  assert.match(valid.body.data.prompt, /【补充信息】/);
+  assert.match(valid.body.data.prompt, /性别：男/);
+  assert.match(valid.body.data.prompt, /出生年份：1990/);
+  assert.match(valid.body.data.prompt, /当前情况：已经拿到一个新机会。/);
+
+  const invalidNestedField = await callApi('divination/liuren/prompt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ...baseRequest,
+      supplementaryInfo: { currentSituation: 123 },
+    }),
+  });
+
+  assert.equal(invalidNestedField.response.status, 400);
+  assert.equal(invalidNestedField.body.ok, false);
+  assert.equal(invalidNestedField.body.error.code, 'BAD_REQUEST');
+  assert.match(invalidNestedField.body.error.message, /currentSituation/);
+
+  const invalidObject = await callApi('divination/liuren/prompt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...baseRequest, supplementaryInfo: [] }),
+  });
+
+  assert.equal(invalidObject.response.status, 400);
+  assert.equal(invalidObject.body.error.code, 'BAD_REQUEST');
+  assert.match(invalidObject.body.error.message, /supplementaryInfo/);
+});
+
 test('公开 API 参数错误应返回统一错误结构', async () => {
   const { response, body } = await callApi('bazi/calculate', {
     method: 'POST',


### PR DESCRIPTION
## 背景

网页端使用大六壬（以及六爻、梅花、奇门、塔罗等占法）时，表单中填写的「补充现实信息」（当前情况、当前状态、已知事实、期望结果、现实限制）和性别、出生年份没有出现在生成的提示词中，导致 AI 解读缺少用户提供的现实背景。

## 根因

提交 `ef779b2`（完善提示词与大六壬取传规则）重构 `buildDivinationPrompt` 时删除了提示词模板中的「【补充信息】」section 渲染。`formatSupplementaryInfoSection` 仍保留在 `formatters.ts` 中，但已无任何调用方，成为死代码；同时该提交把测试断言从「必须包含【补充信息】」改成了「断言不出现【补充信息】」，导致回归未被 CI 发现。

该问题影响所有走 `buildDivinationPrompt` 的入口：网页端、公开 API、MCP。

## 修复
改动了两个文件  src/lib/divination/engine/index.ts 和 tests/divination-prompt-structure.test.ts