### PR TITLE
feat(core): 真太阳时 IANA 历史时区 / 子时双口径 / 南半球端到端透传 (0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# 更新日志 (Changelog)
+
+## 0.2.0 — 真太阳时 IANA 历史时区与子时/南半球端到端透传
+
+> 本次为在 `main`（`fc09fdb`）基础上重新实现并合并的功能集。原本地提交因环境丢失未推送，本版本在演进后的代码库上复用既有 `resolveHistoricalTimezone` 完成闭环。
+
+### 新增能力
+
+- **IANA 历史时区端到端透传**：`resolveTrueSolarBirthTime` / `convertTrueSolarTime` 新增可选 `timeZoneId` 字段。提供时按 IANA 历史规则解析当地时刻的 UTC 偏移，重算标准经线（自动含夏令时），覆盖数值 `timezone`，解决固定偏移无法反映历史 DST 的问题。
+- **子时双口径（zi-hour dual mode）**：新增 `ziHourMode`（`'standard'` 默认 / `'conservative'`）。`conservative` 下 23:00 仍归亥时（index 11），不使用晚子时拆分；`standard` 维持 23:00 起晚子时（index 12）。`getShichenFromClock` / `getTimeIndexFromClock` 增加可选参数，向后兼容。
+- **南半球标记透传（southernHemisphere）**：新增可选布尔字段，由真太阳时解析层一路透传至结果，供上层词库解读季节/年界（仅标记，不参与真太阳时计算）。
+
+### 调用方贯通（end-to-end）
+
+| 调用方 | IANA(`timeZoneId`) | 子时(`ziHourMode`) | 南半球(`southernHemisphere`) | 备注 |
+| --- | --- | --- | --- | --- |
+| bazi (`baziCalculator.ts`) | ✅ 透传 | ✅ 透传 | ✅ 透传 | 经 `Person` 接口 |
+| ziwei (`true-solar-input.ts`) | ✅ 透传 | ✅ 透传 | ✅ 透传 | 经 `ZiweiTrueSolarInput` |
+| astrolabe (`astrolabe.ts`) | ✅ 透传（上游已解析 IANA 数值偏移） | ✅ 透传 | ✅ 透传 | 经 `AstrolabeBirthInput` |
+| qi_zheng (`qi_zheng/index.ts`) | ✅ 透传（低层 `calculateTrueSolarTime` 新增 `options.timeZoneId`） | — | — | 低层换算不消费子时/南半球，故不传入死字段 |
+
+> `client/index.ts` 直接透传 `TrueSolarBirthTimeInput`，自动继承新字段；`profile/index.ts` 维持数值时区口径，行为不变。
+
+### 验证
+
+- `tsc --noEmit -p packages/core/tsconfig.json`：EXIT 0（全量类型检查通过）。
+- 端到端运行时校验（`verify-iana-forwarding.ts`，已清理）：IANA 解析（America/New_York 1988-06-15 → UTC-4 / 经线 -60）、数值兜底、子时双口径（23:30 conservative→亥时 / standard→晚子时）、南半球回显、低层 IANA 选项，全部 PASS。
+- 核心回归测试：`tests/true-solar-time.test.ts` 等 5 文件 27/27 PASS；`core-birth-bundle` 等 4 文件 125/125 PASS。
+- 全量 111 测试套件中其余失败均源于缺失依赖（react / celestine / @modelcontextprotocol/sdk），与本次代码改动无关，属环境限制。
+
+### 兼容性
+
+- 所有新增字段均为可选，未破坏任何既有调用签名。
+- `calculateTrueSolarTime` 新增第 4 参数 `options?`，`getShichenFromClock`/`getTimeIndexFromClock` 新增第 3 参数 `ziHourMode?`，均带默认值，向后兼容。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingyu-core",
-  "version": "0.1.25",
+  "version": "0.2.0",
   "description": "Mingyu core algorithms: traditional Chinese metaphysics (八字Bazi, 紫微斗数Ziwei, 奇门遁甲Qimen, 六爻Liuyao, 六壬Liuren, 梅花易数Meihua, and more)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/bazi/baziCalculator.ts
+++ b/packages/core/src/bazi/baziCalculator.ts
@@ -256,6 +256,9 @@ export class BaziCalculator {
         longitude: birthLongitude!,
         timezone,
         applyChinaDst,
+        timeZoneId: person.timeZoneId,
+        ziHourMode: person.ziHourMode,
+        southernHemisphere: person.southernHemisphere,
       });
       const dstCorrectionMinutes = trueSolarResult.chinaDst.applied
         ? trueSolarResult.chinaDst.offsetMinutes

--- a/packages/core/src/bazi/baziTypes.ts
+++ b/packages/core/src/bazi/baziTypes.ts
@@ -38,6 +38,12 @@ export interface Person {
    * 仅时辰精度时只输出提示不做校正。
    */
   applyChinaDst?: boolean;
+  /** IANA 时区名；提供时按历史规则解析 UTC 偏移并重算标准经线，自动含夏令时，覆盖 timezone。 */
+  timeZoneId?: string;
+  /** 子时口径：'standard'（默认）23:00 起晚子时；'conservative' 23:00 仍归亥时。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 南半球标记：仅透传，由上层词库解读季节/年界。 */
+  southernHemisphere?: boolean;
 }
 
 export interface TimeInfo {

--- a/packages/core/src/calendar/dateUtils.ts
+++ b/packages/core/src/calendar/dateUtils.ts
@@ -42,7 +42,17 @@ export function getShichenByIndex(index: number): ShichenPeriod | null {
   return SHICHEN_PERIODS[index];
 }
 
-export function getTimeIndexFromClock(hour: number, minute = 0): number {
+/**
+ * 由钟表时刻求时辰索引。
+ * @param ziHourMode 子时口径：
+ *  - 'standard'（默认）子时按本项目口径拆为早子时(00:00-01:00)与晚子时(23:00-24:00)；
+ *  - 'conservative' 传统口径，23:00 仍归亥时，不使用晚子时拆分。
+ */
+export function getTimeIndexFromClock(
+  hour: number,
+  minute = 0,
+  ziHourMode: 'standard' | 'conservative' = 'standard',
+): number {
   if (
     !Number.isInteger(hour) ||
     !Number.isInteger(minute) ||
@@ -54,12 +64,16 @@ export function getTimeIndexFromClock(hour: number, minute = 0): number {
     return -1;
   }
 
-  if (hour === 24) return minute === 0 ? 12 : -1;
-  if (hour === 23) return 12;
+  if (hour === 24) return minute === 0 ? (ziHourMode === 'conservative' ? 0 : 12) : -1;
+  if (hour === 23) return ziHourMode === 'conservative' ? 11 : 12;
   if (hour === 0) return 0;
   return Math.floor((hour + 1) / 2);
 }
 
-export function getShichenFromClock(hour: number, minute = 0): ShichenPeriod | null {
-  return getShichenByIndex(getTimeIndexFromClock(hour, minute));
+export function getShichenFromClock(
+  hour: number,
+  minute = 0,
+  ziHourMode: 'standard' | 'conservative' = 'standard',
+): ShichenPeriod | null {
+  return getShichenByIndex(getTimeIndexFromClock(hour, minute, ziHourMode));
 }

--- a/packages/core/src/calendar/true-solar-time.ts
+++ b/packages/core/src/calendar/true-solar-time.ts
@@ -1,6 +1,7 @@
 import { LunarHour, SolarTime } from 'tyme4ts';
 import { daysInSolarMonth, getBirthDateValidationMessage } from './date-validation';
 import { getShichenFromClock } from './dateUtils';
+import { resolveHistoricalTimezone } from './historical-timezone';
 import { checkChinaDst, type ChinaDstCheckResult } from './china-dst';
 
 export interface SolarDateTimeParts {
@@ -91,10 +92,16 @@ export interface TrueSolarTimeConversionInput {
   localDateTime: string;
   /** 出生地或观测地经度，东经为正、西经为负。 */
   longitude: number;
-  /** 当地标准时区，默认 UTC+8；支持小数时区。 */
+  /** 当地标准时区（小时偏移），默认 UTC+8；支持小数时区。 */
   timezone?: number;
+  /** IANA 时区名；提供时按历史规则解析 UTC 偏移并重算标准经线，自动含夏令时，覆盖 timezone。 */
+  timeZoneId?: string;
   /** 是否按中国 1986-1991 历史规则自动还原夏令时，默认 false。 */
   applyChinaDst?: boolean;
+  /** 子时口径：'standard'（默认）23:00 起晚子时；'conservative' 23:00 仍归亥时。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 南半球标记：仅透传，由上层词库解读季节/年界。 */
+  southernHemisphere?: boolean;
 }
 
 export interface TrueSolarTimeConversionResult
@@ -117,6 +124,12 @@ export interface TrueSolarTimeConversionResult
     branch: string;
     name: string;
   };
+  /** 透传的 IANA 时区名（若提供），用于追溯历史偏移来源。 */
+  timeZoneId?: string;
+  /** 透传的子时口径（若提供）。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 透传的南半球标记（若提供）。 */
+  southernHemisphere?: boolean;
 }
 
 export interface TrueSolarBirthTimeInput {
@@ -130,7 +143,14 @@ export interface TrueSolarBirthTimeInput {
   isLeapMonth?: boolean;
   longitude: number;
   timezone?: number;
+  /** IANA 时区名；提供时按历史规则解析 UTC 偏移并重算标准经线，自动含夏令时，覆盖 timezone。 */
+  timeZoneId?: string;
+  /** 是否按中国 1986-1991 历史规则自动还原夏令时，默认 false。 */
   applyChinaDst?: boolean;
+  /** 子时口径：'standard'（默认）23:00 起晚子时；'conservative' 23:00 仍归亥时。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 南半球标记：仅透传，由上层词库解读季节/年界。 */
+  southernHemisphere?: boolean;
 }
 
 export interface TrueSolarBirthTimeResult extends TrueSolarTimeConversionResult {
@@ -533,24 +553,44 @@ export function calculateEquationOfTimeMinutes(year: number, month: number, day:
   return 9.87 * Math.sin(2 * angle) - 7.53 * Math.cos(angle) - 1.5 * Math.sin(angle);
 }
 
+export interface CalculateTrueSolarTimeOptions {
+  /** IANA 时区名；提供时按历史规则解析 UTC 偏移并重算标准经线，自动含夏令时，覆盖传入的 standardMeridian。 */
+  timeZoneId?: string;
+}
+
 export function calculateTrueSolarTime(
   standardTime: Pick<SolarDateTimeParts, 'year' | 'month' | 'day' | 'hour' | 'minute'> &
     Partial<Pick<SolarDateTimeParts, 'second'>>,
   longitude: number,
   standardMeridian = 120,
+  options?: CalculateTrueSolarTimeOptions,
 ): TrueSolarTimeResult {
   const second = standardTime.second ?? 0;
   validateSolarDate(standardTime.year, standardTime.month, standardTime.day);
   validateTimePart(standardTime.hour, standardTime.minute, second);
   assertNumberInRange(longitude, '经度', -180, 180);
-  assertNumberInRange(standardMeridian, '标准经线', -180, 210);
+
+  let meridian = standardMeridian;
+  if (options?.timeZoneId?.trim()) {
+    const historical = resolveHistoricalTimezone({
+      year: standardTime.year,
+      month: standardTime.month,
+      day: standardTime.day,
+      hour: standardTime.hour,
+      minute: standardTime.minute,
+      second,
+      timeZoneId: options.timeZoneId.trim(),
+    });
+    meridian = historical.resolvedOffsetHours * 15;
+  }
+  assertNumberInRange(meridian, '标准经线', -180, 210);
 
   const equationOfTimeMinutes = calculateEquationOfTimeMinutes(
     standardTime.year,
     standardTime.month,
     standardTime.day,
   );
-  const longitudeCorrectionMinutes = (longitude - standardMeridian) * 4;
+  const longitudeCorrectionMinutes = (longitude - meridian) * 4;
   const totalCorrectionMinutes = equationOfTimeMinutes + longitudeCorrectionMinutes;
 
   const correctedDate = new Date(
@@ -581,7 +621,7 @@ export function convertTrueSolarTime(
   input: TrueSolarTimeConversionInput,
 ): TrueSolarTimeConversionResult {
   const clockTime = parseLocalDateTime(input.localDateTime);
-  const timezone = input.timezone ?? 8;
+  let timezone = input.timezone ?? 8;
   assertNumberInRange(timezone, 'timezone', -12, 14);
   if (input.applyChinaDst !== undefined && typeof input.applyChinaDst !== 'boolean') {
     throw new Error('applyChinaDst 必须是布尔值。');
@@ -600,9 +640,23 @@ export function convertTrueSolarTime(
   const standardTime = chinaDstApplied
     ? shiftDateTime(clockTime, chinaDstCheck.offsetMinutes)
     : clockTime;
+  if (input.timeZoneId?.trim()) {
+    const historical = resolveHistoricalTimezone({
+      year: clockTime.year,
+      month: clockTime.month,
+      day: clockTime.day,
+      hour: clockTime.hour,
+      minute: clockTime.minute,
+      second: clockTime.second ?? 0,
+      timeZoneId: input.timeZoneId.trim(),
+      fixedOffsetHours: input.timezone,
+    });
+    timezone = historical.resolvedOffsetHours;
+  }
+  assertNumberInRange(timezone, 'timezone', -12, 14);
   const standardMeridian = timezone * 15;
   const result = calculateTrueSolarTime(standardTime, input.longitude, standardMeridian);
-  const shichen = getShichenFromClock(result.correctedTime.hour, result.correctedTime.minute);
+  const shichen = getShichenFromClock(result.correctedTime.hour, result.correctedTime.minute, input.ziHourMode);
   if (!shichen) {
     throw new Error('无法根据校正后的真太阳时确定时辰。');
   }
@@ -653,6 +707,9 @@ export function convertTrueSolarTime(
     chinaDst,
     crossesDate,
     shichen: shichenResult,
+    timeZoneId: input.timeZoneId,
+    ziHourMode: input.ziHourMode,
+    southernHemisphere: input.southernHemisphere,
   };
 }
 
@@ -704,6 +761,9 @@ export function resolveTrueSolarBirthTime(
     longitude: input.longitude,
     timezone: input.timezone,
     applyChinaDst: input.applyChinaDst,
+    timeZoneId: input.timeZoneId,
+    ziHourMode: input.ziHourMode,
+    southernHemisphere: input.southernHemisphere,
   });
   const solarClockDateTime = formatSolarDateTimeParts(solarClockTime);
   const calendarStep: TrueSolarTimeCalculationStep = {

--- a/packages/core/src/divination/algorithms/astrolabe.ts
+++ b/packages/core/src/divination/algorithms/astrolabe.ts
@@ -298,6 +298,9 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
         minute: standardBirth.minute,
         longitude,
         timezone,
+        timeZoneId: input.timeZoneId,
+        ziHourMode: input.ziHourMode,
+        southernHemisphere: input.southernHemisphere,
       })
     : null;
   const locationName = readOptionalText(input.locationName, '');

--- a/packages/core/src/qi_zheng/index.ts
+++ b/packages/core/src/qi_zheng/index.ts
@@ -1592,6 +1592,7 @@ export function generateQizheng(input: QizhengInput): QizhengResult {
       },
       lon,
       standardMeridian,
+      input.timeZoneId?.trim() ? { timeZoneId: input.timeZoneId.trim() } : undefined,
     );
     palaceHour = trueSolar.correctedTime.hour;
     palaceMinute = trueSolar.correctedTime.minute;

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -1074,6 +1074,10 @@ export interface AstrolabeBirthInput {
   timeZoneId?: string;
   locationName?: string;
   useTrueSolarTime?: boolean;
+  /** 子时口径：'standard'（默认）23:00 起晚子时；'conservative' 23:00 仍归亥时。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 南半球标记：仅透传，由上层词库解读季节/年界。 */
+  southernHemisphere?: boolean;
 }
 
 export interface AstrolabePoint {

--- a/packages/core/src/ziwei/true-solar-input.ts
+++ b/packages/core/src/ziwei/true-solar-input.ts
@@ -15,6 +15,12 @@ export interface ZiweiTrueSolarInput {
   birthLongitude: string;
   timezone?: number;
   applyChinaDst?: boolean;
+  /** IANA 时区名；提供时按历史规则解析 UTC 偏移并重算标准经线，自动含夏令时，覆盖 timezone。 */
+  timeZoneId?: string;
+  /** 子时口径：'standard'（默认）23:00 起晚子时；'conservative' 23:00 仍归亥时。 */
+  ziHourMode?: 'standard' | 'conservative';
+  /** 南半球标记：仅透传，由上层词库解读季节/年界。 */
+  southernHemisphere?: boolean;
 }
 
 export interface ZiweiTrueSolarBirth {
@@ -85,6 +91,9 @@ export function resolveZiweiTrueSolarBirth(input: ZiweiTrueSolarInput): ZiweiTru
     longitude: birthLongitude,
     timezone: input.timezone,
     applyChinaDst: input.applyChinaDst,
+    timeZoneId: input.timeZoneId,
+    ziHourMode: input.ziHourMode,
+    southernHemisphere: input.southernHemisphere,
   });
   const corrected = resolved.correctedTime;
   return {


### PR DESCRIPTION
## 摘要

在 `main`（`fc09fdb`）基础上，为真太阳时解析层补齐 **IANA 历史时区 / 子时双口径 / 南半球** 三项可选字段的端到端透传，并打通 bazi / ziwei / astrolabe / qi_zheng 四大调用方。发布 `0.2.0`。

## 新增能力

- **IANA 历史时区端到端透传**：`resolveTrueSolarBirthTime` / `convertTrueSolarTime` 新增可选 `timeZoneId`。提供时按 IANA 历史规则解析当地 UTC 偏移（自动含夏令时），重算标准经线，覆盖数值 `timezone`，解决固定偏移无法反映历史 DST 的问题。复用既有 `resolveHistoricalTimezone`，无新增依赖。
- **子时双口径（`ziHourMode`）**：`'standard'`（默认，23:00 起晚子时 index 12）/ `'conservative'`（23:00 归亥时 index 11）。`getShichenFromClock` / `getTimeIndexFromClock` 新增可选参数，向后兼容。
- **南半球标记（`southernHemisphere`）**：由真太阳时解析层一路透传至结果，供上层词库解读季节/年界（仅标记，不参与计算）。

## 调用方贯通

| 调用方 | IANA | 子时 | 南半球 | 备注 |
| --- | --- | --- | --- | --- |
| bazi | ✅ | ✅ | ✅ | 经 `Person` 接口 |
| ziwei | ✅ | ✅ | ✅ | 经 `ZiweiTrueSolarInput` |
| astrolabe | ✅（上游已解析数值偏移） | ✅ | ✅ | 经 `AstrolabeBirthInput` |
| qi_zheng | ✅（低层 `calculateTrueSolarTime` 新增 `options.timeZoneId`） | — | — | 低层不消费子时/南半球，不传死字段 |

## 验证

- `tsc --noEmit -p packages/core/tsconfig.json`：EXIT 0（全量类型检查通过）。
- 端到端运行时校验：IANA 解析（America/New_York → UTC-4 / 经线 -60）、数值兜底、子时双口径、南半球回显、低层 IANA 选项，全部 PASS。
- 核心回归测试：27/27 + 125/125 PASS。

## 兼容性

- 所有新增字段均为可选，未破坏任何既有调用签名；`calculateTrueSolarTime` 第 4 参数 `options?`、`getShichenFromClock`/`getTimeIndexFromClock` 第 3 参数均带默认值，向后兼容。

## 提交说明

- 分支 `codex/true-solar-iana-forwarding`，提交 `9b7b91a`，共 10 文件（+145 / -11）。
- 因沙箱 gh 身份为 `solaroran-rgb`（对 `Brhiza/mingyu` 无写权限），故走 fork + PR 路径，由维护者 review 后合入。
