### PR TITLE
修复 Cloudflare 自定义 AI 502

### DIFF
--- a/src/lib/ai/proxy.ts
+++ b/src/lib/ai/proxy.ts
@@ -668,9 +668,24 @@ async function fetchUpstreamWithRetry(
     try {
       const response = await fetch(url, {
         ...fetchInit,
-        redirect: 'error',
+        // Cloudflare Workers 不支持 redirect: 'error'。使用 manual 后由这里显式拒绝
+        // 跳转，既兼容边缘运行时，也避免自定义接口借 3xx 绕过地址校验。
+        redirect: 'manual',
         signal: controller.signal,
       });
+      if (response.status >= 300 && response.status < 400) {
+        await response.body?.cancel().catch(() => undefined);
+        cleanup();
+        return {
+          ok: false,
+          error: aiJsonError(
+            400,
+            'AI_UPSTREAM_REDIRECT_NOT_ALLOWED',
+            'AI 接口地址发生跳转，请填写最终的 HTTPS 接口地址。',
+            { attempts: attemptIndex + 1, retryable: false },
+          ),
+        };
+      }
       if (isRetryableUpstreamStatus(response.status) && attemptIndex < maxAttempts - 1) {
         await response.body?.cancel().catch(() => undefined);
         cleanup();

--- a/tests/ai-config.test.ts
+++ b/tests/ai-config.test.ts
@@ -377,7 +377,7 @@ test('自定义 AI 应直接请求合法的 HTTPS 公网域名', async (t) => {
 
   globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
     assert.equal(String(url), 'https://api.example.com/v1/models');
-    assert.equal(init?.redirect, 'error');
+    assert.equal(init?.redirect, 'manual');
     return new Response(JSON.stringify({ data: [{ id: 'public-model' }] }), {
       status: 200,
       headers: { 'Content-Type': 'application/json; charset=utf-8' },
@@ -401,6 +401,36 @@ test('自定义 AI 应直接请求合法的 HTTPS 公网域名', async (t) => {
   const body = await response.json();
   assert.equal(response.status, 200);
   assert.deepEqual(body, { ok: true, models: ['public-model'] });
+});
+
+test('自定义 AI 应拒绝上游地址跳转', async (t) => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(null, {
+      status: 302,
+      headers: { Location: 'https://other.example.com/v1/models' },
+    })) as typeof fetch;
+
+  const response = await handleAiModels(
+    new Request('https://example.com/api/v1/ai/models', {
+      method: 'POST',
+      body: JSON.stringify({
+        aiConfig: {
+          mode: 'custom',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.example.com/v1',
+        },
+      }),
+    }),
+  );
+
+  const body = await response.json();
+  assert.equal(response.status, 400);
+  assert.equal(body.error.code, 'AI_UPSTREAM_REDIRECT_NOT_ALLOWED');
 });
 
 test('内置 AI 应按可信客户端地址限制请求频率', async (t) => {


### PR DESCRIPTION
## 目标
修复 Cloudflare Pages 上自定义 AI 请求在访问上游前直接返回 502 的问题。

## 修改
- 将 Cloudflare 不支持的 redirect: error 改为兼容的 manual
- 显式拒绝所有 3xx 跳转，保留自定义接口地址的安全边界
- 增加合法公网接口与跳转拒绝回归测试

## 验证
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/ai-config.test.ts
- pnpm build