### PR TITLE
完善八字与紫微传统盘信息展示

### DIFF
--- a/packages/core/src/bazi/index.ts
+++ b/packages/core/src/bazi/index.ts
@@ -45,6 +45,7 @@ export {
   assertPillars,
   getTenGod,
   getTenGodForBranch,
+  getShenShaType,
   getWuxing,
   isEarthlyBranch,
   isGanZhiPair,

--- a/src/pages/ResultPage/components/BaziChartBoard.tsx
+++ b/src/pages/ResultPage/components/BaziChartBoard.tsx
@@ -1,5 +1,7 @@
 import { Suspense, lazy, memo } from 'react';
+import type { ReactNode } from 'react';
 import type { BaziChartResult } from '@core/bazi/baziTypes';
+import { getShenShaType, getTenGodForBranch, getWuxing } from '@core/bazi/baziUtils';
 import { uniqueNonEmptyStrings } from '@/lib/array-utils';
 import {
   formatAvoidGodPrioritySummary,
@@ -14,6 +16,49 @@ const LazyBaziFortuneSelector = lazy(async () => {
   const module = await import('@/components/BaziFortuneTools/BaziFortuneSelector');
   return { default: module.BaziFortuneSelector };
 });
+
+const PILLAR_KEYS = ['year', 'month', 'day', 'hour'] as const;
+
+function BaziGanZhiValue(props: { value: string }) {
+  const wuxing = getWuxing(props.value);
+
+  return (
+    <span className="bazi-ganzhi-value">
+      <strong className="bazi-ganzhi-symbol">{props.value}</strong>
+      <small className="bazi-wuxing-label" data-wuxing={wuxing}>
+        {wuxing}
+      </small>
+    </span>
+  );
+}
+
+function BaziShenShaList(props: { items: string[] }) {
+  const items = uniqueNonEmptyStrings(props.items);
+
+  if (items.length === 0) {
+    return <span className="bazi-shensha-empty">无</span>;
+  }
+
+  return (
+    <span className="bazi-shensha-list">
+      {items.map((item) => {
+        const type = getShenShaType(item);
+        const toneClassName =
+          type === '吉' ? 'is-lucky' : type === '凶' ? 'is-unlucky' : 'is-neutral';
+
+        return (
+          <span
+            className={`bazi-shensha-tag ${toneClassName}`}
+            aria-label={`${item}（${type}）`}
+            key={item}
+          >
+            {item}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
 
 export const BaziChartBoard = memo(function BaziChartBoard(props: {
   title: string;
@@ -40,73 +85,68 @@ export const BaziChartBoard = memo(function BaziChartBoard(props: {
   if (result.shenGong) {
     referenceItems.push({ label: '身宫', value: result.shenGong, detail: '后天着力' });
   }
-  const pillarRows = [
+  const dayOwnerLabel =
+    result.gender === 'male' ? '元男' : result.gender === 'female' ? '元女' : '';
+  const pillarRows: Array<{
+    label: string;
+    values: ReactNode[];
+    className?: string;
+  }> = [
+    {
+      label: '天干十神',
+      values: PILLAR_KEYS.map((key) => result.tenGods[key]),
+    },
     {
       label: '天干',
-      values: [
-        result.pillars.year.gan,
-        result.pillars.month.gan,
-        result.pillars.day.gan,
-        result.pillars.hour.gan,
-      ],
+      values: PILLAR_KEYS.map((key) => (
+        <BaziGanZhiValue key={key} value={result.pillars[key].gan} />
+      )),
       className: 'is-stem',
     },
     {
       label: '地支',
-      values: [
-        result.pillars.year.zhi,
-        result.pillars.month.zhi,
-        result.pillars.day.zhi,
-        result.pillars.hour.zhi,
-      ],
+      values: PILLAR_KEYS.map((key) => (
+        <BaziGanZhiValue key={key} value={result.pillars[key].zhi} />
+      )),
       className: 'is-branch',
     },
     {
-      label: '十神',
-      values: [result.tenGods.year, result.tenGods.month, result.tenGods.day, result.tenGods.hour],
+      label: '地支十神',
+      values: PILLAR_KEYS.map((key) =>
+        getTenGodForBranch(result.pillars[key].zhi, result.dayMaster.gan),
+      ),
     },
     {
       label: '藏干',
-      values: [
-        joinMultilineText(result.hiddenStems.year, '无'),
-        joinMultilineText(result.hiddenStems.month, '无'),
-        joinMultilineText(result.hiddenStems.day, '无'),
-        joinMultilineText(result.hiddenStems.hour, '无'),
-      ],
+      values: PILLAR_KEYS.map((key) => joinMultilineText(result.hiddenStems[key], '无')),
       className: 'is-multiline',
     },
     {
-      label: '副星',
-      values: [
-        joinMultilineText(result.hiddenTenGods.year, '无'),
-        joinMultilineText(result.hiddenTenGods.month, '无'),
-        joinMultilineText(result.hiddenTenGods.day, '无'),
-        joinMultilineText(result.hiddenTenGods.hour, '无'),
-      ],
+      label: '藏干十神',
+      values: PILLAR_KEYS.map((key) => joinMultilineText(result.hiddenTenGods[key], '无')),
       className: 'is-multiline',
     },
     {
       label: '纳音',
-      values: [result.nayin.year, result.nayin.month, result.nayin.day, result.nayin.hour],
+      values: PILLAR_KEYS.map((key) => result.nayin[key]),
+    },
+    {
+      label: '自坐',
+      values: PILLAR_KEYS.map((key) => result.ziZuo[key]),
     },
     {
       label: '长生',
-      values: [
-        result.pillarLifeStages.year,
-        result.pillarLifeStages.month,
-        result.pillarLifeStages.day,
-        result.pillarLifeStages.hour,
-      ],
+      values: PILLAR_KEYS.map((key) => result.pillarLifeStages[key]),
+    },
+    {
+      label: '空亡',
+      values: PILLAR_KEYS.map((key) => joinMultilineText(result.kongWang[key], '无')),
+      className: 'is-multiline',
     },
     {
       label: '神煞',
-      values: [
-        joinMultilineText(result.shensha.year.slice(0, 3), '无'),
-        joinMultilineText(result.shensha.month.slice(0, 3), '无'),
-        joinMultilineText(result.shensha.day.slice(0, 3), '无'),
-        joinMultilineText(result.shensha.hour.slice(0, 3), '无'),
-      ],
-      className: 'is-multiline',
+      values: PILLAR_KEYS.map((key) => <BaziShenShaList items={result.shensha[key]} key={key} />),
+      className: 'is-shensha',
     },
   ];
 
@@ -173,7 +213,10 @@ export const BaziChartBoard = memo(function BaziChartBoard(props: {
             <div className="bazi-pillars-cell is-label is-head">信息</div>
             <div className="bazi-pillars-cell is-head">年柱</div>
             <div className="bazi-pillars-cell is-head">月柱</div>
-            <div className="bazi-pillars-cell is-head is-day-master">日柱</div>
+            <div className="bazi-pillars-cell is-head is-day-master">
+              <span>日柱</span>
+              {dayOwnerLabel ? <small className="bazi-day-owner">{dayOwnerLabel}</small> : null}
+            </div>
             <div className="bazi-pillars-cell is-head">时柱</div>
             {pillarRows.flatMap((row) => [
               <div key={`${row.label}-label`} className="bazi-pillars-cell is-label">

--- a/src/pages/ResultPage/components/BaziChartBoard.tsx
+++ b/src/pages/ResultPage/components/BaziChartBoard.tsx
@@ -94,7 +94,9 @@ export const BaziChartBoard = memo(function BaziChartBoard(props: {
   }> = [
     {
       label: '天干十神',
-      values: PILLAR_KEYS.map((key) => result.tenGods[key]),
+      values: PILLAR_KEYS.map((key) =>
+        key === 'day' && dayOwnerLabel ? dayOwnerLabel : result.tenGods[key],
+      ),
     },
     {
       label: '天干',
@@ -213,10 +215,7 @@ export const BaziChartBoard = memo(function BaziChartBoard(props: {
             <div className="bazi-pillars-cell is-label is-head">信息</div>
             <div className="bazi-pillars-cell is-head">年柱</div>
             <div className="bazi-pillars-cell is-head">月柱</div>
-            <div className="bazi-pillars-cell is-head is-day-master">
-              <span>日柱</span>
-              {dayOwnerLabel ? <small className="bazi-day-owner">{dayOwnerLabel}</small> : null}
-            </div>
+            <div className="bazi-pillars-cell is-head is-day-master">日柱</div>
             <div className="bazi-pillars-cell is-head">时柱</div>
             {pillarRows.flatMap((row) => [
               <div key={`${row.label}-label`} className="bazi-pillars-cell is-label">

--- a/src/pages/ResultPage/components/BaziChartBoard.tsx
+++ b/src/pages/ResultPage/components/BaziChartBoard.tsx
@@ -18,6 +18,57 @@ const LazyBaziFortuneSelector = lazy(async () => {
 });
 
 const PILLAR_KEYS = ['year', 'month', 'day', 'hour'] as const;
+const BAZI_BOARD_COMMON_SHENSHA = new Set([
+  '天乙贵人',
+  '太极贵人',
+  '天德贵人',
+  '天德合',
+  '月德贵人',
+  '月德合',
+  '福星贵人',
+  '文昌贵人',
+  '国印贵人',
+  '天厨贵人',
+  '德秀贵人',
+  '学堂',
+  '词馆',
+  '禄神',
+  '羊刃',
+  '飞刃',
+  '驿马',
+  '将星',
+  '华盖',
+  '金舆',
+  '天赦日',
+  '天医',
+  '魁罡',
+  '金神',
+  '桃花',
+  '红鸾',
+  '天喜',
+  '孤辰',
+  '寡宿',
+  '红艳煞',
+  '孤鸾煞',
+  '亡神',
+  '劫煞',
+  '灾煞',
+  '六厄',
+  '元辰',
+  '血刃',
+  '流霞',
+  '天罗',
+  '地网',
+  '阴差阳错',
+  '十恶大败',
+  '四废日',
+  '童子煞',
+  '勾绞煞',
+]);
+
+function filterBaziBoardShensha(items: string[]) {
+  return uniqueNonEmptyStrings(items).filter((item) => BAZI_BOARD_COMMON_SHENSHA.has(item));
+}
 
 function BaziGanZhiValue(props: { value: string }) {
   const wuxing = getWuxing(props.value);
@@ -33,7 +84,7 @@ function BaziGanZhiValue(props: { value: string }) {
 }
 
 function BaziShenShaList(props: { items: string[] }) {
-  const items = uniqueNonEmptyStrings(props.items);
+  const items = filterBaziBoardShensha(props.items);
 
   if (items.length === 0) {
     return <span className="bazi-shensha-empty">无</span>;

--- a/src/pages/ResultPage/components/ChartStar.tsx
+++ b/src/pages/ResultPage/components/ChartStar.tsx
@@ -1,9 +1,15 @@
 import type { PalaceFact } from '@/types/analysis';
 
-export function ChartStar(props: {
-  star: PalaceFact['major_stars'][number];
-  tone: 'major' | 'minor' | 'scope';
-}) {
+type ChartStarTone = 'major' | 'minor' | 'other' | 'scope';
+
+function getMutagenToneClass(mutagen: string): string {
+  if (mutagen === '禄') return 'is-lu';
+  if (mutagen === '权') return 'is-quan';
+  if (mutagen === '科') return 'is-ke';
+  return 'is-ji';
+}
+
+export function ChartStar(props: { star: PalaceFact['major_stars'][number]; tone: ChartStarTone }) {
   const { star, tone } = props;
 
   return (
@@ -13,11 +19,34 @@ export function ChartStar(props: {
       } ${star.active_scope_mutagen ? 'has-active-mutagen' : ''}`}
     >
       <span className="chart-star-name">{star.name}</span>
+      {star.brightness ? (
+        <span className="chart-star-brightness" aria-label={`亮度${star.brightness}`}>
+          {star.brightness}
+        </span>
+      ) : null}
       {star.birth_mutagen ? (
-        <span className="chart-star-mark chart-star-mark-birth">{star.birth_mutagen}</span>
+        <span
+          className={`chart-star-mark chart-star-mark-birth ${getMutagenToneClass(star.birth_mutagen)}`}
+          aria-label={`生年四化${star.birth_mutagen}`}
+        >
+          {star.birth_mutagen}
+        </span>
+      ) : null}
+      {star.horoscope_mutagen ? (
+        <span
+          className={`chart-star-mark chart-star-mark-horoscope ${getMutagenToneClass(star.horoscope_mutagen)}`}
+          aria-label={`运限星曜四化${star.horoscope_mutagen}`}
+        >
+          {star.horoscope_mutagen}
+        </span>
       ) : null}
       {star.active_scope_mutagen ? (
-        <span className="chart-star-mark chart-star-mark-active">{star.active_scope_mutagen}</span>
+        <span
+          className={`chart-star-mark chart-star-mark-active ${getMutagenToneClass(star.active_scope_mutagen)}`}
+          aria-label={`当前时限四化${star.active_scope_mutagen}`}
+        >
+          {star.active_scope_mutagen}
+        </span>
       ) : null}
     </span>
   );
@@ -25,7 +54,7 @@ export function ChartStar(props: {
 
 export function ChartStarLine(props: {
   stars: PalaceFact['major_stars'];
-  tone: 'major' | 'minor' | 'scope';
+  tone: ChartStarTone;
   fallback?: string;
   limit?: number;
   layout?: 'wrap' | 'column';
@@ -43,9 +72,9 @@ export function ChartStarLine(props: {
 
   return (
     <div className={`chart-cell-stars chart-cell-stars-${props.tone} ${layoutClassName}`}>
-      {stars.map((star) => (
+      {stars.map((star, index) => (
         <ChartStar
-          key={`${props.tone}-${star.name}-${star.birth_mutagen ?? 'n'}-${star.active_scope_mutagen ?? 'n'}`}
+          key={`${props.tone}-${star.name}-${star.birth_mutagen ?? 'n'}-${star.horoscope_mutagen ?? 'n'}-${star.active_scope_mutagen ?? 'n'}-${index}`}
           star={star}
           tone={props.tone}
         />

--- a/src/pages/ResultPage/components/ZiweiTraditionalBoard.tsx
+++ b/src/pages/ResultPage/components/ZiweiTraditionalBoard.tsx
@@ -46,6 +46,14 @@ export function ZiweiTraditionalBoard(props: {
     centerFocusTags.length === 0
       ? uniqueNonEmptyStrings(selectedPalace.summary_tags).slice(0, 2)
       : [];
+  const fourPillars = payload.basic_info.four_pillars
+    ? [
+        payload.basic_info.four_pillars.year_pillar,
+        payload.basic_info.four_pillars.month_pillar,
+        payload.basic_info.four_pillars.day_pillar,
+        payload.basic_info.four_pillars.hour_pillar,
+      ].join(' ')
+    : '';
 
   return (
     <section className="ziwei-traditional-shell">
@@ -109,17 +117,49 @@ export function ZiweiTraditionalBoard(props: {
                 <div className="ziwei-board-center chart-center" key={`center-${index}`}>
                   <div className="ziwei-board-center-head chart-center-head">
                     <div className="chart-center-scope">{payload.active_scope.label}</div>
-                    <div className="chart-center-age">{payload.active_scope.nominal_age} 岁</div>
+                    <div className="chart-center-age">
+                      {payload.active_scope.nominal_age > 0
+                        ? `${payload.active_scope.nominal_age} 岁`
+                        : '本命盘'}
+                    </div>
                   </div>
                   <div className="chart-center-info">
-                    <div>
-                      {name} · {payload.basic_info.gender}
+                    <div className="chart-center-info-row chart-center-info-wide">
+                      <span>命盘</span>
+                      <strong>
+                        {name} · {payload.basic_info.gender}
+                      </strong>
                     </div>
-                    <div>{payload.basic_info.zodiac}</div>
-                    <div>{payload.basic_info.solar_date}</div>
-                    <div>{payload.basic_info.lunar_date}</div>
-                    <div>{payload.basic_info.birth_time_label}</div>
-                    <div>{payload.active_scope.solar_date}</div>
+                    <div className="chart-center-info-row">
+                      <span>生肖</span>
+                      <strong>
+                        {payload.basic_info.zodiac} · {payload.basic_info.sign}
+                      </strong>
+                    </div>
+                    <div className="chart-center-info-row">
+                      <span>阳历</span>
+                      <strong>{payload.basic_info.solar_date}</strong>
+                    </div>
+                    <div className="chart-center-info-row chart-center-info-wide">
+                      <span>农历</span>
+                      <strong>{payload.basic_info.lunar_date}</strong>
+                    </div>
+                    <div className="chart-center-info-row">
+                      <span>时辰</span>
+                      <strong>{payload.basic_info.birth_time_label}</strong>
+                    </div>
+                    {fourPillars ? (
+                      <div className="chart-center-info-row chart-center-info-wide">
+                        <span>四柱</span>
+                        <strong>{fourPillars}</strong>
+                      </div>
+                    ) : null}
+                    {payload.active_scope.scope !== 'origin' ? (
+                      <div className="chart-center-info-row chart-center-info-wide">
+                        <span>当前</span>
+                        <strong>{payload.active_scope.solar_date}</strong>
+                      </div>
+                    ) : null}
                   </div>
                   <div className="ziwei-board-center-meta chart-center-grid">
                     <div className="chart-center-chip">命主 {payload.basic_info.soul}</div>
@@ -130,8 +170,9 @@ export function ZiweiTraditionalBoard(props: {
                     <div className="chart-center-chip">
                       命宫 {payload.basic_info.soul_palace_branch}
                     </div>
-                    <div className="chart-center-chip">长生 {selectedPalace.changsheng12}</div>
-                    <div className="chart-center-chip">博士 {selectedPalace.boshi12}</div>
+                    <div className="chart-center-chip">
+                      身宫 {payload.basic_info.body_palace_branch}
+                    </div>
                   </div>
                   <div className="ziwei-board-center-relation chart-center-focus">
                     <div className="chart-center-focus-label">当前宫位</div>
@@ -189,10 +230,18 @@ export function ZiweiTraditionalBoard(props: {
             const isOpposite = palace.index === selectedPalace.opposite_palace_index;
             const isSurrounded = surroundedIndexSet.has(palace.index);
             const footerBadges = uniqueNonEmptyStrings([
-              palace.dynamic_scope_name ?? palace.scope_hits[0],
-              palace.summary_tags[0],
-              palace.changsheng12,
-            ]).slice(0, 2);
+              palace.dynamic_scope_name,
+              palace.changsheng12 ? `长生 ${palace.changsheng12}` : '',
+              palace.boshi12 ? `博士 ${palace.boshi12}` : '',
+              palace.base_jiangqian12 ? `将前 ${palace.base_jiangqian12}` : '',
+              palace.base_suiqian12 ? `岁前 ${palace.base_suiqian12}` : '',
+              payload.active_scope.scope === 'origin' || !palace.yearly_jiangqian12
+                ? ''
+                : `流年将前 ${palace.yearly_jiangqian12}`,
+              payload.active_scope.scope === 'origin' || !palace.yearly_suiqian12
+                ? ''
+                : `流年岁前 ${palace.yearly_suiqian12}`,
+            ]);
 
             return (
               <button
@@ -223,30 +272,23 @@ export function ZiweiTraditionalBoard(props: {
                     </div>
                   </div>
 
-                  <div className="chart-cell-major-column">
+                  <div className="chart-cell-star-layers">
                     <ChartStarLine
                       fallback="无主星"
-                      layout="column"
+                      layout="wrap"
                       stars={palace.major_stars}
                       tone="major"
                     />
-                  </div>
-
-                  <div className="chart-cell-side-columns">
-                    <ChartStarLine
-                      layout="column"
-                      limit={5}
-                      stars={palace.minor_stars}
-                      tone="minor"
-                    />
-                    <ChartStarLine
-                      layout="column"
-                      limit={4}
-                      stars={palace.scope_stars}
-                      tone="scope"
-                    />
+                    <ChartStarLine layout="wrap" stars={palace.minor_stars} tone="minor" />
+                    <ChartStarLine layout="wrap" stars={palace.other_stars} tone="other" />
+                    <ChartStarLine layout="wrap" stars={palace.scope_stars} tone="scope" />
                   </div>
                 </div>
+                {palace.ages.length > 0 ? (
+                  <div className="chart-cell-age-cycle" title="本宫流年虚岁序列">
+                    流年 {palace.ages.join('·')}
+                  </div>
+                ) : null}
                 <div className="ziwei-grid-cell-foot chart-cell-foot">
                   {footerBadges.map((item) => (
                     <span className="chart-cell-badge" key={`${palace.index}-${item}`}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2055,6 +2055,14 @@ select {
   gap: 12px;
 }
 
+.ziwei-detail-card > .result-tag-cloud {
+  height: 54px;
+  align-content: flex-start;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
 .ziwei-detail-head {
   display: flex;
   justify-content: space-between;

--- a/src/styles.css
+++ b/src/styles.css
@@ -649,20 +649,6 @@ select {
   background: var(--accent-soft);
 }
 
-.bazi-pillars-cell.is-head.is-day-master {
-  flex-direction: column;
-  gap: 2px;
-}
-
-.bazi-day-owner {
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: var(--accent-strong);
-  color: var(--surface-elevated-strong);
-  font-size: 9px;
-  line-height: 1.3;
-}
-
 .bazi-ganzhi-value {
   display: inline-grid;
   justify-items: center;
@@ -717,10 +703,10 @@ select {
 }
 
 .bazi-shensha-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: grid;
+  justify-items: center;
   gap: 4px;
+  width: 100%;
 }
 
 .bazi-shensha-tag {

--- a/src/styles.css
+++ b/src/styles.css
@@ -610,7 +610,7 @@ select {
 .bazi-pillars-table {
   margin-top: 14px;
   display: grid;
-  grid-template-columns: 64px repeat(4, minmax(0, 1fr));
+  grid-template-columns: 72px repeat(4, minmax(0, 1fr));
   border: 1px solid var(--border-soft);
   border-radius: 16px;
   overflow: hidden;
@@ -649,14 +649,143 @@ select {
   background: var(--accent-soft);
 }
 
-.bazi-pillars-cell.is-stem {
+.bazi-pillars-cell.is-head.is-day-master {
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bazi-day-owner {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-strong);
+  color: var(--surface-elevated-strong);
+  font-size: 9px;
+  line-height: 1.3;
+}
+
+.bazi-ganzhi-value {
+  display: inline-grid;
+  justify-items: center;
+  gap: 2px;
+}
+
+.bazi-ganzhi-symbol {
+  color: var(--text-strong);
+  line-height: 1;
+}
+
+.bazi-pillars-cell.is-stem .bazi-ganzhi-symbol {
   font-size: 24px;
   font-weight: 700;
 }
 
-.bazi-pillars-cell.is-branch {
+.bazi-pillars-cell.is-branch .bazi-ganzhi-symbol {
   font-size: 22px;
   font-weight: 700;
+}
+
+.bazi-wuxing-label {
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.bazi-wuxing-label[data-wuxing='木'] {
+  color: #15803d;
+}
+
+.bazi-wuxing-label[data-wuxing='火'] {
+  color: #dc2626;
+}
+
+.bazi-wuxing-label[data-wuxing='土'] {
+  color: #a16207;
+}
+
+.bazi-wuxing-label[data-wuxing='金'] {
+  color: #64748b;
+}
+
+.bazi-wuxing-label[data-wuxing='水'] {
+  color: #2563eb;
+}
+
+.bazi-pillars-cell.is-shensha {
+  min-height: 72px;
+  padding: 8px 5px;
+  align-items: flex-start;
+}
+
+.bazi-shensha-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+}
+
+.bazi-shensha-tag {
+  --bazi-shensha-tone: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--bazi-shensha-tone) 24%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bazi-shensha-tone) 9%, transparent);
+  color: var(--bazi-shensha-tone);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.bazi-shensha-tag.is-lucky {
+  --bazi-shensha-tone: #15803d;
+}
+
+.bazi-shensha-tag.is-unlucky {
+  --bazi-shensha-tone: #b91c1c;
+}
+
+.bazi-shensha-tag.is-neutral {
+  --bazi-shensha-tone: #a16207;
+}
+
+.bazi-shensha-empty {
+  color: var(--text-muted);
+}
+
+@media (prefers-color-scheme: dark) {
+  .bazi-wuxing-label[data-wuxing='木'] {
+    color: #86efac;
+  }
+
+  .bazi-wuxing-label[data-wuxing='火'] {
+    color: #fca5a5;
+  }
+
+  .bazi-wuxing-label[data-wuxing='土'] {
+    color: #fcd34d;
+  }
+
+  .bazi-wuxing-label[data-wuxing='金'] {
+    color: #cbd5e1;
+  }
+
+  .bazi-wuxing-label[data-wuxing='水'] {
+    color: #93c5fd;
+  }
+
+  .bazi-shensha-tag.is-lucky {
+    --bazi-shensha-tone: #86efac;
+  }
+
+  .bazi-shensha-tag.is-unlucky {
+    --bazi-shensha-tone: #fca5a5;
+  }
+
+  .bazi-shensha-tag.is-neutral {
+    --bazi-shensha-tone: #fcd34d;
+  }
 }
 
 .bazi-side-panel,
@@ -1235,10 +1364,9 @@ select {
   display: grid;
   width: 100%;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: repeat(4, minmax(0, 1fr));
+  grid-template-rows: repeat(4, minmax(160px, 1fr));
   gap: 8px;
   min-width: 0;
-  aspect-ratio: 1 / 1.08;
 }
 
 .ziwei-relation-lines {
@@ -1497,7 +1625,7 @@ select {
   border-radius: 8px;
   padding: 16px 4px 4px;
   text-align: left;
-  min-height: 118px;
+  min-height: 160px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -1548,8 +1676,8 @@ select {
 
 .chart-cell-body {
   display: grid;
-  grid-template-columns: 12px minmax(0, 1fr) 22px;
-  gap: 2px;
+  grid-template-columns: 14px minmax(0, 1fr);
+  gap: 4px;
   align-items: stretch;
   min-height: 0;
   flex: 1;
@@ -1625,11 +1753,22 @@ select {
   opacity: 0.78;
 }
 
+.chart-cell-stars-other {
+  color: var(--text-muted);
+}
+
 .chart-star {
   display: inline-flex;
   align-items: center;
   gap: 1px;
   white-space: nowrap;
+}
+
+.chart-cell-star-layers {
+  display: grid;
+  align-content: start;
+  gap: 3px;
+  min-width: 0;
 }
 
 .chart-cell-major-column {
@@ -1654,12 +1793,17 @@ select {
 }
 
 .chart-star-minor .chart-star-name,
+.chart-star-other .chart-star-name,
 .chart-star-scope .chart-star-name {
   font-size: 0.48rem;
 }
 
 .chart-star-minor .chart-star-name {
   color: var(--text-primary);
+}
+
+.chart-star-other .chart-star-name {
+  color: var(--text-muted);
 }
 
 .chart-star-scope .chart-star-name {
@@ -1680,6 +1824,13 @@ select {
   font-weight: 700;
 }
 
+.chart-star-brightness {
+  color: var(--text-muted);
+  font-size: 0.42rem;
+  font-weight: 500;
+  line-height: 1;
+}
+
 .chart-star-mark-birth {
   background: #fee2e2;
   color: #b91c1c;
@@ -1690,14 +1841,46 @@ select {
   color: var(--accent-strong);
 }
 
+.chart-star-mark-horoscope {
+  background: var(--secondary-soft);
+  color: var(--secondary-strong);
+}
+
+.chart-star-mark.is-lu {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.chart-star-mark.is-quan {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.chart-star-mark.is-ke {
+  background: #f3e8ff;
+  color: #7e22ce;
+}
+
+.chart-star-mark.is-ji {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
 .chart-star-empty {
   color: var(--text-secondary);
+}
+
+.chart-cell-age-cycle {
+  color: var(--text-muted);
+  font-size: 0.46rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .chart-cell-foot {
   margin-top: auto;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   flex-wrap: wrap;
   gap: 2px;
 }
@@ -1750,10 +1933,53 @@ select {
 
 .chart-center-info {
   display: grid;
-  gap: 2px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3px 6px;
   font-size: 0.6rem;
   line-height: 1.2;
   color: var(--text-primary);
+}
+
+.chart-center-info-row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 4px;
+}
+
+.chart-center-info-row span {
+  color: var(--text-muted);
+}
+
+.chart-center-info-row strong {
+  color: var(--text-primary);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.chart-center-info-wide {
+  grid-column: 1 / -1;
+}
+
+@media (prefers-color-scheme: dark) {
+  .chart-star-mark.is-lu {
+    background: rgba(34, 197, 94, 0.2);
+    color: #86efac;
+  }
+
+  .chart-star-mark.is-quan {
+    background: rgba(59, 130, 246, 0.2);
+    color: #93c5fd;
+  }
+
+  .chart-star-mark.is-ke {
+    background: rgba(168, 85, 247, 0.2);
+    color: #d8b4fe;
+  }
+
+  .chart-star-mark.is-ji {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fca5a5;
+  }
 }
 
 .chart-center-grid {
@@ -4487,7 +4713,11 @@ select {
   border: 1px solid var(--border-contrast);
   border-radius: 18px;
   background:
-    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--accent-soft) 42%, transparent), transparent 38%),
+    radial-gradient(
+      circle at 12% 0%,
+      color-mix(in srgb, var(--accent-soft) 42%, transparent),
+      transparent 38%
+    ),
     linear-gradient(180deg, var(--surface-elevated), var(--surface-muted));
   box-shadow: var(--shadow-sm);
 }
@@ -4976,7 +5206,11 @@ select {
 }
 
 .traditional-tarot-card.is-reversed {
-  background: linear-gradient(160deg, color-mix(in srgb, var(--accent-soft) 48%, var(--surface-base)), var(--surface-soft));
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--accent-soft) 48%, var(--surface-base)),
+    var(--surface-soft)
+  );
 }
 
 .traditional-card-index {
@@ -6557,9 +6791,8 @@ div.form-actions.page-submit-actions {
     width: 100%;
     min-width: 0;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    grid-template-rows: repeat(4, minmax(0, 1fr));
+    grid-template-rows: repeat(4, minmax(120px, 1fr));
     gap: 4px;
-    aspect-ratio: 1 / 1.08;
   }
 
   .ziwei-relation-lines {
@@ -6594,11 +6827,11 @@ div.form-actions.page-submit-actions {
   .chart-cell {
     border-radius: 7px;
     padding: 15px 3px 3px;
-    min-height: 0;
+    min-height: 120px;
   }
 
   .chart-cell-body {
-    grid-template-columns: 12px minmax(0, 1fr) 24px;
+    grid-template-columns: 12px minmax(0, 1fr);
     gap: 2px;
   }
 
@@ -6625,6 +6858,7 @@ div.form-actions.page-submit-actions {
   }
 
   .chart-star-minor .chart-star-name,
+  .chart-star-other .chart-star-name,
   .chart-star-scope .chart-star-name {
     font-size: 0.48rem;
   }
@@ -6745,7 +6979,7 @@ div.form-actions.page-submit-actions {
 
   .bazi-pillars-table {
     margin-top: 6px;
-    grid-template-columns: 48px repeat(4, minmax(0, 1fr));
+    grid-template-columns: 54px repeat(4, minmax(0, 1fr));
     border-radius: 10px;
   }
 
@@ -6759,12 +6993,18 @@ div.form-actions.page-submit-actions {
     line-height: 1.3;
   }
 
-  .bazi-pillars-cell.is-stem {
+  .bazi-pillars-cell.is-stem .bazi-ganzhi-symbol {
     font-size: 16px;
   }
 
-  .bazi-pillars-cell.is-branch {
+  .bazi-pillars-cell.is-branch .bazi-ganzhi-symbol {
     font-size: 15px;
+  }
+
+  .bazi-shensha-tag {
+    min-height: 18px;
+    padding: 2px 4px;
+    font-size: 9px;
   }
 
   .wuxing-bar-row {
@@ -7961,7 +8201,7 @@ div.form-actions.page-submit-actions {
   }
 
   .bazi-pillars-table {
-    grid-template-columns: 42px repeat(4, minmax(0, 1fr));
+    grid-template-columns: 48px repeat(4, minmax(0, 1fr));
   }
 
   .bazi-pillars-cell {
@@ -7973,11 +8213,11 @@ div.form-actions.page-submit-actions {
     line-height: 1.25;
   }
 
-  .bazi-pillars-cell.is-stem {
+  .bazi-pillars-cell.is-stem .bazi-ganzhi-symbol {
     font-size: 14px;
   }
 
-  .bazi-pillars-cell.is-branch {
+  .bazi-pillars-cell.is-branch .bazi-ganzhi-symbol {
     font-size: 13px;
   }
 
@@ -8061,9 +8301,8 @@ div.form-actions.page-submit-actions {
   }
 
   .ziwei-traditional-grid {
-    grid-template-rows: repeat(4, minmax(0, 1fr));
+    grid-template-rows: repeat(4, minmax(108px, 1fr));
     gap: 3px;
-    aspect-ratio: 1 / 1.1;
   }
 
   .prompt-compact-grid {
@@ -8096,6 +8335,7 @@ div.form-actions.page-submit-actions {
 
   .chart-cell {
     padding: 14px 4px 4px;
+    min-height: 108px;
   }
 
   .chart-cell-title {
@@ -8111,6 +8351,7 @@ div.form-actions.page-submit-actions {
   }
 
   .chart-star-minor .chart-star-name,
+  .chart-star-other .chart-star-name,
   .chart-star-scope .chart-star-name {
     font-size: 0.45rem;
   }

--- a/tests/bazi-chart-board.test.ts
+++ b/tests/bazi-chart-board.test.ts
@@ -50,8 +50,12 @@ test('八字结果盘应展示排盘预警和稳定基础参考', () => {
     ...result.shensha.day,
     ...result.shensha.hour,
   ];
-  assert.ok(allShenSha.length > 3);
-  allShenSha.forEach((item) => assert.ok(html.includes(item), `盘面应展示神煞：${item}`));
+  ['天乙贵人', '太极贵人', '文昌贵人', '华盖', '金舆'].forEach((item) =>
+    assert.ok(html.includes(`>${item}<`), `盘面应展示常用神煞：${item}`),
+  );
+  assert.ok(allShenSha.includes('马财库'), '底层结果仍应保留扩展神煞');
+  assert.ok(!html.includes('>马财库<'), '盘面应隐藏不常用神煞');
+  assert.ok(!html.includes('>真鬼刑疾<'), '盘面应隐藏不常用神煞');
   assert.match(html, /bazi-shensha-tag is-(lucky|unlucky|neutral)/);
 });
 

--- a/tests/bazi-chart-board.test.ts
+++ b/tests/bazi-chart-board.test.ts
@@ -37,6 +37,8 @@ test('八字结果盘应展示排盘预警和稳定基础参考', () => {
   assert.match(html, /天干十神/);
   assert.match(html, /地支十神/);
   assert.match(html, /元男/);
+  assert.ok(html.indexOf('天干十神') < html.indexOf('元男'));
+  assert.ok(html.indexOf('元男') < html.indexOf('>天干<'));
   assert.match(html, /data-wuxing="[木火土金水]"/);
   assert.match(html, /藏干十神/);
   assert.match(html, /自坐/);
@@ -72,4 +74,6 @@ test('八字女命日柱应标注元女', () => {
 
   assert.match(html, /元女/);
   assert.doesNotMatch(html, /元男/);
+  assert.ok(html.indexOf('天干十神') < html.indexOf('元女'));
+  assert.ok(html.indexOf('元女') < html.indexOf('>天干<'));
 });

--- a/tests/bazi-chart-board.test.ts
+++ b/tests/bazi-chart-board.test.ts
@@ -34,4 +34,42 @@ test('八字结果盘应展示排盘预警和稳定基础参考', () => {
   assert.match(html, /命卦/);
   assert.match(html, /命宫/);
   assert.match(html, /身宫/);
+  assert.match(html, /天干十神/);
+  assert.match(html, /地支十神/);
+  assert.match(html, /元男/);
+  assert.match(html, /data-wuxing="[木火土金水]"/);
+  assert.match(html, /藏干十神/);
+  assert.match(html, /自坐/);
+  assert.match(html, /空亡/);
+
+  const allShenSha = [
+    ...result.shensha.year,
+    ...result.shensha.month,
+    ...result.shensha.day,
+    ...result.shensha.hour,
+  ];
+  assert.ok(allShenSha.length > 3);
+  allShenSha.forEach((item) => assert.ok(html.includes(item), `盘面应展示神煞：${item}`));
+  assert.match(html, /bazi-shensha-tag is-(lucky|unlucky|neutral)/);
+});
+
+test('八字女命日柱应标注元女', () => {
+  const result = baziCalculator.calculateBazi({
+    year: 1995,
+    month: 5,
+    day: 20,
+    timeIndex: 6,
+    gender: 'female',
+  });
+
+  const html = renderToStaticMarkup(
+    createElement(BaziChartBoard, {
+      title: '八字排盘',
+      name: '测试女命',
+      result,
+    }),
+  );
+
+  assert.match(html, /元女/);
+  assert.doesNotMatch(html, /元男/);
 });

--- a/tests/ziwei-display-payload.test.ts
+++ b/tests/ziwei-display-payload.test.ts
@@ -1,10 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import {
   buildZiweiChartInput,
   calculateZiweiDisplayPayload,
 } from '../src/lib/full-chart-engine/ziwei';
+import { ChartStar } from '../src/pages/ResultPage/components/ChartStar';
+import { ZiweiTraditionalBoard } from '../src/pages/ResultPage/components/ZiweiTraditionalBoard';
 
 test('紫微排盘入口应拒绝空白数字文本和不存在的出生日期', () => {
   assert.throws(
@@ -73,4 +77,48 @@ test('紫微指定行运 payload 应输出补零后的公历日期', async () =>
   });
 
   assert.equal(payload.active_scope.solar_date, '2101-02-28');
+
+  const html = renderToStaticMarkup(
+    createElement(ZiweiTraditionalBoard, {
+      payload,
+      boardTitle: '传统盘',
+      name: '测试命盘',
+      selectedPalaceIndex: payload.palaces[0].index,
+      onSelectPalace: () => undefined,
+    }),
+  );
+  const otherStarNames = payload.palaces.flatMap((palace) =>
+    palace.other_stars.map((star) => star.name),
+  );
+
+  assert.match(html, /四柱/);
+  assert.match(html, /chart-star-brightness/);
+  assert.match(html, /chart-cell-stars-other/);
+  assert.match(html, /流年/);
+  assert.match(html, /长生/);
+  assert.match(html, /博士/);
+  assert.match(html, /将前/);
+  assert.ok(otherStarNames.length > 0);
+  otherStarNames.forEach((name) => assert.ok(html.includes(name), `盘面应展示杂曜：${name}`));
+});
+
+test('紫微星曜应同时显示亮度与各层四化', () => {
+  const html = renderToStaticMarkup(
+    createElement(ChartStar, {
+      tone: 'major',
+      star: {
+        name: '紫微',
+        kind: 'major',
+        brightness: '庙',
+        birth_mutagen: '禄',
+        horoscope_mutagen: '权',
+        active_scope_mutagen: '科',
+      },
+    }),
+  );
+
+  assert.match(html, /亮度庙/);
+  assert.match(html, /生年四化禄/);
+  assert.match(html, /运限星曜四化权/);
+  assert.match(html, /当前时限四化科/);
 });


### PR DESCRIPTION
## 目标

参考 #194 完善八字与紫微传统盘的信息展示，并结合现有盘面结构按需调整，不照搬参考样式。

## 主要修改

- 八字盘调整天干、地支十神位置，标注干支五行，并在日柱显示元男/元女
- 八字盘补充藏干十神、自坐、空亡；盘面只展示常用神煞，扩展神煞仍完整保留在底层结果
- 紫微十二宫完整展示主星、辅星、杂曜、运限星曜、亮度及多层四化
- 紫微宫位补充完整流年虚岁、长生、博士、将前和岁前资料
- 紫微中央区域补充四柱、阳历、农历、生肖、星座、时辰、命宫与身宫信息
- 固定紫微盘切换宫位时的内容高度，避免页面反复拉伸卡顿
- 调整桌面与移动端盘面布局，避免新增资料重叠
- 补充八字和紫微盘面回归测试

## 验证

- `pnpm test`：1466 项通过
- `pnpm test:e2e`：38 项通过
- `pnpm build`：通过
- `pnpm exec tsc --noEmit -p tsconfig.app.json`：通过
- `pnpm lint`：通过
- `pnpm format:check`：通过
- 桌面与手机宽度真实页面检查：通过，无内容重叠、横向溢出或控制台错误

## 兼容与风险

- 没有修改排盘算法和已有公开数据结构，仅增加核心神煞类型函数的公开导出
- 神煞精简只影响八字前端盘面，npm 包、API、底层计算结果和提示词资料保持完整
- 紫微盘展示资料增多，移动端信息密度相应提高，但保持完整可见
