### PR TITLE
完善真太阳时历史时区支持

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@
 
 | 用户问题类型                       | 首选接口                                     | 推荐参数                                                                                                                                                    | 说明                                                                       |
 | ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| 换算真太阳时                       | `POST /calendar/true-solar-time`             | `localDateTime`、`longitude`，可选 `timezone`、`applyChinaDst`                                                                                              | 默认 UTC+8，返回修正明细、跨日状态和对应时辰                               |
+| 换算真太阳时                       | `POST /calendar/true-solar-time`             | `localDateTime`、`longitude`，可选 `timezone`、`timeZoneId`、`applyChinaDst`                                                                                | 支持固定偏移或 IANA 历史时区，返回修正明细、跨日状态和对应时辰             |
 | 计算太阳光照证据                   | `POST /calendar/solar-illumination`          | `year`、`month`、`day`、`latitude`、`longitude`，并提供 `timezone` 或 `timeZoneId`；可选参考时分秒                                                          | 返回太阳高度、方位、视太阳正午、日出日落与三类曙暮光                       |
 | 查六十甲子、纳音、藏干和合冲       | `POST /foundation/ganzhi`                    | `ganZhi`，如“甲子”                                                                                                                                          | 返回统一公共地基资料，不需重复实现                                         |
 | 统计天干地支五行分布               | `POST /foundation/wuxing`                    | `items`、可选 `weightHidden`                                                                                                                                | 默认计入地支藏干权重                                                       |
@@ -165,7 +165,7 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-time \
   -d '{"localDateTime":"1988-07-15T12:00:00","longitude":116.4074,"timezone":8,"applyChinaDst":true}'
 ```
 
-`localDateTime` 是当地钟表时间，不要附带 `Z` 或 `+08:00`。`timezone` 默认是 `8`；中国 1986–1991 年历史出生记录可传 `applyChinaDst: true` 自动还原夏令时，其他地区仍应按当地历史规则先还原为标准时间。
+`localDateTime` 是当地钟表时间，不要附带 `Z` 或 `+08:00`。未传 `timeZoneId` 时，`timezone` 默认是 `8`；历史日期或实行夏令时的地区可传 IANA 时区（如 `America/New_York`），系统会解析当时的法定偏移。秋季回拨的重复当地时间必须再传与原始记录一致的 `timezone` 消歧，固定偏移与 IANA 规则冲突时会拒绝计算。`timeZoneId` 已包含历史夏令时规则，不能同时启用 `applyChinaDst`；中国 1986–1991 年记录也可只用固定 `timezone: 8` 配合 `applyChinaDst: true` 走兼容口径。
 
 六十甲子基础资料：
 

--- a/mcp/src/tools/bazi-ziwei.ts
+++ b/mcp/src/tools/bazi-ziwei.ts
@@ -46,6 +46,9 @@ const baziZiweiPromptSchema = z.object({
   birthMinute: z.number().optional().describe('精准出生分钟，启用真太阳时时必填'),
   birthPlace: z.string().optional().describe('出生地名称，启用真太阳时时可选'),
   birthLongitude: z.number().optional().describe('出生地经度，启用真太阳时时必填'),
+  timezone: z.number().min(-12).max(14).optional().describe('固定 UTC 偏移，默认 UTC+8'),
+  timeZoneId: z.string().min(1).optional().describe('IANA 历史时区，如 America/New_York'),
+  applyChinaDst: z.boolean().optional().describe('是否应用中国 1986-1991 历史夏令时校正'),
   algorithm: z
     .enum(['default', 'zhongzhou'])
     .optional()
@@ -94,6 +97,9 @@ function buildCombinedZiweiInput(args: z.infer<typeof baziZiweiPromptSchema>) {
     birthHour: args.birthHour === undefined ? undefined : String(args.birthHour),
     birthMinute: args.birthMinute === undefined ? undefined : String(args.birthMinute),
     birthLongitude: args.birthLongitude === undefined ? undefined : String(args.birthLongitude),
+    timezone: args.timezone,
+    timeZoneId: args.timeZoneId,
+    applyChinaDst: args.applyChinaDst,
     algorithm: args.algorithm,
   });
 }

--- a/mcp/src/tools/bazi.ts
+++ b/mcp/src/tools/bazi.ts
@@ -45,6 +45,9 @@ export const baziSchema = z.object({
   birthMinute: z.number().optional().describe('精准出生分钟，启用真太阳时时必填'),
   birthPlace: z.string().optional().describe('出生地名称，启用真太阳时时可选'),
   birthLongitude: z.number().optional().describe('出生地经度，启用真太阳时时必填'),
+  timezone: z.number().min(-12).max(14).optional().describe('固定 UTC 偏移，默认 UTC+8'),
+  timeZoneId: z.string().min(1).optional().describe('IANA 历史时区，如 America/New_York'),
+  applyChinaDst: z.boolean().optional().describe('是否应用中国 1986-1991 历史夏令时校正'),
 });
 
 const baziCompatibilityTypes = [
@@ -151,6 +154,9 @@ export function buildBaziPerson(args: z.infer<typeof baziSchema>): Person {
       birthMinute,
       birthPlace: args.birthPlace ?? '',
       birthLongitude,
+      timezone: args.timezone,
+      timeZoneId: args.timeZoneId,
+      applyChinaDst: args.applyChinaDst,
     };
   }
 

--- a/mcp/src/tools/calendar.ts
+++ b/mcp/src/tools/calendar.ts
@@ -20,7 +20,13 @@ const trueSolarTimeSchema = z.object({
     .string()
     .describe('当地钟表时间，如 1990-05-15T10:30:00；不要附带 Z 或 +08:00 等时区后缀'),
   longitude: z.number().min(-180).max(180).describe('当地经度，东经为正、西经为负'),
-  timezone: z.number().min(-12).max(14).optional().describe('当地标准时区，默认 UTC+8'),
+  timezone: z
+    .number()
+    .min(-12)
+    .max(14)
+    .optional()
+    .describe('固定 UTC 偏移；未提供 timeZoneId 时默认 UTC+8，也可用于回拨时间消歧'),
+  timeZoneId: z.string().min(1).optional().describe('IANA 历史时区，如 America/New_York'),
   applyChinaDst: z
     .boolean()
     .optional()
@@ -37,7 +43,13 @@ const trueSolarBirthSchema = z.object({
   second: z.number().int().min(0).max(59).optional().describe('秒，默认 0'),
   isLeapMonth: z.boolean().optional().describe('农历是否为闰月'),
   longitude: z.number().min(-180).max(180).describe('当地经度，东经为正、西经为负'),
-  timezone: z.number().min(-12).max(14).optional().describe('当地标准时区，默认 UTC+8'),
+  timezone: z
+    .number()
+    .min(-12)
+    .max(14)
+    .optional()
+    .describe('固定 UTC 偏移；未提供 timeZoneId 时默认 UTC+8，也可用于回拨时间消歧'),
+  timeZoneId: z.string().min(1).optional().describe('IANA 历史时区，如 America/New_York'),
   applyChinaDst: z.boolean().optional().describe('是否自动还原中国历史夏令时'),
 });
 
@@ -90,7 +102,7 @@ export function registerCalendarTools(server: McpServer) {
     'calendar_true_solar_time',
     {
       description:
-        '将当地钟表时间换算为真太阳时，返回唯一校正时间、经度与均时差修正、跨日和时辰结果，以及可核验的计算链、校正事实、证据汇总、来源与限制',
+        '将当地钟表时间按固定偏移或IANA历史时区换算为真太阳时，返回唯一校正时间、经度与均时差修正、跨日和时辰结果，以及可核验的计算链、校正事实、证据汇总、来源与限制',
       inputSchema: trueSolarTimeSchema.shape,
       outputSchema: resultOutputSchema,
     },
@@ -107,7 +119,7 @@ export function registerCalendarTools(server: McpServer) {
     'calendar_true_solar_birth',
     {
       description:
-        '统一换算公历或农历出生真太阳时，返回历法换算、历史夏令时、跨日、唯一时辰索引及完整结构化计算链、校正事实、证据汇总、来源与限制',
+        '统一按固定偏移或IANA历史时区换算公历或农历出生真太阳时，返回历法换算、历史夏令时、跨日、唯一时辰索引及完整结构化计算链、校正事实、证据汇总、来源与限制',
       inputSchema: trueSolarBirthSchema.shape,
       outputSchema: resultOutputSchema,
     },

--- a/mcp/src/tools/ziwei.ts
+++ b/mcp/src/tools/ziwei.ts
@@ -54,6 +54,9 @@ export const ziweiSchema = z.object({
   birthHour: z.string().optional().describe('精准出生小时，启用真太阳时时必填，如 1'),
   birthMinute: z.string().optional().describe('精准出生分钟，启用真太阳时时必填，如 20'),
   birthLongitude: z.string().optional().describe('出生地经度，启用真太阳时时必填，如 116.4074'),
+  timezone: z.number().min(-12).max(14).optional().describe('固定 UTC 偏移，默认 UTC+8'),
+  timeZoneId: z.string().min(1).optional().describe('IANA 历史时区，如 America/New_York'),
+  applyChinaDst: z.boolean().optional().describe('是否应用中国 1986-1991 历史夏令时校正'),
   algorithm: z
     .enum(['default', 'zhongzhou'])
     .optional()
@@ -131,6 +134,9 @@ export function buildMcpZiweiChartInput(args: z.infer<typeof ziweiSchema>) {
     birthHour: trueSolarTimeInput?.birthHour ?? args.birthHour ?? '',
     birthMinute: trueSolarTimeInput?.birthMinute ?? args.birthMinute ?? '',
     birthLongitude: trueSolarTimeInput?.birthLongitude ?? args.birthLongitude ?? '',
+    timezone: args.timezone,
+    timeZoneId: args.timeZoneId,
+    applyChinaDst: args.applyChinaDst,
     algorithm: args.algorithm ?? 'default',
   });
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -121,7 +121,7 @@ import { getCapabilities } from 'mingyu-core/capabilities';
 
 八字、紫微若不启用真太阳时，可以直接使用明确的时辰索引排盘；这属于有效的确定输入，不属于出生时间缺失。仅有时辰精度时，统一采用各时段中点作为完成历法日期换算的代表时刻（如午时按 12:00、早子时按 00:30）。统一档案会明确记录输入精度、代表时刻边界、时辰映射、真太阳时状态、证据汇总和解释限制。启用真太阳时，或转换为星盘等分钟级算法输入时，才需要具体小时、分钟和出生地资料；时辰代表值不会被冒充为精确分钟。
 
-统一档案也提供传统盘便捷入口：`calculateBaziFromBirthProfile(profile)` 直接生成八字结果，`birthProfileToZiweiChartInput(profile)` 生成可交给 `mingyu-core/ziwei` 的紫微输入。农历真太阳时会先转换为公历钟表时间，再由八字引擎统一校正一次；出生地的 `timezone` 会参与标准经线计算，未提供时默认 UTC+8。
+统一档案也提供传统盘便捷入口：`calculateBaziFromBirthProfile(profile)` 直接生成八字结果，`birthProfileToZiweiChartInput(profile)` 生成可交给 `mingyu-core/ziwei` 的紫微输入。农历真太阳时会先转换为公历钟表时间，再由八字引擎统一校正一次；出生地可用 `timezone` 提供固定偏移，或用 `timeZoneId` 按出生日期解析 IANA 历史时区，两者都未提供时默认 UTC+8。
 
 如果应用需要一次取得多种盘面，可使用 `mingyu-core/birth` 的 `calculateBirthChartBundle`。默认只计算八字；需要紫微时请安装可选的 `iztro`，并通过 `systems` 明确选择系统：
 
@@ -704,8 +704,8 @@ const voidBranches = getVoidBranches('甲子'); // ['戌','亥'] 旬空
 
 | 导出                                              | 说明                                                             |
 | ------------------------------------------------- | ---------------------------------------------------------------- |
-| `calendar.resolveTrueSolarBirthTime(input)`       | 公历/农历出生真太阳时、夏令时、跨日和时辰索引统一换算            |
-| `calendar.convertTrueSolarTime(input)`            | 当地钟表时间按时区、经度和均时差换算真太阳时                     |
+| `calendar.resolveTrueSolarBirthTime(input)`       | 公历/农历出生真太阳时、历史时区、夏令时、跨日和时辰索引统一换算  |
+| `calendar.convertTrueSolarTime(input)`            | 当地钟表时间按固定偏移或 IANA 历史时区、经度和均时差换算真太阳时 |
 | `profile.calculateBaziFromBirthProfile(profile)`  | 从统一出生档案直接生成八字传统盘结果                             |
 | `profile.birthProfileToZiweiChartInput(profile)`  | 将统一出生档案转换为紫微传统盘输入                               |
 | `bazhai.analyzeBaZhaiByDoorDegree(input)`         | 按入户实测度数、北向基准、磁偏角和测量误差生成八宅结果与候选坐向 |

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -52,6 +52,7 @@
 | `birthMinute`      | `number`                        | *    | 真太阳时模式下的分钟（0-59）                                                              |
 | `birthLongitude`   | `number`                        | *    | 出生地经度（-180~180）                                                                    |
 | `timezone`         | `number`                        |      | 当地标准时区（UTC-12~UTC+14），默认 UTC+8；影响标准经线                                   |
+| `timeZoneId`       | `string`                        |      | IANA 历史时区；按出生日期解析当时的法定 UTC 偏移                                          |
 | `applyChinaDst`    | `boolean`                       |      | 是否自动校正中国夏令时（1986-1991），默认开启；若出生记录已折算为标准时间，可设为 `false` |
 | `shenShaVariants`  | `Partial<ShenShaVariantConfig>` |      | 神煞争议口径配置；不传时使用默认主流口径                                                  |
 
@@ -360,7 +361,7 @@
 | `birthProfileToQizhengInput(profile)`       | 生成七政四余输入；真太阳时保留原始民用时间交给七政四余引擎校正 |
 | `birthProfileToAlmanacParticipant(profile)` | 生成择日参与人输入                                             |
 
-真太阳时模式下必须提供 `hour`、`minute` 和 `location.longitude`；`location.timezone` 未提供时按 UTC+8 处理。八字结果的 `timing` 会返回 `timezone`、`standardMeridian`、经度修正、均时差、跨日结果和完整证据链。
+真太阳时模式下必须提供 `hour`、`minute` 和 `location.longitude`；地点可用 `location.timezone` 提供固定偏移，也可用 `location.timeZoneId` 按出生日期解析 IANA 历史时区，两者都不提供时按 UTC+8 处理。秋季回拨的重复当地时间必须同时提供固定偏移消歧；固定偏移冲突、春季不存在时间及 `timeZoneId` 与 `applyChinaDst` 同时启用会被拒绝。八字结果的 `timing` 会返回解析后的 `timezone`、`standardMeridian`、经度修正、均时差、跨日结果和完整证据链。
 
 ---
 
@@ -425,8 +426,8 @@ console.log(reading.promptText);
 | `getTimeIndexFromClock(hour, minute)`       | 由时钟转时辰索引                                                   |
 | `daysInSolarMonth(year, month)`             | 公历月天数                                                         |
 | `getBirthDateValidationMessage(...)`        | 出生日期校验                                                       |
-| `convertTrueSolarTime(input)`               | 按当地钟表时间、时区、经度和均时差换算真太阳时                     |
-| `resolveTrueSolarBirthTime(input)`          | 统一处理公历/农历、闰月、夏令时、跨日和时辰索引                    |
+| `convertTrueSolarTime(input)`               | 按当地钟表时间、固定偏移或 IANA 历史时区、经度和均时差换算真太阳时 |
+| `resolveTrueSolarBirthTime(input)`          | 统一处理公历/农历、闰月、历史时区、夏令时、跨日和时辰索引          |
 | `buildAstronomicalTimeEvidence(input)`      | 由当地时间与固定偏移或 IANA 时区生成 UTC、JD、近似 UT1、ΔT 和 TT   |
 | `calculateMoonPhaseEvidence(utcTimestamp)`  | 由 UTC Unix 毫秒生成月相、照明比例和前后朔弦望事件                 |
 | `calculateSolarTermEvidence(year, index)`   | 生成单个节气的历表时刻、目标黄经、独立求根及差值核验               |

--- a/packages/core/src/bazi/baziCalculator.ts
+++ b/packages/core/src/bazi/baziCalculator.ts
@@ -185,9 +185,10 @@ export class BaziCalculator {
     ) {
       throw new Error('出生经度需在 -180 到 180 之间。');
     }
-    const timezone = person.timezone ?? 8;
+    const timezone = person.timezone ?? (person.timeZoneId ? undefined : 8);
     if (
       useTrueSolarTimeEnabled &&
+      timezone !== undefined &&
       (!Number.isFinite(timezone) || timezone < -12 || timezone > 14)
     ) {
       throw new Error('时区需在 UTC-12 到 UTC+14 之间。');
@@ -231,7 +232,9 @@ export class BaziCalculator {
       lunarHour = solarTime.getLunarHour();
     }
 
-    const applyChinaDst = person.applyChinaDst !== false;
+    const applyChinaDst = person.timeZoneId
+      ? (person.applyChinaDst ?? false)
+      : person.applyChinaDst !== false;
     const warnings: string[] = [];
 
     if (useTrueSolarTimeEnabled) {
@@ -255,6 +258,7 @@ export class BaziCalculator {
         isLeapMonth: isLeapMonthEnabled,
         longitude: birthLongitude!,
         timezone,
+        timeZoneId: person.timeZoneId,
         applyChinaDst,
       });
       const dstCorrectionMinutes = trueSolarResult.chinaDst.applied
@@ -291,7 +295,8 @@ export class BaziCalculator {
         correctedTime: trueSolarResult.correctedTime,
         birthPlace: birthPlace?.trim() || '',
         birthLongitude,
-        timezone,
+        timezone: trueSolarResult.timezone,
+        ...(trueSolarResult.timeZoneId ? { timeZoneId: trueSolarResult.timeZoneId } : {}),
         standardMeridian: trueSolarResult.standardMeridian,
         longitudeCorrectionMinutes: trueSolarResult.longitudeCorrectionMinutes,
         equationOfTimeMinutes: trueSolarResult.equationOfTimeMinutes,
@@ -305,6 +310,7 @@ export class BaziCalculator {
           summaryFact: trueSolarResult.summaryFact,
           limitations: trueSolarResult.limitations,
           limitationFacts: trueSolarResult.limitationFacts,
+          timezoneEvidence: trueSolarResult.timezoneEvidence,
           source: trueSolarResult.source,
           promptText: trueSolarResult.promptText,
         },

--- a/packages/core/src/bazi/baziTypes.ts
+++ b/packages/core/src/bazi/baziTypes.ts
@@ -30,6 +30,8 @@ export interface Person {
   birthLongitude?: number;
   /** 当地标准时区，例如中国为 UTC+8；真太阳时模式默认 UTC+8。 */
   timezone?: number;
+  /** IANA 历史时区；提供后按出生日期解析当时的法定 UTC 偏移。 */
+  timeZoneId?: string;
   age?: number;
   shenShaVariants?: Partial<ShenShaVariantConfig>;
   /**
@@ -132,6 +134,7 @@ export interface TimingInfo {
   birthPlace?: string;
   birthLongitude?: number;
   timezone: number;
+  timeZoneId?: string;
   standardMeridian: number;
   longitudeCorrectionMinutes: number;
   equationOfTimeMinutes: number;

--- a/packages/core/src/calendar/historical-timezone.ts
+++ b/packages/core/src/calendar/historical-timezone.ts
@@ -216,13 +216,19 @@ export function resolveHistoricalTimezone(
     );
   }
 
-  const selected = matches[0];
   const fixedOffsetHours = input.fixedOffsetHours;
-  const offsetConflict =
-    fixedOffsetHours !== undefined && Math.abs(fixedOffsetHours - selected.offset) > 1e-6;
+  const fixedOffsetMatch =
+    fixedOffsetHours === undefined
+      ? undefined
+      : matches.find((candidate) => Math.abs(fixedOffsetHours - candidate.offset) <= 1e-6);
+  const selected = fixedOffsetMatch ?? matches[0];
+  const offsetConflict = fixedOffsetHours !== undefined && !fixedOffsetMatch;
+  const ambiguityResolvedByFixedOffset = matches.length > 1 && fixedOffsetMatch !== undefined;
   const diagnostics = [
     matches.length > 1
-      ? `该当地时刻因夏令时回拨对应 ${matches.length} 个 UTC 时刻；默认选择较早的 ${toIso(selected.timestamp)}，调用方应结合出生记录确认。`
+      ? ambiguityResolvedByFixedOffset
+        ? `该当地时刻因夏令时回拨对应 ${matches.length} 个 UTC 时刻；已按固定偏移 UTC${fixedOffsetHours! >= 0 ? '+' : ''}${fixedOffsetHours} 选择 ${toIso(selected.timestamp)}。`
+        : `该当地时刻因夏令时回拨对应 ${matches.length} 个 UTC 时刻；未提供可用于消歧的固定偏移，默认选择较早的 ${toIso(selected.timestamp)}，调用方应结合出生记录确认。`
       : '该当地时刻在当前 IANA 时区数据库中只有一个 UTC 对应时刻。',
   ];
   if (offsetConflict) {
@@ -270,7 +276,9 @@ export function resolveHistoricalTimezone(
       },
       promptText:
         matches.length > 1
-          ? `当地钟表时间${wallClockDateTime}匹配到${matches.length}个 UTC 时刻，按明确规则暂取较早的${toIso(selected.timestamp)}`
+          ? ambiguityResolvedByFixedOffset
+            ? `当地钟表时间${wallClockDateTime}匹配到${matches.length}个 UTC 时刻，按固定偏移 UTC${fixedOffsetHours! >= 0 ? '+' : ''}${fixedOffsetHours}选择${toIso(selected.timestamp)}`
+            : `当地钟表时间${wallClockDateTime}匹配到${matches.length}个 UTC 时刻，未提供可用于消歧的固定偏移，暂取较早的${toIso(selected.timestamp)}`
           : `当地钟表时间${wallClockDateTime}唯一映射为 UTC ${toIso(selected.timestamp)}`,
       sources: ['IANA 当地钟表时间反向匹配'],
       limitation: CALCULATION_STEP_LIMITATION,
@@ -344,7 +352,7 @@ export function resolveHistoricalTimezone(
   };
   const limitations = [
     'IANA 历史规则随所用时区数据库版本更新，极早期地方平太阳时或资料修订可能出现版本差异。',
-    '回拨歧义默认选择较早 UTC 时刻只用于保持计算确定性，仍应结合原始钟表记录确认。',
+    '回拨歧义在固定偏移匹配候选时按该偏移消歧；否则默认选择较早 UTC 时刻只用于保持计算确定性，仍应结合原始钟表记录确认。',
     '固定偏移冲突只表示两种时间口径不一致，不自动证明其中任一记录错误。',
   ];
   const limitationFacts: HistoricalTimezoneLimitationFact[] = [

--- a/packages/core/src/calendar/true-solar-time.ts
+++ b/packages/core/src/calendar/true-solar-time.ts
@@ -2,6 +2,7 @@ import { LunarHour, SolarTime } from 'tyme4ts';
 import { daysInSolarMonth, getBirthDateValidationMessage } from './date-validation';
 import { getShichenFromClock } from './dateUtils';
 import { checkChinaDst, type ChinaDstCheckResult } from './china-dst';
+import { resolveHistoricalTimezone, type HistoricalTimezoneEvidence } from './historical-timezone';
 
 export interface SolarDateTimeParts {
   year: number;
@@ -24,12 +25,13 @@ export interface TrueSolarTimeCalculationStep {
   stage:
     | '历法输入换算'
     | '输入口径核验'
+    | '历史时区解析'
     | '历史夏令时还原'
     | '经度时差计算'
     | '均时差计算'
     | '总校正与跨日'
     | '时辰映射';
-  status: '已核验' | '已换算' | '已计算' | '已应用' | '未请求' | '未命中';
+  status: '已核验' | '已换算' | '已解析' | '已计算' | '已应用' | '未请求' | '未命中';
   dependsOnStepKeys: string[];
   inputs: Record<string, string | number | boolean>;
   result: Record<string, string | number | boolean>;
@@ -40,8 +42,16 @@ export interface TrueSolarTimeCalculationStep {
 
 export interface TrueSolarTimeCorrectionFact {
   key: string;
-  type: '历法输入' | '历史夏令时' | '经度时差' | '均时差' | '总校正' | '跨日结果' | '时辰结果';
-  status: '已核验' | '已换算' | '已应用' | '未请求' | '未命中' | '已计算' | '已确定';
+  type:
+    | '历法输入'
+    | '历史时区'
+    | '历史夏令时'
+    | '经度时差'
+    | '均时差'
+    | '总校正'
+    | '跨日结果'
+    | '时辰结果';
+  status: '已核验' | '已换算' | '已解析' | '已应用' | '未请求' | '未命中' | '已计算' | '已确定';
   correctionMinutes?: number;
   ownerFactKeys: string[];
   ownerStepKeys: string[];
@@ -52,7 +62,7 @@ export interface TrueSolarTimeCorrectionFact {
 
 export interface TrueSolarTimeLimitationFact {
   key: string;
-  type: '均时差近似' | '经度与时区口径' | '历史夏令时口径' | '原始记录边界';
+  type: '均时差近似' | '经度与时区口径' | '历史时区口径' | '历史夏令时口径' | '原始记录边界';
   status: '适用';
   ownerFactKeys: string[];
   ownerStepKeys: string[];
@@ -63,7 +73,7 @@ export interface TrueSolarTimeLimitationFact {
 
 export interface TrueSolarTimeSummaryFact {
   key: 'true-solar-time:evidence-summary';
-  status: '证据链完整' | '含夏令时重复时段' | '含夏令时不存在时段';
+  status: '证据链完整' | '历史时区歧义已消解' | '含夏令时重复时段' | '含夏令时不存在时段';
   factKeys: string[];
   calculationStepCount: number;
   correctionFactCount: number;
@@ -82,6 +92,7 @@ export interface TrueSolarTimeEvidenceFields {
   summaryFact: TrueSolarTimeSummaryFact;
   limitations: string[];
   limitationFacts: TrueSolarTimeLimitationFact[];
+  timezoneEvidence?: HistoricalTimezoneEvidence;
   source: string;
   promptText: string;
 }
@@ -93,6 +104,8 @@ export interface TrueSolarTimeConversionInput {
   longitude: number;
   /** 当地标准时区，默认 UTC+8；支持小数时区。 */
   timezone?: number;
+  /** IANA 历史时区，如 America/New_York；用于按当地日期解析历史 UTC 偏移。 */
+  timeZoneId?: string;
   /** 是否按中国 1986-1991 历史规则自动还原夏令时，默认 false。 */
   applyChinaDst?: boolean;
 }
@@ -106,6 +119,7 @@ export interface TrueSolarTimeConversionResult
   correctedDateTime: string;
   longitude: number;
   timezone: number;
+  timeZoneId?: string;
   standardMeridian: number;
   crossesDate: boolean;
   chinaDst: ChinaDstCheckResult & {
@@ -130,6 +144,7 @@ export interface TrueSolarBirthTimeInput {
   isLeapMonth?: boolean;
   longitude: number;
   timezone?: number;
+  timeZoneId?: string;
   applyChinaDst?: boolean;
 }
 
@@ -160,6 +175,8 @@ interface TrueSolarTimeEvidenceInput {
   correctedDateTime: string;
   longitude: number;
   timezone: number;
+  timeZoneId?: string;
+  timezoneEvidence?: HistoricalTimezoneEvidence;
   standardMeridian: number;
   longitudeCorrectionMinutes: number;
   equationOfTimeMinutes: number;
@@ -175,6 +192,7 @@ function buildTrueSolarTimeEvidence(
   input: TrueSolarTimeEvidenceInput,
 ): TrueSolarTimeEvidenceFields {
   const inputStepKey = 'true-solar-time:calculation:input';
+  const timezoneStepKey = 'true-solar-time:calculation:historical-timezone';
   const dstStepKey = 'true-solar-time:calculation:china-dst';
   const longitudeStepKey = 'true-solar-time:calculation:longitude';
   const equationStepKey = 'true-solar-time:calculation:equation-of-time';
@@ -182,15 +200,42 @@ function buildTrueSolarTimeEvidence(
   const shichenStepKey = 'true-solar-time:calculation:shichen';
   const calculationSteps: TrueSolarTimeCalculationStep[] = [
     ...(input.calendarStep ? [input.calendarStep] : []),
+    ...(input.timezoneEvidence
+      ? [
+          {
+            key: timezoneStepKey,
+            stage: '历史时区解析' as const,
+            status: '已解析' as const,
+            dependsOnStepKeys: input.calendarStep ? [input.calendarStep.key] : [],
+            inputs: {
+              timeZoneId: input.timezoneEvidence.timeZoneId,
+              clockDateTime: input.clockDateTime,
+            },
+            result: {
+              timezone: input.timezone,
+              mappingStatus: input.timezoneEvidence.status,
+              offsetConflict: input.timezoneEvidence.offsetConflict,
+            },
+            promptText: `按 IANA 时区 ${input.timezoneEvidence.timeZoneId} 的历史规则，将当地钟表时间${input.clockDateTime}解析为 UTC${input.timezone >= 0 ? '+' : ''}${input.timezone}${input.timezoneEvidence.status === 'ambiguous' ? '，并已用明确固定偏移消解回拨歧义' : ''}`,
+            sources: ['IANA Time Zone Database 与 Intl.DateTimeFormat 历史时区解析'],
+            limitation: TRUE_SOLAR_STEP_LIMITATION,
+          },
+        ]
+      : []),
     {
       key: inputStepKey,
       stage: '输入口径核验',
       status: '已核验',
-      dependsOnStepKeys: input.calendarStep ? [input.calendarStep.key] : [],
+      dependsOnStepKeys: input.timezoneEvidence
+        ? [timezoneStepKey]
+        : input.calendarStep
+          ? [input.calendarStep.key]
+          : [],
       inputs: {
         clockDateTime: input.clockDateTime,
         longitude: input.longitude,
         timezone: input.timezone,
+        ...(input.timeZoneId ? { timeZoneId: input.timeZoneId } : {}),
       },
       result: { standardMeridian: input.standardMeridian },
       promptText: `核验当地钟表时间${input.clockDateTime}、经度${input.longitude}°与法定时区 UTC${input.timezone >= 0 ? '+' : ''}${input.timezone}，对应标准经线${input.standardMeridian}°`,
@@ -277,6 +322,20 @@ function buildTrueSolarTimeEvidence(
   ];
   const correctionFacts: TrueSolarTimeCorrectionFact[] = [
     ...(input.calendarFact ? [input.calendarFact] : []),
+    ...(input.timezoneEvidence
+      ? [
+          {
+            key: 'true-solar-time:fact:historical-timezone',
+            type: '历史时区' as const,
+            status: '已解析' as const,
+            ownerFactKeys: [timezoneStepKey],
+            ownerStepKeys: [timezoneStepKey],
+            promptText: `IANA 时区 ${input.timezoneEvidence.timeZoneId} 的当地历史偏移解析为 UTC${input.timezone >= 0 ? '+' : ''}${input.timezone}`,
+            sources: ['IANA 历史时区映射结果'],
+            limitation: TRUE_SOLAR_CORRECTION_LIMITATION,
+          },
+        ]
+      : []),
     {
       key: 'true-solar-time:fact:china-dst',
       type: '历史夏令时',
@@ -344,11 +403,22 @@ function buildTrueSolarTimeEvidence(
       limitation: TRUE_SOLAR_CORRECTION_LIMITATION,
     },
   ];
+  const equationLimitation =
+    '均时差采用年内日序近似公式，用于民用排盘校正，不宣称达到观测级或航海级精度。';
+  const longitudeTimezoneLimitation =
+    '经度时差依赖已确认的出生地经度与当地法定时区；时区口径错误会直接改变校正结果。';
+  const historicalTimezoneLimitation =
+    'IANA 历史规则随运行环境的时区数据库版本更新；回拨重复时刻必须用明确固定偏移消歧后才能生成唯一结果。';
+  const chinaDstLimitation =
+    '中国历史夏令时只在明确请求时按 1986-1991 年规则还原；如原记录已折算为标准时间，不应重复校正。';
+  const sourceRecordLimitation =
+    '当前结果只采用用户明确提供的精准时分、经度与时区生成唯一真太阳时和唯一时辰；不生成候选时辰、敏感性结果或缺时柱命盘。';
   const limitations = [
-    '均时差采用年内日序近似公式，用于民用排盘校正，不宣称达到观测级或航海级精度。',
-    '经度时差依赖已确认的出生地经度与当地法定时区；时区口径错误会直接改变校正结果。',
-    '中国历史夏令时只在明确请求时按 1986-1991 年规则还原；如原记录已折算为标准时间，不应重复校正。',
-    '当前结果只采用用户明确提供的精准时分、经度与时区生成唯一真太阳时和唯一时辰；不生成候选时辰、敏感性结果或缺时柱命盘。',
+    equationLimitation,
+    longitudeTimezoneLimitation,
+    ...(input.timezoneEvidence ? [historicalTimezoneLimitation] : []),
+    chinaDstLimitation,
+    sourceRecordLimitation,
   ];
   const limitationFacts: TrueSolarTimeLimitationFact[] = [
     {
@@ -357,7 +427,7 @@ function buildTrueSolarTimeEvidence(
       status: '适用',
       ownerFactKeys: ['true-solar-time:fact:equation-of-time'],
       ownerStepKeys: [equationStepKey],
-      promptText: limitations[0],
+      promptText: equationLimitation,
       sources: ['均时差近似公式精度说明'],
       limitation: TRUE_SOLAR_LIMITATION_FACT_LIMITATION,
     },
@@ -367,17 +437,31 @@ function buildTrueSolarTimeEvidence(
       status: '适用',
       ownerFactKeys: [inputStepKey, 'true-solar-time:fact:longitude'],
       ownerStepKeys: [inputStepKey, longitudeStepKey],
-      promptText: limitations[1],
+      promptText: longitudeTimezoneLimitation,
       sources: ['出生地经度、法定时区与标准经线口径'],
       limitation: TRUE_SOLAR_LIMITATION_FACT_LIMITATION,
     },
+    ...(input.timezoneEvidence
+      ? [
+          {
+            key: 'true-solar-time:limitation:historical-timezone',
+            type: '历史时区口径' as const,
+            status: '适用' as const,
+            ownerFactKeys: [timezoneStepKey, 'true-solar-time:fact:historical-timezone'],
+            ownerStepKeys: [timezoneStepKey],
+            promptText: historicalTimezoneLimitation,
+            sources: ['IANA Time Zone Database 版本与回拨消歧边界'],
+            limitation: TRUE_SOLAR_LIMITATION_FACT_LIMITATION,
+          },
+        ]
+      : []),
     {
       key: 'true-solar-time:limitation:china-dst',
       type: '历史夏令时口径',
       status: '适用',
       ownerFactKeys: ['true-solar-time:fact:china-dst'],
       ownerStepKeys: [dstStepKey],
-      promptText: limitations[2],
+      promptText: chinaDstLimitation,
       sources: ['中国历史夏令时还原边界'],
       limitation: TRUE_SOLAR_LIMITATION_FACT_LIMITATION,
     },
@@ -387,7 +471,7 @@ function buildTrueSolarTimeEvidence(
       status: '适用',
       ownerFactKeys: [inputStepKey, 'true-solar-time:fact:shichen'],
       ownerStepKeys: [inputStepKey, shichenStepKey],
-      promptText: limitations[3],
+      promptText: sourceRecordLimitation,
       sources: ['明确输入与唯一真太阳时、时辰结果'],
       limitation: TRUE_SOLAR_LIMITATION_FACT_LIMITATION,
     },
@@ -396,7 +480,9 @@ function buildTrueSolarTimeEvidence(
     ? '含夏令时不存在时段'
     : input.chinaDst.ambiguous
       ? '含夏令时重复时段'
-      : '证据链完整';
+      : input.timezoneEvidence?.status === 'ambiguous'
+        ? '历史时区歧义已消解'
+        : '证据链完整';
   const summaryFact: TrueSolarTimeSummaryFact = {
     key: 'true-solar-time:evidence-summary',
     status: summaryStatus,
@@ -420,6 +506,7 @@ function buildTrueSolarTimeEvidence(
     input.calendarStep
       ? '公历农历换算由 tyme4ts 完成'
       : '当地钟表时间格式、日期与时空参数由公共日历入口核验',
+    ...(input.timezoneEvidence ? ['IANA 历史时区由 Intl.DateTimeFormat 所带时区数据库解析'] : []),
     '中国历史夏令时按明确规则还原',
     '经度时差按4分钟/度',
     '均时差采用年内日序近似公式',
@@ -433,8 +520,9 @@ function buildTrueSolarTimeEvidence(
     summaryFact,
     limitations,
     limitationFacts,
+    ...(input.timezoneEvidence ? { timezoneEvidence: input.timezoneEvidence } : {}),
     source,
-    promptText: `真太阳时证据：钟表时间${input.clockDateTime}，标准时间${input.standardDateTime}，经度时差${input.longitudeCorrectionMinutes.toFixed(3)}分钟，均时差${input.equationOfTimeMinutes.toFixed(3)}分钟，总校正${input.totalCorrectionMinutes.toFixed(3)}分钟，采用${input.correctedDateTime}与${input.shichen.name}。计算链：${calculationSteps.map((item) => item.promptText).join(' → ')}。证据汇总：${summaryFact.promptText}。来源：${source}。限制：${limitations.join('；')}`,
+    promptText: `真太阳时证据：钟表时间${input.clockDateTime}${input.timezoneEvidence ? `，IANA 时区 ${input.timezoneEvidence.timeZoneId} 的历史偏移为 UTC${input.timezone >= 0 ? '+' : ''}${input.timezone}` : ''}，标准时间${input.standardDateTime}，经度时差${input.longitudeCorrectionMinutes.toFixed(3)}分钟，均时差${input.equationOfTimeMinutes.toFixed(3)}分钟，总校正${input.totalCorrectionMinutes.toFixed(3)}分钟，采用${input.correctedDateTime}与${input.shichen.name}。计算链：${calculationSteps.map((item) => item.promptText).join(' → ')}。证据汇总：${summaryFact.promptText}。来源：${source}。限制：${limitations.join('；')}`,
   };
 }
 
@@ -575,17 +663,47 @@ export function calculateTrueSolarTime(
 
 /**
  * 面向 API/MCP 的便捷真太阳时换算入口。
- * localDateTime 表示当地钟表时间，不应包含 Z 或 +08:00 等时区后缀；夏令时需先还原为标准时间。
+ * localDateTime 表示当地钟表时间，不应包含 Z 或 +08:00 等时区后缀；
+ * IANA 时区会自动解析历史夏令时，固定偏移口径可按需启用中国历史夏令时兼容校正。
  */
 export function convertTrueSolarTime(
   input: TrueSolarTimeConversionInput,
 ): TrueSolarTimeConversionResult {
   const clockTime = parseLocalDateTime(input.localDateTime);
-  const timezone = input.timezone ?? 8;
-  assertNumberInRange(timezone, 'timezone', -12, 14);
+  if (input.timezone !== undefined) {
+    assertNumberInRange(input.timezone, 'timezone', -12, 14);
+  }
+  if (input.timeZoneId !== undefined && typeof input.timeZoneId !== 'string') {
+    throw new Error('timeZoneId 必须是 IANA 时区名称。');
+  }
+  const timeZoneId = input.timeZoneId?.trim();
+  if (input.timeZoneId !== undefined && !timeZoneId) {
+    throw new Error('IANA 时区名不能为空。');
+  }
   if (input.applyChinaDst !== undefined && typeof input.applyChinaDst !== 'boolean') {
     throw new Error('applyChinaDst 必须是布尔值。');
   }
+  if (timeZoneId && input.applyChinaDst === true) {
+    throw new Error('timeZoneId 已包含历史夏令时规则，不能同时启用 applyChinaDst。');
+  }
+  const timezoneEvidence = timeZoneId
+    ? resolveHistoricalTimezone({
+        ...clockTime,
+        timeZoneId,
+        fixedOffsetHours: input.timezone,
+      })
+    : undefined;
+  if (timezoneEvidence?.status === 'ambiguous' && input.timezone === undefined) {
+    throw new Error(
+      `${timeZoneId} 的当地钟表时间 ${input.localDateTime} 存在夏令时回拨歧义，请同时提供与原始记录一致的 timezone 固定偏移。`,
+    );
+  }
+  if (timezoneEvidence?.offsetConflict) {
+    throw new Error(
+      `timezone 固定偏移 UTC${input.timezone! >= 0 ? '+' : ''}${input.timezone} 与 ${timeZoneId} 在该当地时刻的历史偏移不一致。`,
+    );
+  }
+  const timezone = timezoneEvidence?.resolvedOffsetHours ?? input.timezone ?? 8;
   const requestedChinaDst = input.applyChinaDst ?? false;
   const chinaDstCheck = requestedChinaDst
     ? checkChinaDst(
@@ -624,12 +742,14 @@ export function convertTrueSolarTime(
     name: shichen.name,
   };
   const evidence = buildTrueSolarTimeEvidence({
-    key: `true-solar-time:${clockDateTime}:${input.longitude}:${timezone}`,
+    key: `true-solar-time:${clockDateTime}:${input.longitude}:${timeZoneId ? `${timeZoneId}:${timezone}` : timezone}`,
     clockDateTime,
     standardDateTime,
     correctedDateTime,
     longitude: input.longitude,
     timezone,
+    timeZoneId,
+    timezoneEvidence,
     standardMeridian,
     longitudeCorrectionMinutes: result.longitudeCorrectionMinutes,
     equationOfTimeMinutes: result.equationOfTimeMinutes,
@@ -649,6 +769,7 @@ export function convertTrueSolarTime(
     correctedDateTime,
     longitude: input.longitude,
     timezone,
+    ...(timeZoneId ? { timeZoneId } : {}),
     standardMeridian,
     chinaDst,
     crossesDate,
@@ -703,6 +824,7 @@ export function resolveTrueSolarBirthTime(
     localDateTime: formatSolarDateTimeParts(solarClockTime),
     longitude: input.longitude,
     timezone: input.timezone,
+    timeZoneId: input.timeZoneId,
     applyChinaDst: input.applyChinaDst,
   });
   const solarClockDateTime = formatSolarDateTimeParts(solarClockTime);
@@ -745,6 +867,8 @@ export function resolveTrueSolarBirthTime(
     correctedDateTime: converted.correctedDateTime,
     longitude: converted.longitude,
     timezone: converted.timezone,
+    timeZoneId: converted.timeZoneId,
+    timezoneEvidence: converted.timezoneEvidence,
     standardMeridian: converted.standardMeridian,
     longitudeCorrectionMinutes: converted.longitudeCorrectionMinutes,
     equationOfTimeMinutes: converted.equationOfTimeMinutes,

--- a/packages/core/src/capabilities/index.ts
+++ b/packages/core/src/capabilities/index.ts
@@ -153,6 +153,7 @@ const systems: SystemCapability[] = [
       },
       { id: 'longitude', label: '出生地经度', type: 'number', required: true },
       { id: 'timezone', label: '固定时区偏移', type: 'number', required: false },
+      { id: 'timeZoneId', label: 'IANA历史时区', type: 'text', required: false },
       {
         id: 'applyChinaDst',
         label: '应用中国历史夏令时',
@@ -168,6 +169,7 @@ const systems: SystemCapability[] = [
       '跨日状态',
       '时辰索引',
       '真太阳时结构化计算链与校正事实',
+      'IANA历史时区映射与消歧证据',
       '真太阳时证据汇总、来源与限制',
       'UTC与儒略日时间尺度证据',
       'ΔT与近似TT儒略日',
@@ -180,6 +182,10 @@ const systems: SystemCapability[] = [
       birthTimeModes: ['precise-clock-time'],
       batch: false,
     },
+    notes: [
+      '未提供 timeZoneId 时 timezone 默认 UTC+8；回拨重复时刻使用 IANA 时区时需同时提供 timezone 消歧。',
+      'timeZoneId 已包含历史夏令时规则，不能同时启用 applyChinaDst。',
+    ],
   },
   {
     id: 'calendar.astronomicalTime',

--- a/packages/core/src/profile/index.ts
+++ b/packages/core/src/profile/index.ts
@@ -46,6 +46,8 @@ export interface BirthProfileLocation {
   latitude?: number;
   /** 当地标准时区，例如中国为 UTC+8。 */
   timezone?: number;
+  /** IANA 历史时区，例如 America/New_York。 */
+  timeZoneId?: string;
 }
 
 export interface ResolvedBirthProfileLocation {
@@ -53,7 +55,8 @@ export interface ResolvedBirthProfileLocation {
   name?: string;
   longitude: number;
   latitude?: number;
-  timezone: number;
+  timezone?: number;
+  timeZoneId?: string;
   coordinateAccuracy?: BirthPlaceCoordinateAccuracy | 'user-provided' | 'mixed';
 }
 
@@ -159,6 +162,12 @@ function assertProfileShape(profile: BirthProfile): void {
     if (profile.location.timezone !== undefined) {
       assertFiniteInRange(profile.location.timezone, '时区', -12, 14);
     }
+    if (
+      profile.location.timeZoneId !== undefined &&
+      (typeof profile.location.timeZoneId !== 'string' || !profile.location.timeZoneId.trim())
+    ) {
+      throw new TypeError('IANA 时区名不能为空。');
+    }
   }
 }
 
@@ -200,7 +209,8 @@ export function resolveBirthProfileLocation(
     name: location.name ?? region?.displayName,
     longitude: location.longitude ?? region!.longitude,
     latitude,
-    timezone: location.timezone ?? region?.timezone ?? 8,
+    timezone: location.timezone ?? (location.timeZoneId ? undefined : (region?.timezone ?? 8)),
+    ...(location.timeZoneId ? { timeZoneId: location.timeZoneId.trim() } : {}),
     coordinateAccuracy,
   };
 }
@@ -331,7 +341,10 @@ export function normalizeBirthProfile(profile: BirthProfile): NormalizedBirthPro
     second,
     isLeapMonth: profile.isLeapMonth,
     longitude: resolvedLocation?.longitude ?? (resolvedLocation?.timezone ?? 8) * 15,
-    timezone: resolvedLocation?.timezone ?? 8,
+    timezone: profile.useTrueSolarTime
+      ? (resolvedLocation?.timezone ?? (resolvedLocation?.timeZoneId ? undefined : 8))
+      : 8,
+    timeZoneId: profile.useTrueSolarTime ? resolvedLocation?.timeZoneId : undefined,
     applyChinaDst: profile.useTrueSolarTime ? profile.applyChinaDst : false,
   });
 
@@ -347,6 +360,7 @@ export function normalizeBirthProfile(profile: BirthProfile): NormalizedBirthPro
       summaryFact: resolved.summaryFact,
       limitations: resolved.limitations,
       limitationFacts: resolved.limitationFacts,
+      timezoneEvidence: resolved.timezoneEvidence,
       source: resolved.source,
       promptText: resolved.promptText,
     };
@@ -454,6 +468,7 @@ export function birthProfileToBaziPerson(profile: BirthProfile): Person {
     birthPlace: location?.name,
     birthLongitude: location?.longitude,
     timezone: location?.timezone,
+    timeZoneId: location?.timeZoneId,
     applyChinaDst: profile.applyChinaDst,
   };
 }
@@ -546,7 +561,8 @@ export function birthProfileToAstrolabeInput(profile: BirthProfile): AstrolabeBi
     minute: String(clock.minute),
     latitude: String(location.latitude),
     longitude: String(location.longitude),
-    timezone: String(location.timezone ?? 8),
+    ...(location.timezone !== undefined ? { timezone: String(location.timezone) } : {}),
+    ...(location.timeZoneId ? { timeZoneId: location.timeZoneId } : {}),
     locationName: location.name,
     useTrueSolarTime: profile.useTrueSolarTime,
   };
@@ -573,6 +589,7 @@ export function birthProfileToQizhengInput(profile: BirthProfile): QizhengInput 
     ...(location?.latitude !== undefined ? { latitude: location.latitude } : {}),
     ...(location?.longitude !== undefined ? { longitude: location.longitude } : {}),
     ...(location?.timezone !== undefined ? { timezone: location.timezone } : {}),
+    ...(location?.timeZoneId ? { timeZoneId: location.timeZoneId } : {}),
     useTrueSolarTime: profile.useTrueSolarTime === true,
   };
 }

--- a/packages/core/src/ziwei/runtime.ts
+++ b/packages/core/src/ziwei/runtime.ts
@@ -199,6 +199,7 @@ export interface ZiweiChartInputDraft {
   birthMinute?: ZiweiInputText;
   birthLongitude?: ZiweiInputText;
   timezone?: number;
+  timeZoneId?: string;
   applyChinaDst?: boolean;
   algorithm?: 'default' | 'zhongzhou';
 }
@@ -255,6 +256,7 @@ export function buildZiweiChartInput(input: ZiweiChartInputDraft): ChartInput {
         birthMinute: input.birthMinute === undefined ? '' : String(input.birthMinute),
         birthLongitude: input.birthLongitude === undefined ? '' : String(input.birthLongitude),
         timezone: input.timezone,
+        timeZoneId: input.timeZoneId,
         applyChinaDst: input.applyChinaDst,
       })
     : null;

--- a/packages/core/src/ziwei/true-solar-input.ts
+++ b/packages/core/src/ziwei/true-solar-input.ts
@@ -14,6 +14,7 @@ export interface ZiweiTrueSolarInput {
   birthMinute: string;
   birthLongitude: string;
   timezone?: number;
+  timeZoneId?: string;
   applyChinaDst?: boolean;
 }
 
@@ -84,6 +85,7 @@ export function resolveZiweiTrueSolarBirth(input: ZiweiTrueSolarInput): ZiweiTru
     isLeapMonth: input.isLeapMonth,
     longitude: birthLongitude,
     timezone: input.timezone,
+    timeZoneId: input.timeZoneId,
     applyChinaDst: input.applyChinaDst,
   });
   const corrected = resolved.correctedTime;
@@ -99,6 +101,7 @@ export function resolveZiweiTrueSolarBirth(input: ZiweiTrueSolarInput): ZiweiTru
       summaryFact: resolved.summaryFact,
       limitations: resolved.limitations,
       limitationFacts: resolved.limitationFacts,
+      timezoneEvidence: resolved.timezoneEvidence,
       source: resolved.source,
       promptText: resolved.promptText,
     },

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -931,12 +931,14 @@ export function getPublicApiOpenApiDocument(
         TrueSolarTimeRequest: {
           type: 'object',
           required: ['localDateTime', 'longitude'],
+          description:
+            '可用 timezone 提供固定 UTC 偏移，或用 timeZoneId 按当地日期解析历史偏移；两者同时提供时，timezone 用于回拨重复时刻消歧和一致性核验。',
           properties: {
             localDateTime: {
               type: 'string',
               example: '1990-05-15T10:30:00',
               description:
-                '当地钟表时间，格式为 YYYY-MM-DDTHH:mm 或 YYYY-MM-DDTHH:mm:ss，不要附带 Z 或时区偏移；夏令时需先还原为标准时间',
+                '当地钟表时间，格式为 YYYY-MM-DDTHH:mm 或 YYYY-MM-DDTHH:mm:ss，不要附带 Z 或时区偏移；IANA 时区会自动解析历史夏令时',
             },
             longitude: {
               type: 'number',
@@ -949,9 +951,13 @@ export function getPublicApiOpenApiDocument(
               type: 'number',
               minimum: -12,
               maximum: 14,
-              default: 8,
               example: 8,
-              description: '当地标准时区，默认 UTC+8，支持 5.5 等小数时区',
+              description: '固定 UTC 偏移；未提供 timeZoneId 时默认 UTC+8，支持 5.5 等小数时区',
+            },
+            timeZoneId: {
+              type: 'string',
+              example: 'America/New_York',
+              description: 'IANA 历史时区；会按当地日期解析当时的法定 UTC 偏移',
             },
             applyChinaDst: {
               type: 'boolean',
@@ -963,6 +969,8 @@ export function getPublicApiOpenApiDocument(
         TrueSolarBirthRequest: {
           type: 'object',
           required: ['dateType', 'year', 'month', 'day', 'hour', 'minute', 'longitude'],
+          description:
+            '可用 timezone 提供固定 UTC 偏移，或用 timeZoneId 按出生日期解析历史偏移；回拨重复时刻需同时提供 timezone 消歧。',
           properties: {
             dateType: { enum: ['solar', 'lunar'], description: '公历或农历' },
             year: { type: 'integer', minimum: 1900, maximum: 2100 },
@@ -973,7 +981,8 @@ export function getPublicApiOpenApiDocument(
             second: { type: 'integer', minimum: 0, maximum: 59, default: 0 },
             isLeapMonth: { type: 'boolean', default: false, description: '农历是否为闰月' },
             longitude: { type: 'number', minimum: -180, maximum: 180 },
-            timezone: { type: 'number', minimum: -12, maximum: 14, default: 8 },
+            timezone: { type: 'number', minimum: -12, maximum: 14 },
+            timeZoneId: { type: 'string', example: 'America/New_York' },
             applyChinaDst: { type: 'boolean', default: false },
           },
         },
@@ -1126,6 +1135,9 @@ export function getPublicApiOpenApiDocument(
             birthMinute: { type: 'integer', minimum: 0, maximum: 59 },
             birthPlace: { type: 'string' },
             birthLongitude: { type: 'number', minimum: -180, maximum: 180 },
+            timezone: { type: 'number', minimum: -12, maximum: 14 },
+            timeZoneId: { type: 'string', example: 'America/New_York' },
+            applyChinaDst: { type: 'boolean' },
             shenShaVariants: { $ref: '#/components/schemas/ShenShaVariants' },
             detailMode: DIVINATION_REQUEST_PROPERTIES.detailMode,
           },
@@ -1351,6 +1363,9 @@ export function getPublicApiOpenApiDocument(
             birthHour: { type: 'string' },
             birthMinute: { type: 'string' },
             birthLongitude: { type: 'string' },
+            timezone: { type: 'number', minimum: -12, maximum: 14 },
+            timeZoneId: { type: 'string', example: 'America/New_York' },
+            applyChinaDst: { type: 'boolean' },
             algorithm: {
               enum: ['default', 'zhongzhou'],
               description:
@@ -1683,10 +1698,19 @@ async function route(context: RouteContext) {
 function calculateTrueSolarTimeApi(input: JsonRecord) {
   const localDateTime = readRequiredString(input, 'localDateTime');
   const longitude = readNumberLike(input, 'longitude', -180, 180);
-  const timezone = input.timezone === undefined ? 8 : readNumberLike(input, 'timezone', -12, 14);
+  const timezone =
+    input.timezone === undefined ? undefined : readNumberLike(input, 'timezone', -12, 14);
+  const timeZoneId =
+    input.timeZoneId === undefined ? undefined : readRequiredString(input, 'timeZoneId');
   const applyChinaDst = readBoolean(input, 'applyChinaDst', false);
   try {
-    return convertTrueSolarTime({ localDateTime, longitude, timezone, applyChinaDst });
+    return convertTrueSolarTime({
+      localDateTime,
+      longitude,
+      timezone,
+      timeZoneId,
+      applyChinaDst,
+    });
   } catch (error) {
     throw new ApiError(
       400,
@@ -1708,7 +1732,10 @@ function calculateTrueSolarBirthApi(input: JsonRecord) {
       second: input.second === undefined ? 0 : readIntegerLike(input, 'second', 0, 59),
       isLeapMonth: readBoolean(input, 'isLeapMonth', false),
       longitude: readNumberLike(input, 'longitude', -180, 180),
-      timezone: input.timezone === undefined ? 8 : readNumberLike(input, 'timezone', -12, 14),
+      timezone:
+        input.timezone === undefined ? undefined : readNumberLike(input, 'timezone', -12, 14),
+      timeZoneId:
+        input.timeZoneId === undefined ? undefined : readRequiredString(input, 'timeZoneId'),
       applyChinaDst: readBoolean(input, 'applyChinaDst', false),
     });
   } catch (error) {
@@ -2384,6 +2411,11 @@ function readBaziPerson(input: JsonRecord): Person {
     birthMinute,
     birthLongitude,
     birthPlace: readString(input, 'birthPlace', ''),
+    timezone: input.timezone === undefined ? undefined : readNumberLike(input, 'timezone', -12, 14),
+    timeZoneId:
+      input.timeZoneId === undefined ? undefined : readRequiredString(input, 'timeZoneId'),
+    applyChinaDst:
+      input.applyChinaDst === undefined ? undefined : readBoolean(input, 'applyChinaDst', false),
     shenShaVariants: readShenShaVariants(input),
   };
 
@@ -2565,6 +2597,12 @@ async function calculateZiweiRuntime(input: JsonRecord, scopes: ScopeType[] = ['
       birthHour: timeInput.birthHour,
       birthMinute: timeInput.birthMinute,
       birthLongitude: timeInput.birthLongitude,
+      timezone:
+        input.timezone === undefined ? undefined : readNumberLike(input, 'timezone', -12, 14),
+      timeZoneId:
+        input.timeZoneId === undefined ? undefined : readRequiredString(input, 'timeZoneId'),
+      applyChinaDst:
+        input.applyChinaDst === undefined ? undefined : readBoolean(input, 'applyChinaDst', false),
       algorithm: readEnum(input, 'algorithm', ['default', 'zhongzhou'], 'default') as
         'default' | 'zhongzhou',
     }),

--- a/tests/core-profile-capabilities.test.ts
+++ b/tests/core-profile-capabilities.test.ts
@@ -8,6 +8,7 @@ import {
   birthProfileToAstrolabeInput,
   birthProfileToAlmanacParticipant,
   birthProfileToBaziPerson,
+  birthProfileToQizhengInput,
   calculateBaziFromBirthProfile,
   normalizeBirthProfile,
 } from '../packages/core/src/profile/index';
@@ -162,6 +163,44 @@ test('统一出生档案可复用到八字与星盘输入', () => {
   assert.equal(astrolabeInput.latitude, '39.9');
   assert.equal(astrolabeInput.useTrueSolarTime, true);
   assert.equal(normalized.trueSolarEvidence?.summaryFact.status, '证据链完整');
+});
+
+test('统一出生档案应向八字、星盘和七政四余透传 IANA 历史时区', () => {
+  const profile = {
+    name: '纽约历史时区样例',
+    gender: 'male' as const,
+    calendarType: 'solar' as const,
+    year: 2024,
+    month: 7,
+    day: 1,
+    hour: 12,
+    minute: 0,
+    location: {
+      longitude: -74.006,
+      latitude: 40.7128,
+      timeZoneId: 'America/New_York',
+    },
+    useTrueSolarTime: true,
+  };
+
+  const normalized = normalizeBirthProfile(profile);
+  const baziInput = birthProfileToBaziPerson(profile);
+  const astrolabeInput = birthProfileToAstrolabeInput(profile);
+  const qizhengInput = birthProfileToQizhengInput(profile);
+  const chart = calculateBaziFromBirthProfile(profile);
+
+  assert.equal(normalized.resolvedLocation?.timezone, undefined);
+  assert.equal(normalized.resolvedLocation?.timeZoneId, 'America/New_York');
+  assert.equal(normalized.trueSolarEvidence?.timezoneEvidence?.resolvedOffsetHours, -4);
+  assert.equal(baziInput.timezone, undefined);
+  assert.equal(baziInput.timeZoneId, 'America/New_York');
+  assert.equal(astrolabeInput.timezone, undefined);
+  assert.equal(astrolabeInput.timeZoneId, 'America/New_York');
+  assert.equal(qizhengInput.timezone, undefined);
+  assert.equal(qizhengInput.timeZoneId, 'America/New_York');
+  assert.equal(chart.timing?.timezone, -4);
+  assert.equal(chart.timing?.timeZoneId, 'America/New_York');
+  assert.equal(chart.timing?.evidence.timezoneEvidence?.resolvedOffsetHours, -4);
 });
 
 test('农历统一档案启用真太阳时应只换算一次，并保留时区', () => {

--- a/tests/historical-timezone.test.ts
+++ b/tests/historical-timezone.test.ts
@@ -140,6 +140,37 @@ test('IANA 历史时区应保留纽约秋季回拨的两个候选时刻', () => 
   assertEvidenceReferences(evidence);
 });
 
+test('固定偏移应选择秋季回拨时间中对应的唯一候选', () => {
+  const daylight = resolveHistoricalTimezone({
+    year: 2024,
+    month: 11,
+    day: 3,
+    hour: 1,
+    minute: 30,
+    second: 0,
+    timeZoneId: 'America/New_York',
+    fixedOffsetHours: -4,
+  });
+  const standard = resolveHistoricalTimezone({
+    year: 2024,
+    month: 11,
+    day: 3,
+    hour: 1,
+    minute: 30,
+    second: 0,
+    timeZoneId: 'America/New_York',
+    fixedOffsetHours: -5,
+  });
+
+  assert.equal(daylight.selectedUtcDateTime, '2024-11-03T05:30:00.000Z');
+  assert.equal(daylight.resolvedOffsetHours, -4);
+  assert.equal(daylight.offsetConflict, false);
+  assert.equal(standard.selectedUtcDateTime, '2024-11-03T06:30:00.000Z');
+  assert.equal(standard.resolvedOffsetHours, -5);
+  assert.equal(standard.offsetConflict, false);
+  assert.match(standard.diagnostics[0], /固定偏移 UTC-5/);
+});
+
 test('IANA 历史时区应拒绝春季跳时与无效时区', () => {
   assert.throws(
     () =>

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -1146,6 +1146,30 @@ test('MCP 真太阳时工具应返回换算资料并拒绝带时区后缀的钟�
     assert.equal(chinaDst.structuredContent?.result.standardDateTime, '1988-07-15T11:00:00');
     assert.equal(chinaDst.structuredContent?.result.chinaDst.applied, true);
 
+    const iana = await client.callTool({
+      name: 'calendar_true_solar_time',
+      arguments: {
+        localDateTime: '2024-07-01T12:00:00',
+        longitude: -74.006,
+        timeZoneId: 'America/New_York',
+      },
+    });
+    assert.equal(iana.isError, undefined);
+    assert.equal(iana.structuredContent?.result.timezone, -4);
+    assert.equal(iana.structuredContent?.result.timezoneEvidence.timeZoneId, 'America/New_York');
+
+    const ambiguous = await client.callTool({
+      name: 'calendar_true_solar_time',
+      arguments: {
+        localDateTime: '2024-11-03T01:30:00',
+        longitude: -74.006,
+        timeZoneId: 'America/New_York',
+      },
+    });
+    assert.equal(ambiguous.isError, true);
+    const ambiguousText = ambiguous.content[0]?.type === 'text' ? ambiguous.content[0].text : '';
+    assert.match(ambiguousText, /回拨歧义.*timezone/);
+
     const invalid = await client.callTool({
       name: 'calendar_true_solar_time',
       arguments: { localDateTime: '1990-05-15T10:30:20+08:00', longitude: 116.4074 },

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -574,6 +574,32 @@ test('公开 API 应提供便捷真太阳时换算接口', async () => {
   assert.equal(chinaDst.body.data.standardDateTime, '1988-07-15T11:00:00');
   assert.equal(chinaDst.body.data.chinaDst.applied, true);
 
+  const iana = await callApi('calendar/true-solar-time', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      localDateTime: '2024-07-01T12:00:00',
+      longitude: -74.006,
+      timeZoneId: 'America/New_York',
+    }),
+  });
+  assert.equal(iana.response.status, 200);
+  assert.equal(iana.body.data.timezone, -4);
+  assert.equal(iana.body.data.timeZoneId, 'America/New_York');
+  assert.equal(iana.body.data.timezoneEvidence.resolvedOffsetHours, -4);
+
+  const ambiguous = await callApi('calendar/true-solar-time', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      localDateTime: '2024-11-03T01:30:00',
+      longitude: -74.006,
+      timeZoneId: 'America/New_York',
+    }),
+  });
+  assert.equal(ambiguous.response.status, 400);
+  assert.match(ambiguous.body.error.message, /回拨歧义.*timezone/);
+
   for (const payload of [
     { localDateTime: '1990-05-15T10:30:20+08:00', longitude: 116.4074 },
     { localDateTime: '1990-02-30T10:30', longitude: 116.4074 },
@@ -614,6 +640,24 @@ test('公开 API 应提供统一公历农历出生真太阳时接口', async () 
   assert.equal(body.data.calculationSteps[0].stage, '历法输入换算');
   assert.equal(body.data.correctionFacts[0].type, '历法输入');
   assert.equal(body.data.summaryFact.status, '证据链完整');
+
+  const iana = await callApi('calendar/true-solar-birth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      dateType: 'solar',
+      year: 2024,
+      month: 7,
+      day: 1,
+      hour: 12,
+      minute: 0,
+      longitude: -74.006,
+      timeZoneId: 'America/New_York',
+    }),
+  });
+  assert.equal(iana.response.status, 200);
+  assert.equal(iana.body.data.timezone, -4);
+  assert.equal(iana.body.data.timezoneEvidence.timeZoneId, 'America/New_York');
 });
 
 test('公开 API 应提供太阳高度、日出日落与曙暮光证据接口', async () => {
@@ -1129,6 +1173,27 @@ test('公开 API 八字排盘应支持真太阳时精确时分和经度', async 
     body.data.timing.evidence.calculationSteps.length,
   );
   assert.match(body.data.timing.evidence.promptText, /唯一映射为/);
+
+  const iana = await callApi('bazi/calculate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      gender: 'male',
+      year: 2024,
+      month: 7,
+      day: 1,
+      dateType: 'solar',
+      useTrueSolarTime: true,
+      birthHour: 12,
+      birthMinute: 0,
+      birthLongitude: -74.006,
+      timeZoneId: 'America/New_York',
+    }),
+  });
+  assert.equal(iana.response.status, 200);
+  assert.equal(iana.body.data.timing.timezone, -4);
+  assert.equal(iana.body.data.timing.timeZoneId, 'America/New_York');
+  assert.equal(iana.body.data.timing.evidence.timezoneEvidence.resolvedOffsetHours, -4);
 });
 
 test('公开 API 八字公历日期不存在时应返回参数错误', async () => {
@@ -2024,6 +2089,26 @@ test('公开 API 紫微排盘应支持真太阳时精确时分和经度', async 
   assert.equal(body.data.trueSolarEvidence.status, '已计算');
   assert.equal(body.data.trueSolarEvidence.calculationSteps.length, 7);
   assert.equal(body.data.trueSolarEvidence.summaryFact.status, '证据链完整');
+
+  const iana = await callApi('ziwei/calculate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: '纽约测试',
+      gender: 'male',
+      dateType: 'solar',
+      year: '2024',
+      month: '7',
+      day: '1',
+      useTrueSolarTime: true,
+      birthHour: '12',
+      birthMinute: '0',
+      birthLongitude: '-74.006',
+      timeZoneId: 'America/New_York',
+    }),
+  });
+  assert.equal(iana.response.status, 200);
+  assert.equal(iana.body.data.trueSolarEvidence.timezoneEvidence.resolvedOffsetHours, -4);
 
   const promptResult = await callApi('ziwei/prompt', {
     method: 'POST',

--- a/tests/true-solar-time.test.ts
+++ b/tests/true-solar-time.test.ts
@@ -128,6 +128,81 @@ test('真太阳时便捷入口应识别跨日并支持全球时区', () => {
   assert.equal(utcPlus14.standardMeridian, 210);
 });
 
+test('真太阳时应按 IANA 历史时区解析偏移并保留证据', () => {
+  const result = convertTrueSolarTime({
+    localDateTime: '2024-07-01T12:00:00',
+    longitude: -74.006,
+    timeZoneId: 'America/New_York',
+  });
+
+  assert.equal(result.timezone, -4);
+  assert.equal(result.timeZoneId, 'America/New_York');
+  assert.equal(result.timezoneEvidence?.resolvedOffsetHours, -4);
+  assert.equal(result.timezoneEvidence?.status, 'unique');
+  assert.equal(
+    result.correctionFacts.some((item) => item.type === '历史时区'),
+    true,
+  );
+  assert.equal(
+    result.calculationSteps.some((item) => item.stage === '历史时区解析'),
+    true,
+  );
+  assert.match(result.promptText, /America\/New_York.*UTC-4/);
+  assertTrueSolarEvidence(result);
+});
+
+test('真太阳时应严格处理 IANA 跳时、回拨消歧和冲突组合', () => {
+  assert.throws(
+    () =>
+      convertTrueSolarTime({
+        localDateTime: '2024-03-10T02:30:00',
+        longitude: -74.006,
+        timeZoneId: 'America/New_York',
+      }),
+    /不存在.*夏令时跳时/,
+  );
+  assert.throws(
+    () =>
+      convertTrueSolarTime({
+        localDateTime: '2024-11-03T01:30:00',
+        longitude: -74.006,
+        timeZoneId: 'America/New_York',
+      }),
+    /回拨歧义.*timezone/,
+  );
+
+  const resolved = convertTrueSolarTime({
+    localDateTime: '2024-11-03T01:30:00',
+    longitude: -74.006,
+    timezone: -5,
+    timeZoneId: 'America/New_York',
+  });
+  assert.equal(resolved.timezone, -5);
+  assert.equal(resolved.timezoneEvidence?.selectedUtcDateTime, '2024-11-03T06:30:00.000Z');
+  assert.equal(resolved.summaryFact.status, '历史时区歧义已消解');
+
+  assert.throws(
+    () =>
+      convertTrueSolarTime({
+        localDateTime: '2024-07-01T12:00:00',
+        longitude: -74.006,
+        timezone: -5,
+        timeZoneId: 'America/New_York',
+      }),
+    /固定偏移.*历史偏移不一致/,
+  );
+  assert.throws(
+    () =>
+      convertTrueSolarTime({
+        localDateTime: '1990-07-01T12:00:00',
+        longitude: 121.47,
+        timeZoneId: 'Asia/Shanghai',
+        applyChinaDst: true,
+      }),
+    /不能同时启用 applyChinaDst/,
+  );
+});
+
 test('真太阳时便捷入口应拒绝含时区后缀、非法日期和越界参数', () => {
   assert.throws(() => parseLocalDateTime('2026-07-10T12:00:00+08:00'), /不要附带时区偏移/);
   assert.throws(


### PR DESCRIPTION
## 目标

整理 PR #199 中有价值的 IANA 历史时区能力，并在 PR #198 的最新主线基础上补成完整、安全、可验证的真太阳时链路。

## 主要修改

- 真太阳时、八字、紫微和统一出生档案支持按 IANA 时区解析历史 UTC 偏移。
- 公开 API、MCP、能力目录和文档补齐 `timeZoneId`。
- 秋季回拨重复时间必须用固定偏移消歧；春季不存在时间、固定偏移冲突会明确拒绝。
- 禁止 `timeZoneId` 与中国夏令时兼容开关重复校正，并保留历史时区证据。
- 保留 #199 的有效时区能力，不引入错误的 23 点亥时映射、无消费者的南半球字段、版本跳升和 PR 自述日志。

## 验证

- `pnpm test`：1547 项通过
- `pnpm test:api`：107 项通过
- `pnpm test:e2e`：40 项通过
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm package:check`
- `git diff --check`

## 兼容性

- 未提供 `timeZoneId` 时继续默认 UTC+8，既有固定时区和中国历史夏令时口径保持兼容。
- 核心包版本保持 0.1.26，本次不发布 npm。