### PR TITLE
精简结果页并优先展示提示词复制入口

### DIFF
--- a/src/components/CollapsiblePromptPreview.tsx
+++ b/src/components/CollapsiblePromptPreview.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+interface CollapsiblePromptPreviewProps {
+  promptText: string;
+  fallback?: ReactNode;
+}
+
+export function CollapsiblePromptPreview({
+  promptText,
+  fallback = null,
+}: CollapsiblePromptPreviewProps) {
+  return (
+    <details className="prompt-preview-details">
+      <summary>{promptText ? '查看提示词内容' : '正在整理提示词'}</summary>
+      {promptText ? <pre className="result-pre">{promptText}</pre> : fallback}
+    </details>
+  );
+}

--- a/src/components/DivinationPanel/DivinationResult.tsx
+++ b/src/components/DivinationPanel/DivinationResult.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { DivinationDraft } from '@/lib/divination/engine';
 import type { DivinationSession } from '@/lib/divination/engine';
 import type { DivinationSummaryBlocks } from '@/lib/divination/summary';
@@ -8,6 +8,7 @@ import { TraditionalDivinationBoard } from '@/components/DivinationPanel/Traditi
 import { useAiSettings } from '@/hooks/useAiSettings';
 import { buildAiRequestConfig } from '@/lib/ai/settings';
 import { CollapsiblePromptPreview } from '@/components/CollapsiblePromptPreview';
+import { getCompactDivinationSummary } from './compact-evidence';
 
 interface DivinationResultProps {
   isSubmitting: boolean;
@@ -17,6 +18,7 @@ interface DivinationResultProps {
   copyState: string;
   shareState: string;
   showShareButton: boolean;
+  isPhoneLayout: boolean;
   onCopy: () => void;
   onShare: () => void;
 }
@@ -175,12 +177,19 @@ export function DivinationResult({
   copyState,
   shareState,
   showShareButton,
+  isPhoneLayout,
   onCopy,
   onShare,
 }: DivinationResultProps) {
   const [aiSettings] = useAiSettings();
   const isAiEnabled = aiSettings.enabled;
   const aiRequestConfig = useMemo(() => buildAiRequestConfig(aiSettings), [aiSettings]);
+  const [isEvidenceOpen, setIsEvidenceOpen] = useState(!isPhoneLayout);
+
+  useEffect(() => {
+    setIsEvidenceOpen(!isPhoneLayout);
+  }, [isPhoneLayout, session]);
+
   if (isSubmitting) {
     if (isAiEnabled) {
       return (
@@ -248,8 +257,9 @@ export function DivinationResult({
   }
 
   const isLiurenResult = session.method === 'liuren';
+  const compactSummary = getCompactDivinationSummary(summary);
 
-  // 占卜结果区块（复用于折叠展示和原有双栏）
+  // 前端只展示核对盘面所需的摘要；完整传统资料继续保留在提示词中。
   const resultBlock = (
     <section className="panel divination-result-panel">
       {!isLiurenResult ? (
@@ -270,7 +280,7 @@ export function DivinationResult({
       {!isLiurenResult ? (
         <>
           <div className="divination-tag-cloud">
-            {summary.tags.map((item) => (
+            {compactSummary.tags.map((item) => (
               <span className="result-soft-tag" key={item}>
                 {item}
               </span>
@@ -278,7 +288,7 @@ export function DivinationResult({
           </div>
 
           <div className="divination-summary-list">
-            {summary.lines.filter(Boolean).map((item) => (
+            {compactSummary.lines.map((item) => (
               <div className="divination-summary-item" key={item}>
                 {item}
               </div>
@@ -294,8 +304,12 @@ export function DivinationResult({
   if (isAiEnabled) {
     return (
       <div className="divination-ai-card">
-        <details className="divination-result-collapse">
-          <summary>排盘结果（点开查看卦象 / 星盘）</summary>
+        <details
+          className="divination-result-collapse"
+          open={isEvidenceOpen}
+          onToggle={(event) => setIsEvidenceOpen(event.currentTarget.open)}
+        >
+          <summary>{isEvidenceOpen ? '收起排盘依据' : '查看排盘依据'}</summary>
           {resultBlock}
         </details>
         <AiChatPanel
@@ -332,8 +346,12 @@ export function DivinationResult({
         <CollapsiblePromptPreview promptText={session.prompt} />
       </section>
 
-      <details className="divination-result-collapse">
-        <summary>查看排盘依据</summary>
+      <details
+        className="divination-result-collapse"
+        open={isEvidenceOpen}
+        onToggle={(event) => setIsEvidenceOpen(event.currentTarget.open)}
+      >
+        <summary>{isEvidenceOpen ? '收起排盘依据' : '查看排盘依据'}</summary>
         {resultBlock}
       </details>
     </div>

--- a/src/components/DivinationPanel/DivinationResult.tsx
+++ b/src/components/DivinationPanel/DivinationResult.tsx
@@ -7,6 +7,7 @@ import { AiChatPanel } from '@/components/AiChatPanel';
 import { TraditionalDivinationBoard } from '@/components/DivinationPanel/TraditionalDivinationBoard';
 import { useAiSettings } from '@/hooks/useAiSettings';
 import { buildAiRequestConfig } from '@/lib/ai/settings';
+import { CollapsiblePromptPreview } from '@/components/CollapsiblePromptPreview';
 
 interface DivinationResultProps {
   isSubmitting: boolean;
@@ -310,13 +311,11 @@ export function DivinationResult({
 
   return (
     <div className="workspace-grid divination-output-grid">
-      {resultBlock}
-
       <section className="panel panel-output divination-result-panel">
         <div className="panel-head divination-prompt-head">
           <div>
-            <h2>占卜提示词</h2>
-            <p>系统要求、结构化结果和你的问题都已经合并，复制整段即可使用。</p>
+            <h2>复制占卜提示词</h2>
+            <p>完整提示词已经生成，可以直接复制使用。</p>
           </div>
           <div className="action-row compact-actions divination-prompt-actions">
             <button className="copy-button secondary-button" type="button" onClick={onCopy}>
@@ -330,9 +329,13 @@ export function DivinationResult({
           </div>
         </div>
         <div className="prompt-send-tip">点击复制后，发送到你常用的在线 AI 软件继续提问。</div>
-
-        <pre className="result-pre">{session.prompt}</pre>
+        <CollapsiblePromptPreview promptText={session.prompt} />
       </section>
+
+      <details className="divination-result-collapse">
+        <summary>查看排盘依据</summary>
+        {resultBlock}
+      </details>
     </div>
   );
 }

--- a/src/components/DivinationPanel/compact-evidence.ts
+++ b/src/components/DivinationPanel/compact-evidence.ts
@@ -1,0 +1,47 @@
+import type { DivinationSummaryBlocks } from '@/lib/divination/summary';
+
+const MAX_VISIBLE_TAGS = 4;
+const MAX_VISIBLE_LINES = 4;
+const DEFERRED_LINE_PREFIXES = [
+  '干支：',
+  '节气：',
+  '定局节气：',
+  '时辰：',
+  '历法口径：',
+  '起卦法：',
+  '过程：',
+];
+
+function uniqueNonEmpty(items: string[]) {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const normalized = item.trim();
+    if (!normalized || seen.has(normalized)) {
+      return false;
+    }
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function isExpandedEvidenceDump(line: string) {
+  return line.startsWith('证据：') || (line.length > 240 && line.includes('\n'));
+}
+
+export function getCompactDivinationSummary(summary: DivinationSummaryBlocks) {
+  const lines = uniqueNonEmpty(summary.lines).filter((line) => !isExpandedEvidenceDump(line));
+  const mainLines = lines.filter((line) => line.startsWith('主轴：'));
+  const supportingLines = lines.filter(
+    (line) =>
+      !line.startsWith('主轴：') &&
+      !DEFERRED_LINE_PREFIXES.some((prefix) => line.startsWith(prefix)),
+  );
+  const deferredLines = lines.filter((line) =>
+    DEFERRED_LINE_PREFIXES.some((prefix) => line.startsWith(prefix)),
+  );
+
+  return {
+    tags: uniqueNonEmpty(summary.tags).slice(0, MAX_VISIBLE_TAGS),
+    lines: [...mainLines, ...supportingLines, ...deferredLines].slice(0, MAX_VISIBLE_LINES),
+  };
+}

--- a/src/components/DivinationPanel/index.tsx
+++ b/src/components/DivinationPanel/index.tsx
@@ -240,18 +240,6 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
 
   return (
     <div className="divination-panel-shell">
-      <DivinationForm
-        draft={draft}
-        updateDraft={updateDraft}
-        lockedMethod={lockedMethod}
-        isSubmitting={isSubmitting}
-        error={error}
-        onSubmit={handleSubmit}
-        onOpenInspiration={openQuestionInspirationModal}
-        onNavigateToHistory={() => navigate('/records?tab=divination')}
-        questionInputRef={questionInputRef}
-      />
-
       <DivinationResult
         isSubmitting={isSubmitting}
         session={session}
@@ -262,6 +250,18 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
         showShareButton={showShareButton}
         onCopy={handleCopy}
         onShare={handleShare}
+      />
+
+      <DivinationForm
+        draft={draft}
+        updateDraft={updateDraft}
+        lockedMethod={lockedMethod}
+        isSubmitting={isSubmitting}
+        error={error}
+        onSubmit={handleSubmit}
+        onOpenInspiration={openQuestionInspirationModal}
+        onNavigateToHistory={() => navigate('/records?tab=divination')}
+        questionInputRef={questionInputRef}
       />
 
       {isQuestionInspirationModalOpen ? (

--- a/src/components/DivinationPanel/index.tsx
+++ b/src/components/DivinationPanel/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/divination/inspiration';
 import { addDivinationHistory, getDivinationHistoryById } from '@/lib/history-records';
 import { shouldShowPromptShareButton } from '@/lib/prompt-page-rules';
+import { shouldUsePhoneLayout } from '@/lib/responsive-layout';
 import { useViewportSize } from '@/hooks/useViewportWidth';
 import { usePromptCopyShare } from '@/hooks/usePromptCopyShare';
 import {
@@ -173,6 +174,10 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
     viewportHeight: viewportSize.height,
     hasNavigatorShare: typeof navigator !== 'undefined' && typeof navigator.share === 'function',
   });
+  const isPhoneLayout = shouldUsePhoneLayout({
+    viewportWidth: viewportSize.width,
+    viewportHeight: viewportSize.height,
+  });
 
   useEffect(() => {
     if (!lockedMethod || draft.method === lockedMethod) {
@@ -240,18 +245,6 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
 
   return (
     <div className="divination-panel-shell">
-      <DivinationResult
-        isSubmitting={isSubmitting}
-        session={session}
-        summary={summary}
-        methodLabelMap={methodLabelMap}
-        copyState={copyState}
-        shareState={shareState}
-        showShareButton={showShareButton}
-        onCopy={handleCopy}
-        onShare={handleShare}
-      />
-
       <DivinationForm
         draft={draft}
         updateDraft={updateDraft}
@@ -262,6 +255,19 @@ export function DivinationPanel({ initialMethod, lockedMethod }: DivinationPanel
         onOpenInspiration={openQuestionInspirationModal}
         onNavigateToHistory={() => navigate('/records?tab=divination')}
         questionInputRef={questionInputRef}
+      />
+
+      <DivinationResult
+        isSubmitting={isSubmitting}
+        session={session}
+        summary={summary}
+        methodLabelMap={methodLabelMap}
+        copyState={copyState}
+        shareState={shareState}
+        showShareButton={showShareButton}
+        isPhoneLayout={isPhoneLayout}
+        onCopy={handleCopy}
+        onShare={handleShare}
       />
 
       {isQuestionInspirationModalOpen ? (

--- a/src/pages/InputPage.tsx
+++ b/src/pages/InputPage.tsx
@@ -320,7 +320,7 @@ export function InputPage() {
         pathname: '/result',
         search: `?${buildResultSearch(form, {
           ...defaultPromptState,
-          tab: 'bazi',
+          tab: 'prompt',
           promptSource: 'bazi',
           baziShortcutMode:
             form.analysisMode === 'compatibility' ? '合婚' : defaultPromptState.baziShortcutMode,

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -80,6 +80,7 @@ import {
 import { BIRTH_TIME_OPTIONS } from '@/lib/birth-time';
 import { buildRecentBaziFortuneSelection } from '@/components/BaziFortuneTools/helpers';
 import type { BaziFortuneSelectionValue } from 'mingyu-core/bazi';
+import { CollapsiblePromptPreview } from '@/components/CollapsiblePromptPreview';
 
 type FortuneScopePreset = 'default' | 'recent' | 'all' | 'manual';
 
@@ -1262,6 +1263,13 @@ export function ResultPage() {
       <div className="tab-strip">
         <button
           type="button"
+          className={`tab-chip ${promptState.tab === 'prompt' ? 'is-active' : ''}`}
+          onClick={() => switchTab('prompt')}
+        >
+          {isAiEnabled ? 'AI 解析' : '复制提示词'}
+        </button>
+        <button
+          type="button"
           className={`tab-chip ${promptState.tab === 'bazi' ? 'is-active' : ''}`}
           onClick={() => switchTab('bazi')}
         >
@@ -1301,13 +1309,6 @@ export function ResultPage() {
             住宅风水
           </button>
         ) : null}
-        <button
-          type="button"
-          className={`tab-chip ${promptState.tab === 'prompt' ? 'is-active' : ''}`}
-          onClick={() => switchTab('prompt')}
-        >
-          {isAiEnabled ? 'AI 解析' : '提示词'}
-        </button>
       </div>
 
       <div className={`result-tab-stage${isDesktopAiWorkspace ? ' is-ai-wide' : ''}`}>
@@ -1737,17 +1738,15 @@ export function ResultPage() {
                 </div>
               )
             ) : (
-              /* ── 非 AI 模式：原始布局，左侧设置+提示词快捷面板，右侧提示词正文 ── */
-              <div className="workspace-grid">
-                <section className="panel">
-                  <div className="panel-head">
-                    <div>
-                      <h2 className="prompt-settings-title">提示词设置</h2>
-                      <p>选择已生成的排盘作为解读依据，再输入问题，即可生成完整提示词。</p>
-                    </div>
-                  </div>
+              /* ── 非 AI 模式：复制优先，设置与完整正文按需查看 ── */
+              <div className="workspace-grid prompt-output-grid">
+                <details className="panel prompt-settings-panel">
+                  <summary className="prompt-settings-summary">
+                    <span>调整提示词（可选）</span>
+                    <small>更换排盘来源、年限或问题</small>
+                  </summary>
 
-                  <div className="field-list">
+                  <div className="prompt-settings-content field-list">
                     {metaphysicsPromptQuestionField}
                     <>
                       <div className="prompt-compact-grid">
@@ -1883,7 +1882,7 @@ export function ResultPage() {
                       ) : null}
                     </>
                   </div>
-                </section>
+                </details>
 
                 {isAstrolabePromptSource && astrolabeCalculation.error ? (
                   <p className="error-text">{astrolabeCalculation.error}</p>
@@ -1892,8 +1891,8 @@ export function ResultPage() {
                 <section className="panel panel-output">
                   <div className="panel-head">
                     <div>
-                      <h2>提示词正文</h2>
-                      <p>排盘资料和问题已整理好，复制这一整段提示词即可。</p>
+                      <h2>复制提示词</h2>
+                      <p>完整提示词已经生成，可以直接复制使用。</p>
                     </div>
                     <div className="action-row compact-actions">
                       <button
@@ -1913,11 +1912,10 @@ export function ResultPage() {
                   <div className="prompt-send-tip">
                     点击复制后，发送到你常用的在线 AI 软件继续提问。
                   </div>
-                  {previewActivePromptText ? (
-                    <pre className="result-pre">{previewActivePromptText}</pre>
-                  ) : (
-                    <PromptPreSkeleton />
-                  )}
+                  <CollapsiblePromptPreview
+                    promptText={previewActivePromptText}
+                    fallback={<PromptPreSkeleton />}
+                  />
                 </section>
               </div>
             )

--- a/src/styles.css
+++ b/src/styles.css
@@ -2648,6 +2648,65 @@ select {
   min-width: 0;
 }
 
+.prompt-output-grid > .panel-output {
+  order: -1;
+}
+
+.prompt-settings-panel {
+  height: fit-content;
+  padding: 0;
+  overflow: hidden;
+}
+
+.prompt-settings-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 18px 22px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.prompt-settings-summary::-webkit-details-marker,
+.prompt-preview-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.prompt-settings-summary span {
+  color: var(--text-strong);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.prompt-settings-summary small {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.prompt-settings-summary::after,
+.prompt-preview-details > summary::after {
+  flex: 0 0 auto;
+  color: var(--accent-strong);
+  font-size: 12px;
+  font-weight: 700;
+  content: '展开';
+}
+
+.prompt-settings-panel[open] > .prompt-settings-summary,
+.prompt-preview-details[open] > summary {
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.prompt-settings-panel[open] > .prompt-settings-summary::after,
+.prompt-preview-details[open] > summary::after {
+  content: '收起';
+}
+
+.prompt-settings-content {
+  padding: 20px 22px 22px;
+}
+
 .copy-button {
   border: none;
   border-radius: var(--radius-control);
@@ -2680,6 +2739,35 @@ select {
   max-width: 100%;
   overflow: auto;
   overflow-wrap: anywhere;
+}
+
+.prompt-preview-details {
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-control);
+  background: linear-gradient(180deg, var(--surface-elevated), var(--surface-soft));
+}
+
+.prompt-preview-details > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 700;
+  list-style: none;
+  cursor: pointer;
+}
+
+.prompt-preview-details > .result-pre {
+  max-height: min(520px, 55vh);
+  min-height: 0;
+  margin: 0;
+  padding: 14px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .prompt-send-tip {
@@ -7116,6 +7204,29 @@ div.form-actions.page-submit-actions {
     background: transparent;
     box-shadow: none;
     backdrop-filter: none;
+  }
+
+  .prompt-output-grid > .prompt-settings-panel {
+    padding: 0;
+    border: 1px solid var(--border-soft);
+    border-radius: 12px;
+    background: linear-gradient(180deg, var(--surface-elevated), var(--surface-soft));
+  }
+
+  .prompt-settings-summary {
+    padding: 12px 14px;
+  }
+
+  .prompt-settings-summary small {
+    display: none;
+  }
+
+  .prompt-settings-content {
+    padding: 12px;
+  }
+
+  .prompt-preview-details > .result-pre {
+    max-height: 44vh;
   }
 
   .panel-head {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4489,7 +4489,10 @@ select {
 }
 
 .divination-output-grid {
+  width: 100%;
   margin-top: 0;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
 }
 
 .divination-output-grid > .panel {

--- a/tests/collapsible-prompt-preview.test.tsx
+++ b/tests/collapsible-prompt-preview.test.tsx
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { CollapsiblePromptPreview } from '../src/components/CollapsiblePromptPreview';
+
+test('完整提示词默认收起但仍保留可查看内容', () => {
+  const html = renderToStaticMarkup(<CollapsiblePromptPreview promptText="这是一份完整提示词" />);
+
+  assert.match(html, /<details class="prompt-preview-details">/);
+  assert.doesNotMatch(html, /<details[^>]* open/);
+  assert.match(html, /查看提示词内容/);
+  assert.match(html, /这是一份完整提示词/);
+});
+
+test('提示词尚未生成时显示整理状态和加载内容', () => {
+  const html = renderToStaticMarkup(
+    <CollapsiblePromptPreview promptText="" fallback={<span>加载中</span>} />,
+  );
+
+  assert.match(html, /正在整理提示词/);
+  assert.match(html, /加载中/);
+});

--- a/tests/compact-divination-evidence.test.ts
+++ b/tests/compact-divination-evidence.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getCompactDivinationSummary } from '../src/components/DivinationPanel/compact-evidence';
+
+test('前端依据只保留关键摘要并去掉完整证据长文', () => {
+  const compact = getCompactDivinationSummary({
+    title: '奇门起局结果',
+    tags: ['局数', '值符', '值使', '重复', '不再展示'],
+    lines: [
+      '干支：丙午、丙申、甲寅、丙寅',
+      '节气：立秋',
+      '主轴：值符落坎宫；值使落离宫',
+      '格局：门迫、击刑',
+      '复合格局：支持与限制并存',
+      '空亡：子、丑',
+      '证据：这里是一整段只需要保留在提示词里的完整证据',
+    ],
+  });
+
+  assert.deepEqual(compact.tags, ['局数', '值符', '值使', '重复']);
+  assert.deepEqual(compact.lines, [
+    '主轴：值符落坎宫；值使落离宫',
+    '格局：门迫、击刑',
+    '复合格局：支持与限制并存',
+    '空亡：子、丑',
+  ]);
+});
+
+test('辅助起卦信息仅在关键摘要不足时补位', () => {
+  const compact = getCompactDivinationSummary({
+    title: '小六壬起课结果',
+    tags: [],
+    lines: ['主轴：占得大安', '历法口径：子初换日', '历法口径：子初换日'],
+  });
+
+  assert.deepEqual(compact.lines, ['主轴：占得大安', '历法口径：子初换日']);
+});


### PR DESCRIPTION
## 目标

精简排盘与占卜结果页，生成结果后优先提供复制入口，减少用户在前端停留和滚动的时间。

## 主要修改

- 排盘完成后默认进入“复制提示词”，并将该标签放在首位。
- 复制按钮置于结果首屏；提示词设置和完整提示词正文默认收起，可按需展开。
- 占卜页面保持原有顺序：表单在前，复制提示词和排盘依据在后，不再把结果移到表单前面。
- 结果区统一改为单列：复制提示词卡片占满整行，排盘依据紧随其后，消除桌面端左右两栏高度不一致造成的大面积空白。
- 手机端结果区与表单同宽，排盘依据默认收起；桌面端依据默认展开，用户可随时展开或收起。
- 前端依据最多展示 4 个标签和 4 条核心摘要，优先保留主轴、格局等关键信息，移除完整“证据：”长文和不必要的超长资料。
- 完整传统资料仍保留在复制提示词中，不改变生成结果、算法、公开接口或复制内容。
- 新增统一的折叠提示词预览组件，并补充折叠状态和依据精简规则测试。

## 界面验收

- 390×844 手机端：表单在结果前；结果区宽 378px，与表单对齐；依据默认收起，收起区域约 46px。
- 手机端展开后仅显示精简后的标签和核心摘要，不再显示完整“证据：”长文。
- 1701×1145 桌面端：结果区为 1180px 单列布局，复制卡片在前、依据在后，依据默认展开。
- 手机端无横向滚动；桌面和手机均已实际生成结果检查，浏览器重新加载后无新增控制台错误。

## 验证

- 直接相关测试：6 项通过。
- `pnpm lint`：通过。
- `pnpm format:check`：通过。
- `pnpm exec prettier --check src/styles.css`：通过。
- `pnpm build`：通过，689 个模块完成生产构建。
- 真实浏览器验证：390×844 手机端与 1701×1145 桌面端均通过。

## 兼容风险

- 本次仅调整前端展示、结果区布局和按设备默认折叠状态；复制提示词中的完整资料未删减。
- 不修改占卜算法、数据结构和公开接口。
- Vite 仍有既有的大分块体积提醒，不影响本次构建成功。