### PR TITLE
修复六爻盘移动端内容重叠

### DIFF
--- a/src/traditional-charts.css
+++ b/src/traditional-charts.css
@@ -1930,17 +1930,32 @@
 
   .traditional-liuyao-head,
   .traditional-liuyao-row {
-    min-width: 0;
-    grid-template-columns: 34px 34px 38px 48px 34px 50px minmax(48px, 1fr);
-    gap: 3px;
-    padding: 7px 4px;
+    min-width: 540px;
+    grid-template-columns: 38px 38px 42px 52px 46px 112px minmax(150px, 1fr);
+    gap: 4px;
+    padding: 7px 6px;
     font-size: 10px;
   }
 
+  .traditional-liuyao-row > span,
+  .traditional-liuyao-row > .traditional-yao-line {
+    min-width: 0;
+  }
+
+  .traditional-liuyao-row small {
+    overflow-wrap: anywhere;
+  }
+
   .traditional-yao-line {
-    width: 48px;
+    width: 52px;
     min-width: 0;
     gap: 3px;
+    justify-content: flex-start;
+  }
+
+  .traditional-yao-line > em {
+    right: 0;
+    left: auto;
   }
 
   .traditional-yao-symbol {


### PR DESCRIPTION
## 目标

系统修复手机端六爻纳甲盘在窄屏下列内容互相重叠的问题。

## 主要修改

- 恢复六爻七列表格在移动端的可读最小宽度，并限制横向滚动在表格内部。
- 为纳甲、化爻和状态列保留足够空间，长内容在所属单元格内换行。
- 将动爻标记收回爻象单元格，避免侵入纳甲列。

## 验证

- Playwright 实测 320、360、390、412、430 像素宽度：页面整体横向溢出为 0，列间重叠为 0，单元格内部元素越界为 0。
- pnpm build 在 NAS 开发环境通过。

## 风险

窄屏下表格需要在表格区域内横向滑动，属于为保证完整可读性而保留的交互。