### PR TITLE
完善星盘福点显示

### DIFF
--- a/src/components/AstrolabeChart.tsx
+++ b/src/components/AstrolabeChart.tsx
@@ -1,5 +1,19 @@
 import type { AstrolabeData } from '@/types/divination';
 
+const VISIBLE_POINT_NAMES = new Set([
+  'Sun',
+  'Moon',
+  'Mercury',
+  'Venus',
+  'Mars',
+  'Jupiter',
+  'Saturn',
+  'Uranus',
+  'Neptune',
+  'Pluto',
+  'Part of Fortune',
+]);
+
 function toChartPoint(longitude: number, radius: number) {
   const angle = ((longitude - 90) * Math.PI) / 180;
   return {
@@ -15,19 +29,8 @@ export function AstrolabeChart({
   data: AstrolabeData;
   showHeader?: boolean;
 }) {
-  const majorPlanetNames = new Set([
-    'Sun',
-    'Moon',
-    'Mercury',
-    'Venus',
-    'Mars',
-    'Jupiter',
-    'Saturn',
-    'Uranus',
-    'Neptune',
-    'Pluto',
-  ]);
-  const visiblePlanets = data.planets.filter((planet) => majorPlanetNames.has(planet.name));
+  const visiblePlanets = data.planets.filter((planet) => VISIBLE_POINT_NAMES.has(planet.name));
+  const fortunePoint = data.planets.find((planet) => planet.name === 'Part of Fortune');
   const zodiacSigns = [
     '白羊',
     '金牛',
@@ -51,7 +54,16 @@ export function AstrolabeChart({
           <span>{data.birth.dateTime}</span>
         </div>
       ) : null}
-      <svg className="astrolabe-chart-svg" viewBox="0 0 300 300" role="img" aria-label="星盘图">
+      <svg
+        className="astrolabe-chart-svg"
+        viewBox="0 0 300 300"
+        role="img"
+        aria-label={
+          fortunePoint
+            ? `星盘图，福点位于${fortunePoint.formatted}，第${fortunePoint.house}宫`
+            : '星盘图'
+        }
+      >
         <circle cx="150" cy="150" r="132" className="astrolabe-ring-outer" />
         <circle cx="150" cy="150" r="104" className="astrolabe-ring-inner" />
         <circle cx="150" cy="150" r="58" className="astrolabe-ring-core" />
@@ -113,8 +125,14 @@ export function AstrolabeChart({
         })}
         {visiblePlanets.map((planet) => {
           const point = toChartPoint(planet.longitude, 78);
+          const isFortunePoint = planet.name === 'Part of Fortune';
           return (
-            <g key={planet.name}>
+            <g
+              key={planet.name}
+              className={`astrolabe-point-marker${isFortunePoint ? ' is-fortune' : ''}`}
+              data-point-name={planet.name}
+            >
+              <title>{`${planet.label}：${planet.formatted}，第${planet.house}宫`}</title>
               <circle cx={point.x} cy={point.y} r="8" className="astrolabe-planet-dot" />
               <text x={point.x} y={point.y + 3} className="astrolabe-planet-label">
                 {planet.label.slice(0, 1)}
@@ -123,6 +141,16 @@ export function AstrolabeChart({
           );
         })}
       </svg>
+      {fortunePoint ? (
+        <div className="astrolabe-point-highlights" aria-label="重要虚拟点">
+          <span className="astrolabe-point-highlight">
+            <strong>福点</strong>
+            <span>
+              {fortunePoint.formatted} · 第{fortunePoint.house}宫
+            </span>
+          </span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/AstrolabeChart.tsx
+++ b/src/components/AstrolabeChart.tsx
@@ -142,7 +142,7 @@ export function AstrolabeChart({
         })}
       </svg>
       {fortunePoint ? (
-        <div className="astrolabe-point-highlights" aria-label="重要虚拟点">
+        <div className="astrolabe-point-highlights" role="group" aria-label="重要虚拟点">
           <span className="astrolabe-point-highlight">
             <strong>福点</strong>
             <span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6148,6 +6148,39 @@ select {
   font-weight: 700;
 }
 
+.astrolabe-point-marker.is-fortune .astrolabe-planet-dot {
+  fill: var(--accent-soft);
+  stroke-width: 1.6;
+}
+
+.astrolabe-point-marker.is-fortune .astrolabe-planet-label {
+  fill: var(--accent-strong);
+}
+
+.astrolabe-point-highlights {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+}
+
+.astrolabe-point-highlight {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.astrolabe-point-highlight strong {
+  color: var(--accent-deep);
+  font-weight: 700;
+}
+
 .divination-result-skeleton {
   display: grid;
   gap: 12px;

--- a/tests/astrolabe-chart.test.ts
+++ b/tests/astrolabe-chart.test.ts
@@ -29,7 +29,34 @@ test('星盘图应显示福点标记与星座宫位摘要', () => {
 
   assert.match(html, /data-point-name="Part of Fortune"/);
   assert.match(html, /astrolabe-point-marker is-fortune/);
+  assert.match(html, /role="group" aria-label="重要虚拟点"/);
   assert.match(html, new RegExp(`福点位于${fortunePoint.formatted}，第${fortunePoint.house}宫`));
   assert.match(html, new RegExp(`福点：${fortunePoint.formatted}，第${fortunePoint.house}宫`));
   assert.match(html, new RegExp(`${fortunePoint.formatted} · 第${fortunePoint.house}宫`));
+});
+
+test('缺少福点的历史数据仍应正常显示星盘图', () => {
+  const data = generateAstrolabe({
+    name: '历史星盘样本',
+    gender: '女',
+    year: '1990',
+    month: '5',
+    day: '20',
+    hour: '12',
+    minute: '30',
+    latitude: '31.2304',
+    longitude: '121.4737',
+    timezone: '8',
+    locationName: '上海',
+  });
+  const dataWithoutFortune = {
+    ...data,
+    planets: data.planets.filter((planet) => planet.name !== 'Part of Fortune'),
+  };
+
+  const html = renderToStaticMarkup(createElement(AstrolabeChart, { data: dataWithoutFortune }));
+
+  assert.match(html, /aria-label="星盘图"/);
+  assert.doesNotMatch(html, /data-point-name="Part of Fortune"/);
+  assert.doesNotMatch(html, /astrolabe-point-highlights/);
 });

--- a/tests/astrolabe-chart.test.ts
+++ b/tests/astrolabe-chart.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { AstrolabeChart } from '../src/components/AstrolabeChart';
+import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
+
+test('星盘图应显示福点标记与星座宫位摘要', () => {
+  const data = generateAstrolabe({
+    name: '星盘样本',
+    gender: '女',
+    year: '1990',
+    month: '5',
+    day: '20',
+    hour: '12',
+    minute: '30',
+    latitude: '31.2304',
+    longitude: '121.4737',
+    timezone: '8',
+    locationName: '上海',
+  });
+  const fortunePoint = data.planets.find((planet) => planet.name === 'Part of Fortune');
+
+  assert.ok(fortunePoint);
+
+  const html = renderToStaticMarkup(createElement(AstrolabeChart, { data }));
+
+  assert.match(html, /data-point-name="Part of Fortune"/);
+  assert.match(html, /astrolabe-point-marker is-fortune/);
+  assert.match(html, new RegExp(`福点位于${fortunePoint.formatted}，第${fortunePoint.house}宫`));
+  assert.match(html, new RegExp(`福点：${fortunePoint.formatted}，第${fortunePoint.house}宫`));
+  assert.match(html, new RegExp(`${fortunePoint.formatted} · 第${fortunePoint.house}宫`));
+});


### PR DESCRIPTION
## 目标

福点此前已经进入真实星盘数据、证据链和完整 AI 提示词，AI 解读能力并未缺少这一信息。最初前端主要作为 AI 解读入口，盘面采用相对精简的展示，因此未单独绘制福点。

本次将此前主要供 AI 使用的福点数据同步展示在前端盘面中，方便用户直接查看和核对；不涉及底层算法补算，也不改变现有提示词口径。

## 主要修改

- 在星盘圆盘中加入福点标记，并与普通星体作视觉区分
- 增加福点悬停说明和读屏信息，包含星座度数与宫位
- 在图下增加“重要虚拟点”摘要，直接展示福点位置
- 增加前端福点显示回归测试

## 验证

- 星盘算法与显示相关测试：15/15 通过
- 生产构建：通过
- 源码 ESLint：通过
- 改动文件 Prettier：通过
- 本地实际页面验收：福点标记、星座度数、宫位摘要和无障碍说明均显示正常

Closes #218