### PR TITLE
增加 Android 更新多线路测速与蓝奏云分发

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -115,9 +115,34 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            "release/mingyu-${ANDROID_VERSION}.apk" \
-            "release/mingyu-${ANDROID_VERSION}.apk.sha256" \
-            --verify-tag \
-            --title "命语 Android ${ANDROID_VERSION}" \
-            --generate-notes
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" \
+              "release/mingyu-${ANDROID_VERSION}.apk" \
+              "release/mingyu-${ANDROID_VERSION}.apk.sha256" \
+              --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              "release/mingyu-${ANDROID_VERSION}.apk" \
+              "release/mingyu-${ANDROID_VERSION}.apk.sha256" \
+              --verify-tag \
+              --title "命语 Android ${ANDROID_VERSION}" \
+              --generate-notes
+          fi
+      - name: 上传到蓝奏云线路
+        env:
+          LANZOU_API_TOKEN: ${{ secrets.LANZOU_API_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "$LANZOU_API_TOKEN" ]]; then
+            echo "缺少 LANZOU_API_TOKEN，已停止发布。" >&2
+            exit 1
+          fi
+          APK_PATH="release/mingyu-${ANDROID_VERSION}.apk"
+          APK_NAME="mingyu-${ANDROID_VERSION}.apk"
+          curl --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
+            --header "Authorization: Bearer ${LANZOU_API_TOKEN}" \
+            --header "Content-Type: application/octet-stream" \
+            --header "Content-Length: $(stat -c%s "$APK_PATH")" \
+            --data-binary "@${APK_PATH}" \
+            "https://lanzou-cloudflare-api.brhiza.workers.dev/v1/files?filename=${APK_NAME}&folder_id=13903360"

--- a/android/app/src/main/java/cc/aov/mingyu/AndroidAppUpdatePlugin.java
+++ b/android/app/src/main/java/cc/aov/mingyu/AndroidAppUpdatePlugin.java
@@ -85,12 +85,11 @@ public class AndroidAppUpdatePlugin extends Plugin {
         final URL apkUrl;
         final URL checksumUrl;
         try {
-            apkUrl = AndroidAppUpdateVerifier.requireReleaseAssetUrl(call.getString("apkUrl"), ".apk");
             checksumUrl = AndroidAppUpdateVerifier.requireReleaseAssetUrl(
                 call.getString("checksumUrl"),
                 ".sha256"
             );
-            AndroidAppUpdateVerifier.requireMatchingReleaseAssets(apkUrl, checksumUrl);
+            apkUrl = AndroidAppUpdateVerifier.requireOfficialApkUrl(call.getString("apkUrl"), checksumUrl);
         } catch (IllegalArgumentException error) {
             call.reject(error.getMessage(), error);
             return;
@@ -199,17 +198,17 @@ public class AndroidAppUpdatePlugin extends Plugin {
             if (status >= 200 && status < 300) return connection;
             if (status < 300 || status >= 400 || redirectCount == MAX_REDIRECTS) {
                 connection.disconnect();
-                throw new IOException("GitHub 更新下载失败（" + status + "）。");
+                throw new IOException("更新线路下载失败（" + status + "）。");
             }
             String location = connection.getHeaderField("Location");
             URL nextUrl = location == null ? null : new URL(currentUrl, location);
             connection.disconnect();
             if (!AndroidAppUpdateVerifier.isAllowedRedirectUrl(nextUrl)) {
-                throw new IOException("GitHub 返回了不受信任的更新地址。");
+                throw new IOException("更新线路返回了不受信任的地址。");
             }
             currentUrl = nextUrl;
         }
-        throw new IOException("GitHub 更新重定向次数过多。");
+        throw new IOException("更新线路重定向次数过多。");
     }
 
     private void copyWithLimit(InputStream input, java.io.OutputStream output, long limit) throws IOException {

--- a/android/app/src/main/java/cc/aov/mingyu/AndroidAppUpdateVerifier.java
+++ b/android/app/src/main/java/cc/aov/mingyu/AndroidAppUpdateVerifier.java
@@ -15,6 +15,9 @@ import java.util.regex.Pattern;
 final class AndroidAppUpdateVerifier {
     private static final Set<String> REDIRECT_HOSTS = Set.of(
         "github.com",
+        "gh-proxy.com",
+        "ghfast.top",
+        "lanzou-cloudflare-api.brhiza.workers.dev",
         "objects.githubusercontent.com",
         "release-assets.githubusercontent.com"
     );
@@ -27,6 +30,42 @@ final class AndroidAppUpdateVerifier {
     );
 
     private AndroidAppUpdateVerifier() {}
+
+    static URL requireOfficialApkUrl(String rawUrl, URL checksumUrl) {
+        Matcher checksumMatcher = RELEASE_ASSET_PATH_PATTERN.matcher(checksumUrl.getPath());
+        if (!checksumMatcher.matches() || !checksumMatcher.group(2).toLowerCase(Locale.ROOT).endsWith(".apk.sha256")) {
+            throw new IllegalArgumentException("更新校验地址无效。");
+        }
+        String tagName = checksumMatcher.group(1);
+        String apkName = checksumMatcher.group(2).substring(0, checksumMatcher.group(2).length() - ".sha256".length());
+        String version = tagName.substring("android-v".length());
+        String githubPath = "/Brhiza/mingyu/releases/download/" + tagName + "/" + apkName;
+        String acceleratedPath = "/https://github.com" + githubPath;
+        final URL url;
+        try {
+            url = new URL(rawUrl == null ? "" : rawUrl.trim());
+        } catch (MalformedURLException error) {
+            throw new IllegalArgumentException("更新地址无效。", error);
+        }
+        String host = url.getHost().toLowerCase(Locale.ROOT);
+        String path = url.getPath();
+        boolean matches = "github.com".equals(host) && githubPath.equals(path)
+            || "gh-proxy.com".equals(host) && acceleratedPath.equals(path)
+            || "ghfast.top".equals(host) && acceleratedPath.equals(path)
+            || "lanzou-cloudflare-api.brhiza.workers.dev".equals(host)
+                && ("/v1/public/mingyu/" + version).equals(path);
+        if (
+            !"https".equalsIgnoreCase(url.getProtocol())
+                || url.getUserInfo() != null
+                || url.getPort() != -1
+                || url.getQuery() != null
+                || url.getRef() != null
+                || !matches
+        ) {
+            throw new IllegalArgumentException("更新地址不是命语官方发布线路。");
+        }
+        return url;
+    }
 
     static URL requireReleaseAssetUrl(String rawUrl, String expectedSuffix) {
         final URL url;
@@ -76,8 +115,14 @@ final class AndroidAppUpdateVerifier {
         ) {
             return false;
         }
-        return !"github.com".equalsIgnoreCase(url.getHost()) ||
-            (url.getQuery() == null && RELEASE_ASSET_PATH_PATTERN.matcher(url.getPath()).matches());
+        String host = url.getHost().toLowerCase(Locale.ROOT);
+        if ("github.com".equals(host)) {
+            return url.getQuery() == null && RELEASE_ASSET_PATH_PATTERN.matcher(url.getPath()).matches();
+        }
+        if ("lanzou-cloudflare-api.brhiza.workers.dev".equals(host)) {
+            return url.getQuery() == null && url.getPath().matches("^/v1/public/mingyu/\\d+\\.\\d+\\.\\d+$");
+        }
+        return true;
     }
 
     static String parseSha256(String content) {

--- a/android/app/src/test/java/cc/aov/mingyu/AndroidAppUpdateVerifierTest.java
+++ b/android/app/src/test/java/cc/aov/mingyu/AndroidAppUpdateVerifierTest.java
@@ -63,6 +63,37 @@ public class AndroidAppUpdateVerifierTest {
     }
 
     @Test
+    public void acceptsOnlyTheFourOfficialApkRoutes() throws Exception {
+        URL checksum = new URL(
+            "https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk.sha256"
+        );
+        String github = "https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk";
+        assertEquals("github.com", AndroidAppUpdateVerifier.requireOfficialApkUrl(github, checksum).getHost());
+        assertEquals(
+            "lanzou-cloudflare-api.brhiza.workers.dev",
+            AndroidAppUpdateVerifier.requireOfficialApkUrl(
+                "https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.3",
+                checksum
+            ).getHost()
+        );
+        assertEquals(
+            "gh-proxy.com",
+            AndroidAppUpdateVerifier.requireOfficialApkUrl("https://gh-proxy.com/" + github, checksum).getHost()
+        );
+        assertEquals(
+            "ghfast.top",
+            AndroidAppUpdateVerifier.requireOfficialApkUrl("https://ghfast.top/" + github, checksum).getHost()
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AndroidAppUpdateVerifier.requireOfficialApkUrl(
+                "https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.4",
+                checksum
+            )
+        );
+    }
+
+    @Test
     public void validatesRedirectHostsAndChecksum() throws Exception {
         assertTrue(
             AndroidAppUpdateVerifier.isAllowedRedirectUrl(

--- a/src/components/AndroidAppUpdateDialog.tsx
+++ b/src/components/AndroidAppUpdateDialog.tsx
@@ -26,7 +26,32 @@ export function AndroidAppUpdateDialog({ updater }: AndroidAppUpdateDialogProps)
       </header>
       <div className="workspace-ui-dialog-body android-app-update-body">
         <p>{updater.message || '新版本已经可以安装。'}</p>
-        <small>更新包来自命语 GitHub Release，下载后会校验文件，再由系统安装器确认安装。</small>
+        <div className="android-update-routes" role="radiogroup" aria-label="下载线路">
+          {updater.routeProbes.map((route) => (
+            <button
+              key={route.id}
+              type="button"
+              className={updater.selectedRouteId === route.id ? 'is-selected' : ''}
+              disabled={busy || route.status === 'unavailable'}
+              onClick={() => updater.selectRoute(route.id)}
+              role="radio"
+              aria-checked={updater.selectedRouteId === route.id}
+            >
+              <span>{route.name}</span>
+              <span>
+                {route.status === 'testing'
+                  ? '测速中…'
+                  : route.status === 'available'
+                    ? `${route.latencyMs} ms`
+                    : '不可用'}
+              </span>
+            </button>
+          ))}
+        </div>
+        <WorkspaceButton disabled={busy} onClick={() => void updater.testRoutes()}>
+          重新测速
+        </WorkspaceButton>
+        <small>会自动选择响应最快的可用线路；下载后仍使用 GitHub 官方校验值验证安装包。</small>
       </div>
       <footer className="workspace-ui-dialog-footer">
         <WorkspaceButton disabled={busy} onClick={updater.dismissDialog}>

--- a/src/hooks/useAndroidAppUpdate.ts
+++ b/src/hooks/useAndroidAppUpdate.ts
@@ -123,10 +123,11 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
       }
       setStatus('downloading');
       setMessage('正在下载并校验更新包…');
-      const selectedUrl = release.downloadRoutes.find((route) => route.id === selectedRouteId)?.url
-        ?? selectBestAndroidRoute(routeProbes)?.url
-        ?? release.downloadRoutes[0]?.url
-        ?? release.apkUrl;
+      const selectedUrl =
+        release.downloadRoutes.find((route) => route.id === selectedRouteId)?.url ??
+        selectBestAndroidRoute(routeProbes)?.url ??
+        release.downloadRoutes[0]?.url ??
+        release.apkUrl;
       await downloadAndInstallAndroidUpdate(release, selectedUrl);
       setStatus('installer-opened');
       setMessage('已打开系统安装页面');

--- a/src/hooks/useAndroidAppUpdate.ts
+++ b/src/hooks/useAndroidAppUpdate.ts
@@ -10,6 +10,13 @@ import {
 } from '@/lib/android-app-update';
 import { isAndroidApp } from '@/lib/android-ai-app';
 import { safeStorage } from '@/lib/safe-storage';
+import {
+  createTestingRouteProbes,
+  probeAndroidDownloadRoutes,
+  selectBestAndroidRoute,
+  type AndroidDownloadRouteId,
+  type AndroidRouteProbe,
+} from '@/lib/android-update-routes';
 
 const LAST_CHECK_STORAGE_KEY = 'mingyu:android-update-last-check:v1';
 const AUTO_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -31,7 +38,11 @@ export type AndroidAppUpdateController = {
   status: AndroidUpdateStatus;
   message: string;
   dialogOpen: boolean;
+  routeProbes: AndroidRouteProbe[];
+  selectedRouteId: AndroidDownloadRouteId | null;
   checkForUpdates: (manual?: boolean) => Promise<void>;
+  testRoutes: () => Promise<void>;
+  selectRoute: (routeId: AndroidDownloadRouteId) => void;
   installUpdate: () => Promise<void>;
   dismissDialog: () => void;
 };
@@ -52,7 +63,17 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
   const [status, setStatus] = useState<AndroidUpdateStatus>('idle');
   const [message, setMessage] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [routeProbes, setRouteProbes] = useState<AndroidRouteProbe[]>([]);
+  const [selectedRouteId, setSelectedRouteId] = useState<AndroidDownloadRouteId | null>(null);
   const automaticCheckStartedRef = useRef(false);
+
+  const testReleaseRoutes = useCallback(async (targetRelease: AndroidReleaseInfo) => {
+    setRouteProbes(createTestingRouteProbes(targetRelease.downloadRoutes));
+    const probes = await probeAndroidDownloadRoutes(targetRelease.downloadRoutes);
+    setRouteProbes(probes);
+    const best = selectBestAndroidRoute(probes);
+    setSelectedRouteId(best?.id ?? targetRelease.downloadRoutes[0]?.id ?? null);
+  }, []);
 
   const checkForUpdates = useCallback(
     async (manual = false) => {
@@ -71,6 +92,7 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
           setStatus('available');
           setMessage(`发现新版本 ${latest.version}`);
           setDialogOpen(true);
+          void testReleaseRoutes(latest);
           return;
         }
         setStatus('up-to-date');
@@ -81,8 +103,12 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
         setMessage(getErrorMessage(error, '检查更新失败，请稍后重试'));
       }
     },
-    [supported],
+    [supported, testReleaseRoutes],
   );
+
+  const testRoutes = useCallback(async () => {
+    if (release) await testReleaseRoutes(release);
+  }, [release, testReleaseRoutes]);
 
   const installUpdate = useCallback(async () => {
     if (!supported || !release) return;
@@ -97,14 +123,18 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
       }
       setStatus('downloading');
       setMessage('正在下载并校验更新包…');
-      await downloadAndInstallAndroidUpdate(release);
+      const selectedUrl = release.downloadRoutes.find((route) => route.id === selectedRouteId)?.url
+        ?? selectBestAndroidRoute(routeProbes)?.url
+        ?? release.downloadRoutes[0]?.url
+        ?? release.apkUrl;
+      await downloadAndInstallAndroidUpdate(release, selectedUrl);
       setStatus('installer-opened');
       setMessage('已打开系统安装页面');
     } catch (error) {
       setStatus('error');
       setMessage(getErrorMessage(error, '下载更新失败，请稍后重试'));
     }
-  }, [release, supported]);
+  }, [release, routeProbes, selectedRouteId, supported]);
 
   useEffect(() => {
     if (!supported) return;
@@ -124,7 +154,11 @@ export function useAndroidAppUpdate(): AndroidAppUpdateController {
     status,
     message,
     dialogOpen,
+    routeProbes,
+    selectedRouteId,
     checkForUpdates,
+    testRoutes,
+    selectRoute: setSelectedRouteId,
     installUpdate,
     dismissDialog: () => setDialogOpen(false),
   };

--- a/src/lib/android-app-update.ts
+++ b/src/lib/android-app-update.ts
@@ -1,5 +1,6 @@
 import { registerPlugin } from '@capacitor/core';
 import { isAndroidApp } from '@/lib/android-ai-app';
+import { buildAndroidDownloadRoutes, type AndroidDownloadRoute } from '@/lib/android-update-routes';
 
 const RELEASE_API_URL = 'https://api.github.com/repos/Brhiza/mingyu/releases?per_page=100';
 const RELEASE_DOWNLOAD_PREFIX = 'https://github.com/Brhiza/mingyu/releases/download/';
@@ -17,6 +18,7 @@ export interface AndroidReleaseInfo {
   apkUrl: string;
   checksumUrl: string;
   releaseUrl: string;
+  downloadRoutes: AndroidDownloadRoute[];
 }
 
 interface AndroidAppUpdatePlugin {
@@ -88,7 +90,14 @@ export function normalizeAndroidRelease(value: unknown): AndroidReleaseInfo | nu
     release.html_url === `https://github.com/Brhiza/mingyu/releases/tag/${tagName}`
       ? release.html_url
       : `https://github.com/Brhiza/mingyu/releases/tag/${tagName}`;
-  return { version, tagName, apkUrl, checksumUrl, releaseUrl };
+  return {
+    version,
+    tagName,
+    apkUrl,
+    checksumUrl,
+    releaseUrl,
+    downloadRoutes: buildAndroidDownloadRoutes(version, apkUrl),
+  };
 }
 
 export async function getAndroidAppInfo(): Promise<AndroidAppInfo | null> {
@@ -123,9 +132,12 @@ export async function openAndroidInstallPermission(): Promise<void> {
   await AndroidAppUpdate.openInstallPermission();
 }
 
-export async function downloadAndInstallAndroidUpdate(release: AndroidReleaseInfo): Promise<void> {
+export async function downloadAndInstallAndroidUpdate(
+  release: AndroidReleaseInfo,
+  apkUrl = release.apkUrl,
+): Promise<void> {
   await AndroidAppUpdate.downloadAndInstall({
-    apkUrl: release.apkUrl,
+    apkUrl,
     checksumUrl: release.checksumUrl,
   });
 }

--- a/src/lib/android-update-routes.ts
+++ b/src/lib/android-update-routes.ts
@@ -1,0 +1,69 @@
+export type AndroidDownloadRouteId = 'lanzou' | 'github' | 'gh-proxy' | 'ghfast';
+
+export type AndroidDownloadRoute = {
+  id: AndroidDownloadRouteId;
+  name: string;
+  url: string;
+  priority: number;
+};
+
+export type AndroidRouteProbe = AndroidDownloadRoute & {
+  status: 'testing' | 'available' | 'unavailable';
+  latencyMs: number | null;
+};
+
+const PROBE_TIMEOUT_MS = 8_000;
+
+export function buildAndroidDownloadRoutes(version: string, githubUrl: string): AndroidDownloadRoute[] {
+  const encodedVersion = encodeURIComponent(version);
+  return [
+    {
+      id: 'lanzou',
+      name: '线路 1 · 蓝奏云',
+      url: `https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/${encodedVersion}`,
+      priority: 1,
+    },
+    { id: 'github', name: '线路 2 · GitHub 直连', url: githubUrl, priority: 2 },
+    { id: 'gh-proxy', name: '线路 3 · GitHub 加速', url: `https://gh-proxy.com/${githubUrl}`, priority: 3 },
+    { id: 'ghfast', name: '线路 4 · GitHub 加速', url: `https://ghfast.top/${githubUrl}`, priority: 4 },
+  ];
+}
+
+export function createTestingRouteProbes(routes: readonly AndroidDownloadRoute[]): AndroidRouteProbe[] {
+  return routes.map((route) => ({ ...route, status: 'testing', latencyMs: null }));
+}
+
+export function selectBestAndroidRoute(probes: readonly AndroidRouteProbe[]): AndroidRouteProbe | null {
+  return [...probes]
+    .filter((probe) => probe.status === 'available' && probe.latencyMs !== null)
+    .sort((left, right) => (left.latencyMs! - right.latencyMs!) || (left.priority - right.priority))[0] ?? null;
+}
+
+export async function probeAndroidDownloadRoutes(
+  routes: readonly AndroidDownloadRoute[],
+  fetcher: typeof fetch = fetch,
+  timeoutMs = PROBE_TIMEOUT_MS,
+): Promise<AndroidRouteProbe[]> {
+  return Promise.all(routes.map(async (route) => {
+    const controller = new AbortController();
+    const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+    const startedAt = Date.now();
+    try {
+      const response = await fetcher(route.url, {
+        method: 'HEAD',
+        cache: 'no-store',
+        redirect: 'follow',
+        signal: controller.signal,
+      });
+      return {
+        ...route,
+        status: response.ok ? 'available' as const : 'unavailable' as const,
+        latencyMs: response.ok ? Math.max(1, Date.now() - startedAt) : null,
+      };
+    } catch {
+      return { ...route, status: 'unavailable' as const, latencyMs: null };
+    } finally {
+      globalThis.clearTimeout(timer);
+    }
+  }));
+}

--- a/src/lib/android-update-routes.ts
+++ b/src/lib/android-update-routes.ts
@@ -14,6 +14,28 @@ export type AndroidRouteProbe = AndroidDownloadRoute & {
 
 const PROBE_TIMEOUT_MS = 8_000;
 
+async function fetchRouteProbe(
+  route: AndroidDownloadRoute,
+  fetcher: typeof fetch,
+  signal: AbortSignal,
+): Promise<Response> {
+  const headResponse = await fetcher(route.url, {
+    method: 'HEAD',
+    cache: 'no-store',
+    redirect: 'follow',
+    signal,
+  });
+  if (headResponse.ok || route.id !== 'gh-proxy') return headResponse;
+  await headResponse.body?.cancel().catch(() => undefined);
+  return fetcher(route.url, {
+    method: 'GET',
+    headers: { Range: 'bytes=0-0' },
+    cache: 'no-store',
+    redirect: 'follow',
+    signal,
+  });
+}
+
 export function buildAndroidDownloadRoutes(
   version: string,
   githubUrl: string,
@@ -71,12 +93,8 @@ export async function probeAndroidDownloadRoutes(
       const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
       const startedAt = Date.now();
       try {
-        const response = await fetcher(route.url, {
-          method: 'HEAD',
-          cache: 'no-store',
-          redirect: 'follow',
-          signal: controller.signal,
-        });
+        const response = await fetchRouteProbe(route, fetcher, controller.signal);
+        await response.body?.cancel().catch(() => undefined);
         return {
           ...route,
           status: response.ok ? ('available' as const) : ('unavailable' as const),

--- a/src/lib/android-update-routes.ts
+++ b/src/lib/android-update-routes.ts
@@ -14,7 +14,10 @@ export type AndroidRouteProbe = AndroidDownloadRoute & {
 
 const PROBE_TIMEOUT_MS = 8_000;
 
-export function buildAndroidDownloadRoutes(version: string, githubUrl: string): AndroidDownloadRoute[] {
+export function buildAndroidDownloadRoutes(
+  version: string,
+  githubUrl: string,
+): AndroidDownloadRoute[] {
   const encodedVersion = encodeURIComponent(version);
   return [
     {
@@ -24,19 +27,37 @@ export function buildAndroidDownloadRoutes(version: string, githubUrl: string): 
       priority: 1,
     },
     { id: 'github', name: '线路 2 · GitHub 直连', url: githubUrl, priority: 2 },
-    { id: 'gh-proxy', name: '线路 3 · GitHub 加速', url: `https://gh-proxy.com/${githubUrl}`, priority: 3 },
-    { id: 'ghfast', name: '线路 4 · GitHub 加速', url: `https://ghfast.top/${githubUrl}`, priority: 4 },
+    {
+      id: 'gh-proxy',
+      name: '线路 3 · GitHub 加速',
+      url: `https://gh-proxy.com/${githubUrl}`,
+      priority: 3,
+    },
+    {
+      id: 'ghfast',
+      name: '线路 4 · GitHub 加速',
+      url: `https://ghfast.top/${githubUrl}`,
+      priority: 4,
+    },
   ];
 }
 
-export function createTestingRouteProbes(routes: readonly AndroidDownloadRoute[]): AndroidRouteProbe[] {
+export function createTestingRouteProbes(
+  routes: readonly AndroidDownloadRoute[],
+): AndroidRouteProbe[] {
   return routes.map((route) => ({ ...route, status: 'testing', latencyMs: null }));
 }
 
-export function selectBestAndroidRoute(probes: readonly AndroidRouteProbe[]): AndroidRouteProbe | null {
-  return [...probes]
-    .filter((probe) => probe.status === 'available' && probe.latencyMs !== null)
-    .sort((left, right) => (left.latencyMs! - right.latencyMs!) || (left.priority - right.priority))[0] ?? null;
+export function selectBestAndroidRoute(
+  probes: readonly AndroidRouteProbe[],
+): AndroidRouteProbe | null {
+  return (
+    [...probes]
+      .filter((probe) => probe.status === 'available' && probe.latencyMs !== null)
+      .sort(
+        (left, right) => left.latencyMs! - right.latencyMs! || left.priority - right.priority,
+      )[0] ?? null
+  );
 }
 
 export async function probeAndroidDownloadRoutes(
@@ -44,26 +65,28 @@ export async function probeAndroidDownloadRoutes(
   fetcher: typeof fetch = fetch,
   timeoutMs = PROBE_TIMEOUT_MS,
 ): Promise<AndroidRouteProbe[]> {
-  return Promise.all(routes.map(async (route) => {
-    const controller = new AbortController();
-    const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
-    const startedAt = Date.now();
-    try {
-      const response = await fetcher(route.url, {
-        method: 'HEAD',
-        cache: 'no-store',
-        redirect: 'follow',
-        signal: controller.signal,
-      });
-      return {
-        ...route,
-        status: response.ok ? 'available' as const : 'unavailable' as const,
-        latencyMs: response.ok ? Math.max(1, Date.now() - startedAt) : null,
-      };
-    } catch {
-      return { ...route, status: 'unavailable' as const, latencyMs: null };
-    } finally {
-      globalThis.clearTimeout(timer);
-    }
-  }));
+  return Promise.all(
+    routes.map(async (route) => {
+      const controller = new AbortController();
+      const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+      const startedAt = Date.now();
+      try {
+        const response = await fetcher(route.url, {
+          method: 'HEAD',
+          cache: 'no-store',
+          redirect: 'follow',
+          signal: controller.signal,
+        });
+        return {
+          ...route,
+          status: response.ok ? ('available' as const) : ('unavailable' as const),
+          latencyMs: response.ok ? Math.max(1, Date.now() - startedAt) : null,
+        };
+      } catch {
+        return { ...route, status: 'unavailable' as const, latencyMs: null };
+      } finally {
+        globalThis.clearTimeout(timer);
+      }
+    }),
+  );
 }

--- a/src/workspace-ui.css
+++ b/src/workspace-ui.css
@@ -1615,6 +1615,33 @@ label.workspace-ui-field > span:first-child {
   line-height: 1.65;
 }
 
+.android-update-routes {
+  display: grid;
+  gap: 6px;
+}
+
+.android-update-routes button {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  background: var(--surface-soft);
+  cursor: pointer;
+}
+
+.android-update-routes button.is-selected {
+  border-color: var(--accent-color);
+  color: var(--text-primary);
+}
+
+.android-update-routes button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 .android-app-update-body p {
   color: var(--text-secondary);
   font-size: 14px;

--- a/tests/android-app-update.test.ts
+++ b/tests/android-app-update.test.ts
@@ -61,15 +61,24 @@ test('更新检查会跳过其他用途的 GitHub Release', async () => {
 });
 
 test('Android 更新生成蓝奏云、GitHub 直连和两个加速线路', () => {
-  const githubUrl = 'https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk';
+  const githubUrl =
+    'https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk';
   const routes = buildAndroidDownloadRoutes('1.2.3', githubUrl);
-  assert.deepEqual(routes.map((route) => route.id), ['lanzou', 'github', 'gh-proxy', 'ghfast']);
-  assert.equal(routes[0]?.url, 'https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.3');
+  assert.deepEqual(
+    routes.map((route) => route.id),
+    ['lanzou', 'github', 'gh-proxy', 'ghfast'],
+  );
+  assert.equal(
+    routes[0]?.url,
+    'https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.3',
+  );
 });
 
 test('线路测速会跳过失败线路并自动选择最低延迟', async () => {
   const routes = buildAndroidDownloadRoutes('1.2.3', 'https://github.com/example.apk');
-  const probes = await probeAndroidDownloadRoutes(routes.slice(0, 3), (async (url: RequestInfo | URL) => {
+  const probes = await probeAndroidDownloadRoutes(routes.slice(0, 3), (async (
+    url: RequestInfo | URL,
+  ) => {
     const value = String(url);
     await new Promise((resolve) => setTimeout(resolve, value.includes('gh-proxy') ? 2 : 12));
     return new Response(null, {
@@ -77,11 +86,14 @@ test('线路测速会跳过失败线路并自动选择最低延迟', async () =>
     });
   }) as typeof fetch);
   assert.equal(probes[1]?.status, 'unavailable');
-  assert.equal(selectBestAndroidRoute([
-    { ...routes[0]!, status: 'available', latencyMs: 40 },
-    { ...routes[1]!, status: 'unavailable', latencyMs: null },
-    { ...routes[2]!, status: 'available', latencyMs: 12 },
-  ])?.id, 'gh-proxy');
+  assert.equal(
+    selectBestAndroidRoute([
+      { ...routes[0]!, status: 'available', latencyMs: 40 },
+      { ...routes[1]!, status: 'unavailable', latencyMs: null },
+      { ...routes[2]!, status: 'available', latencyMs: 12 },
+    ])?.id,
+    'gh-proxy',
+  );
 });
 
 test('APK 工作流覆盖调试构建、正式签名、校验文件和 Release', async () => {

--- a/tests/android-app-update.test.ts
+++ b/tests/android-app-update.test.ts
@@ -6,6 +6,11 @@ import {
   fetchLatestAndroidRelease,
   normalizeAndroidRelease,
 } from '../src/lib/android-app-update.ts';
+import {
+  buildAndroidDownloadRoutes,
+  probeAndroidDownloadRoutes,
+  selectBestAndroidRoute,
+} from '../src/lib/android-update-routes.ts';
 
 function buildRelease(version = '1.2.3') {
   const tagName = `android-v${version}`;
@@ -55,6 +60,30 @@ test('更新检查会跳过其他用途的 GitHub Release', async () => {
   assert.equal(result?.version, '2.0.0');
 });
 
+test('Android 更新生成蓝奏云、GitHub 直连和两个加速线路', () => {
+  const githubUrl = 'https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk';
+  const routes = buildAndroidDownloadRoutes('1.2.3', githubUrl);
+  assert.deepEqual(routes.map((route) => route.id), ['lanzou', 'github', 'gh-proxy', 'ghfast']);
+  assert.equal(routes[0]?.url, 'https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.3');
+});
+
+test('线路测速会跳过失败线路并自动选择最低延迟', async () => {
+  const routes = buildAndroidDownloadRoutes('1.2.3', 'https://github.com/example.apk');
+  const probes = await probeAndroidDownloadRoutes(routes.slice(0, 3), (async (url: RequestInfo | URL) => {
+    const value = String(url);
+    await new Promise((resolve) => setTimeout(resolve, value.includes('gh-proxy') ? 2 : 12));
+    return new Response(null, {
+      status: value.startsWith('https://github.com/') ? 503 : 200,
+    });
+  }) as typeof fetch);
+  assert.equal(probes[1]?.status, 'unavailable');
+  assert.equal(selectBestAndroidRoute([
+    { ...routes[0]!, status: 'available', latencyMs: 40 },
+    { ...routes[1]!, status: 'unavailable', latencyMs: null },
+    { ...routes[2]!, status: 'available', latencyMs: 12 },
+  ])?.id, 'gh-proxy');
+});
+
 test('APK 工作流覆盖调试构建、正式签名、校验文件和 Release', async () => {
   const workflow = await readFile('.github/workflows/android-apk.yml', 'utf8');
   assert.match(workflow, /pull_request:/);
@@ -64,4 +93,5 @@ test('APK 工作流覆盖调试构建、正式签名、校验文件和 Release',
   assert.match(workflow, /APKSIGNER.*verify/);
   assert.match(workflow, /sha256sum/);
   assert.match(workflow, /gh release create/);
+  assert.match(workflow, /LANZOU_API_TOKEN/);
 });

--- a/tests/android-app-update.test.ts
+++ b/tests/android-app-update.test.ts
@@ -96,6 +96,20 @@ test('线路测速会跳过失败线路并自动选择最低延迟', async () =>
   );
 });
 
+test('GitHub 加速线路拒绝 HEAD 时改用单字节 Range 测速', async () => {
+  const route = buildAndroidDownloadRoutes('1.2.3', 'https://github.com/example.apk')[2]!;
+  const methods: string[] = [];
+  const probes = await probeAndroidDownloadRoutes([route], (async (
+    _url: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    methods.push(init?.method || 'GET');
+    return new Response(null, { status: init?.method === 'GET' ? 206 : 500 });
+  }) as typeof fetch);
+  assert.deepEqual(methods, ['HEAD', 'GET']);
+  assert.equal(probes[0]?.status, 'available');
+});
+
 test('APK 工作流覆盖调试构建、正式签名、校验文件和 Release', async () => {
   const workflow = await readFile('.github/workflows/android-apk.yml', 'utf8');
   assert.match(workflow, /pull_request:/);


### PR DESCRIPTION
## 改动内容
- Android 更新增加蓝奏云、GitHub 直连和两个 GitHub 加速线路
- 对四条线路并行执行 HEAD 测速并自动选择响应最快的可用线路，仍允许手动切换和重新测速
- 原生层严格限制官方更新地址，安装前继续使用 GitHub 官方 SHA-256 校验
- 正式 Release 工作流自动把同一签名 APK 上传到命语蓝奏云文件夹

## 验证
- 1246 项前端单元测试通过
- Vite 生产构建通过
- Android testDebugUnitTest 通过
- 蓝奏云 Worker 21 项测试和线上路由检查通过