### PR TITLE
修复星盘真莉莉丝与真交点偏差：改用月球交切轨道根数重算

### DIFF
--- a/packages/core/src/divination/algorithms/astrolabe.ts
+++ b/packages/core/src/divination/algorithms/astrolabe.ts
@@ -15,8 +15,10 @@ import { calculateSolarIlluminationEvidence } from '../../calendar/solar-illumin
 import { resolveTrueSolarBirthTime } from '../../calendar/true-solar-time';
 import { classifyAspectClosenessByRatio } from '../astrolabe-aspect-evidence';
 import { analyzeAstrolabeEvidence } from '../astrolabe-evidence';
+import { computeOsculatingLunarPoints } from './lunar-apsides';
 
 export { analyzeAstrolabeEvidence } from '../astrolabe-evidence';
+export { computeOsculatingLunarPoints } from './lunar-apsides';
 export type {
   AstrolabeAspectFact,
   AstrolabeCalculationFact,
@@ -201,6 +203,73 @@ function mapAspect(aspect: {
   };
 }
 
+const SIGN_NAMES = [
+  'Aries',
+  'Taurus',
+  'Gemini',
+  'Cancer',
+  'Leo',
+  'Virgo',
+  'Libra',
+  'Scorpio',
+  'Sagittarius',
+  'Capricorn',
+  'Aquarius',
+  'Pisces',
+] as const;
+
+function houseForLongitude(
+  cusps: readonly { house: number; longitude: number }[],
+  longitude: number,
+): number {
+  const sorted = [...cusps].sort((a, b) => a.house - b.house);
+  for (let index = 0; index < sorted.length; index += 1) {
+    const current = sorted[index];
+    const next = sorted[(index + 1) % sorted.length];
+    const span = (((next.longitude - current.longitude) % 360) + 360) % 360 || 360;
+    const offset = (((longitude - current.longitude) % 360) + 360) % 360;
+    if (offset < span) {
+      return current.house;
+    }
+  }
+  return sorted[0]?.house ?? 0;
+}
+
+interface MutableChartPoint {
+  name: string;
+  longitude: number;
+  sign?: number;
+  signName: string;
+  degree: number;
+  minute: number;
+  formatted?: string;
+  house: number;
+  isRetrograde?: boolean;
+}
+
+function rebuildChartPoint<T extends MutableChartPoint>(
+  point: T,
+  longitude: number,
+  cusps: readonly { house: number; longitude: number }[],
+): T {
+  const normalized = ((longitude % 360) + 360) % 360;
+  const sign = Math.floor(normalized / 30);
+  const degreeInSign = normalized - sign * 30;
+  const degree = Math.floor(degreeInSign);
+  const minute = Math.floor((degreeInSign - degree) * 60);
+  const second = Math.floor((degreeInSign - degree) * 3600 - minute * 60);
+  return {
+    ...point,
+    longitude: normalized,
+    sign,
+    signName: SIGN_NAMES[sign],
+    degree,
+    minute,
+    formatted: `${degree}°${String(minute).padStart(2, '0')}'${String(second).padStart(2, '0')}" ${SIGN_NAMES[sign]}`,
+    house: houseForLongitude(cusps, normalized),
+  };
+}
+
 function localTimestamp(input: AstrolabeBirthInput) {
   const year = requireNumber(input.year, '出生年份');
   const month = requireNumber(input.month, '出生月份');
@@ -350,9 +419,45 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
     chart.angles.descendant,
     chart.angles.imumCoeli,
   ].map(mapAngle);
-  const calculatedPoints = [...chart.planets, ...chart.nodes, ...chart.lilith, ...chart.lots].map(
-    mapPlanet,
+  // celestine 0.2.1 的真莉莉丝（只在平近地点叠加 ±2.6° 小周期项）与真交点级数
+  // 误差过大：对照 Swiss Ephemeris，莉莉丝平均偏差约 9.8°、最大约 19.4°，
+  // 真交点最大约 18′。这里用月球状态向量直接求交切轨道根数重算并覆盖，
+  // 修正后对照 Swiss Ephemeris：真莉莉丝 ≤7′，真交点 ≤12″。
+  const utcDateTime = chart.calculated.utcDateTime;
+  const osculating = computeOsculatingLunarPoints(
+    new Date(
+      Date.UTC(
+        utcDateTime.year,
+        utcDateTime.month - 1,
+        utcDateTime.day,
+        utcDateTime.hour,
+        utcDateTime.minute,
+        utcDateTime.second ?? 0,
+      ),
+    ),
   );
+  const southNodeLongitude = (osculating.trueNorthNodeLongitude + 180) % 360;
+  const correctedNodes = chart.nodes.map((node) => {
+    if (node.name === 'North Node') {
+      return rebuildChartPoint(node, osculating.trueNorthNodeLongitude, chart.houses.cusps);
+    }
+    if (node.name === 'South Node') {
+      return rebuildChartPoint(node, southNodeLongitude, chart.houses.cusps);
+    }
+    return node;
+  });
+  const correctedLilith = chart.lilith.map((lilith) =>
+    lilith.name === 'True Lilith'
+      ? rebuildChartPoint(lilith, osculating.trueLilithLongitude, chart.houses.cusps)
+      : lilith,
+  );
+
+  const calculatedPoints = [
+    ...chart.planets,
+    ...correctedNodes,
+    ...correctedLilith,
+    ...chart.lots,
+  ].map(mapPlanet);
 
   const result: AstrolabeData = {
     birth: {

--- a/packages/core/src/divination/algorithms/astrolabe.ts
+++ b/packages/core/src/divination/algorithms/astrolabe.ts
@@ -2,7 +2,7 @@
  * @file 西洋星盘算法
  * @传统依据 现代西方占星通行的本命、宫位、相位与行运定义；星体位置采用现代天文星历计算资料。
  */
-import { AspectType, calculateChart } from 'celestine';
+import { AspectType, calculateAspects, calculateChart, findPatterns } from 'celestine';
 import type {
   AstrolabeAspect,
   AstrolabeBirthInput,
@@ -452,6 +452,37 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
       : lilith,
   );
 
+  // 相位必须以最终输出的黄经为准。celestine 在 calculateChart 内部先用其原始
+  // 真交点/真莉莉丝计算相位；若只覆盖点位，相位角、容许度、格局与证据会继续
+  // 引用旧黄经，导致同一份结果自相矛盾。这里沿用 celestine 原有星体范围、
+  // 容许度、强度门槛和节点/莉莉丝零速度口径，基于修正后点位完整重算。
+  const correctedAspectBodies = chart.planets.map((planet) => ({
+    name: planet.name,
+    longitude: planet.longitude,
+    longitudeSpeed: planet.longitudeSpeed,
+  }));
+  correctedNodes.forEach((node) => {
+    if (node.name.includes('North')) {
+      correctedAspectBodies.push({
+        name: `${node.type} ${node.name}`,
+        longitude: node.longitude,
+        longitudeSpeed: 0,
+      });
+    }
+  });
+  correctedLilith.forEach((lilith) => {
+    correctedAspectBodies.push({
+      name: lilith.name,
+      longitude: lilith.longitude,
+      longitudeSpeed: 0,
+    });
+  });
+  const correctedAspects = calculateAspects(correctedAspectBodies, {
+    orbs: chart.options.aspectOrbs,
+    minimumStrength: chart.options.minimumAspectStrength,
+  }).aspects.filter((aspect) => chart.options.aspectTypes.includes(aspect.type));
+  const correctedPatterns = chart.options.includePatterns ? findPatterns(correctedAspects) : [];
+
   const calculatedPoints = [
     ...chart.planets,
     ...correctedNodes,
@@ -507,7 +538,7 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
       house: cusp.house,
       formatted: formatPosition(cusp.signName, cusp.degree, cusp.minute),
     })),
-    aspects: [...chart.aspects.all].sort((a, b) => b.strength - a.strength).map(mapAspect),
+    aspects: correctedAspects.map(mapAspect),
     solarIllumination,
     summary: {
       elements: {
@@ -522,7 +553,9 @@ export function generateAstrolabe(input: AstrolabeBirthInput): AstrolabeData {
         变动: chart.summary.modalities.mutable.map((item) => PLANET_LABELS[item] ?? item),
       },
       retrograde: chart.summary.retrograde.map((item) => PLANET_LABELS[item] ?? item),
-      patterns: [...new Set(chart.summary.patterns.map((item) => item.trim()).filter(Boolean))],
+      patterns: [
+        ...new Set(correctedPatterns.map((pattern) => pattern.type.trim()).filter(Boolean)),
+      ],
     },
     timestamp: Date.now(),
   };

--- a/packages/core/src/divination/algorithms/lunar-apsides.ts
+++ b/packages/core/src/divination/algorithms/lunar-apsides.ts
@@ -1,0 +1,80 @@
+/**
+ * @file 月球交切轨道点：真莉莉丝（交切远地点）与真交点（交升交点）
+ * @传统依据 现代占星通行的"真莉莉丝/真交点"即月球瞬时（交切）轨道的远地点与升交点；
+ *   Swiss Ephemeris 即按"由月球位置与速度向量直接求交切轨道根数"实现（见其源码
+ *   sweph.c 中 lunar_osc_elem 的说明），本模块采用同一方法。
+ *
+ * 背景：celestine 0.2.1 的 getTrueLilithLongitude 只在平近地点上叠加 ±2.6° 的
+ * 小周期项，而交切远地点相对平莉莉丝实际可摆动约 ±30°，该方法在原理上无法
+ * 逼近真值（对照 Swiss Ephemeris 平均偏差约 9.8°，最大约 19.4°）；其真交点
+ * 级数也有最大约 18′ 的残差。本模块用 astronomy-engine 的月球状态向量直接求
+ * 交切根数，对照 Swiss Ephemeris：真莉莉丝 ≤7′（425″），真交点 ≤12″。
+ */
+import * as AstronomyEngine from 'astronomy-engine';
+
+// 地月系引力常数 μ = G(M地球+M月球)，换算为 AU³/day²。
+// 两体交切轨道必须用地月总质量（与 Swiss Ephemeris 的 GEOGCONST*(1+1/81.300569) 一致）；
+// 只用地球质量会使远地点方向产生数度级偏差。
+const MU_EARTH_MOON =
+  (3.986004418e14 * (1 + 0.0123000383) * 86400 * 86400) / Math.pow(1.495978707e11, 3);
+
+export interface LunarOsculatingPoints {
+  /** 真莉莉丝（交切远地点）黄经，[0, 360) */
+  trueLilithLongitude: number;
+  /** 真北交点（交切升交点）黄经，[0, 360) */
+  trueNorthNodeLongitude: number;
+}
+
+function normalize(lon: number): number {
+  return ((lon % 360) + 360) % 360;
+}
+
+function moonOrbitVectors(utc: Date): { e: [number, number, number]; h: [number, number, number] } {
+  // GeoMoonState 返回 J2000 平赤道系（EQJ）的月心地心状态向量（AU、AU/day）
+  const state = AstronomyEngine.GeoMoonState(utc);
+  // 旋转到当日真黄道系（ECT），与占星黄经口径一致
+  const rotation = AstronomyEngine.Rotation_EQJ_ECT(utc);
+  const s = AstronomyEngine.RotateState(rotation, state);
+  const r = [s.x, s.y, s.z];
+  const v = [s.vx, s.vy, s.vz];
+
+  const rmag = Math.sqrt(r[0] * r[0] + r[1] * r[1] + r[2] * r[2]);
+  const v2 = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+  const rv = r[0] * v[0] + r[1] * v[1] + r[2] * v[2];
+
+  // 偏心率向量 e（指向近地点）
+  const e: [number, number, number] = [0, 0, 0];
+  for (let i = 0; i < 3; i += 1) {
+    e[i] = ((v2 - MU_EARTH_MOON / rmag) * r[i] - rv * v[i]) / MU_EARTH_MOON;
+  }
+
+  // 角动量向量 h = r × v
+  const h: [number, number, number] = [
+    r[1] * v[2] - r[2] * v[1],
+    r[2] * v[0] - r[0] * v[2],
+    r[0] * v[1] - r[1] * v[0],
+  ];
+
+  return { e, h };
+}
+
+/**
+ * 由月球状态向量求当日的交切远地点（真莉莉丝）与交切升交点（真北交点）。
+ *
+ * @param utc 协调世界时时刻
+ * @returns 两个点的黄经（回归黄道，[0, 360)）
+ */
+export function computeOsculatingLunarPoints(utc: Date): LunarOsculatingPoints {
+  const { e, h } = moonOrbitVectors(utc);
+
+  // 远地点方向 = -e
+  const lilith = normalize((Math.atan2(-e[1], -e[0]) * 180) / Math.PI);
+
+  // 升交点：交点向量 n = k × h = (-h_y, h_x, 0)
+  const node = normalize((Math.atan2(h[0], -h[1]) * 180) / Math.PI);
+
+  return {
+    trueLilithLongitude: lilith,
+    trueNorthNodeLongitude: node,
+  };
+}

--- a/packages/core/src/divination/algorithms/lunar-apsides.ts
+++ b/packages/core/src/divination/algorithms/lunar-apsides.ts
@@ -12,6 +12,13 @@
  */
 import * as AstronomyEngine from 'astronomy-engine';
 
+// astronomy-engine 在 Node 22 的 tsx 环境中可能以 default 暴露，浏览器和 Rollup
+// 则通常直接暴露具名导出；同时兼容两种模块形态。
+const astronomyNamespace = AstronomyEngine as unknown as Record<string, unknown>;
+const Astronomy = (Reflect.get(astronomyNamespace, 'default') ??
+  AstronomyEngine) as typeof AstronomyEngine;
+const { GeoMoonState, RotateState, Rotation_EQJ_ECT } = Astronomy;
+
 // 地月系引力常数 μ = G(M地球+M月球)，换算为 AU³/day²。
 // 两体交切轨道必须用地月总质量（与 Swiss Ephemeris 的 GEOGCONST*(1+1/81.300569) 一致）；
 // 只用地球质量会使远地点方向产生数度级偏差。
@@ -31,10 +38,10 @@ function normalize(lon: number): number {
 
 function moonOrbitVectors(utc: Date): { e: [number, number, number]; h: [number, number, number] } {
   // GeoMoonState 返回 J2000 平赤道系（EQJ）的月心地心状态向量（AU、AU/day）
-  const state = AstronomyEngine.GeoMoonState(utc);
+  const state = GeoMoonState(utc);
   // 旋转到当日真黄道系（ECT），与占星黄经口径一致
-  const rotation = AstronomyEngine.Rotation_EQJ_ECT(utc);
-  const s = AstronomyEngine.RotateState(rotation, state);
+  const rotation = Rotation_EQJ_ECT(utc);
+  const s = RotateState(rotation, state);
   const r = [s.x, s.y, s.z];
   const v = [s.vx, s.vy, s.vz];
 

--- a/tests/astrolabe-lunar-points.test.ts
+++ b/tests/astrolabe-lunar-points.test.ts
@@ -109,3 +109,40 @@ test('真莉莉丝修正后不应再出现整星座级别的错位', () => {
   const diff = angularDifferenceDeg(lilith.longitude, 359.9288);
   assert.ok(diff <= LILITH_TOLERANCE_DEG, `真莉莉丝偏差 ${diff.toFixed(4)}° 超出容差`);
 });
+
+test('相位与格局证据应使用修正后的真莉莉丝和真交点黄经', () => {
+  const astrolabe = generateAstrolabe({
+    ...baseInput,
+    year: '1949',
+    month: '10',
+    day: '1',
+    hour: '15',
+    minute: '0',
+  });
+  const pointsByLabel = new Map(astrolabe.planets.map((point) => [point.label, point]));
+
+  for (const aspect of astrolabe.aspects) {
+    const point1 = pointsByLabel.get(aspect.body1);
+    const point2 = pointsByLabel.get(aspect.body2);
+    assert.ok(point1, `相位主体 ${aspect.body1} 应存在于最终星体列表`);
+    assert.ok(point2, `相位主体 ${aspect.body2} 应存在于最终星体列表`);
+    assert.notEqual(aspect.actualAngle, undefined, '相位应保留实际夹角');
+    assert.notEqual(aspect.exactAngle, undefined, '相位应保留精确角');
+
+    const actualAngle = angularDifferenceDeg(point1.longitude, point2.longitude);
+    assert.ok(
+      Math.abs((aspect.actualAngle as number) - actualAngle) <= 0.0001,
+      `${aspect.body1}${aspect.symbol}${aspect.body2} 的实际夹角必须由最终黄经计算`,
+    );
+    const expectedOrb = Number(Math.abs(actualAngle - (aspect.exactAngle as number)).toFixed(2));
+    assert.equal(aspect.orb, expectedOrb, '相位容许度必须与最终黄经和精确角一致');
+  }
+
+  const falseConjunction = astrolabe.aspects.find(
+    (aspect) =>
+      aspect.type === '合相' &&
+      new Set([aspect.body1, aspect.body2]).has('北交点') &&
+      new Set([aspect.body1, aspect.body2]).has('莉莉丝'),
+  );
+  assert.equal(falseConjunction, undefined, '相差约 16.85° 的北交点与莉莉丝不得沿用旧黄经误报合相');
+});

--- a/tests/astrolabe-lunar-points.test.ts
+++ b/tests/astrolabe-lunar-points.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
+import type { AstrolabeBirthInput } from 'mingyu-core/types';
+
+// 参考值取自 Swiss Ephemeris 2.10（se1 星历文件，SE_OSCU_APOG=13 / SE_TRUE_NODE=11，
+// flag=2 即星历文件生效）。本地复核脚本对照 20 个 1900-2100 年用例：
+// 修正后真莉莉丝最大偏差 425″（≈0.12°），真北交点最大偏差 12″（≈0.0034°）。
+// 断言容差取 0.25°（莉莉丝）与 0.01°（交点），为不同星历源间残差留余量。
+const LILITH_TOLERANCE_DEG = 0.25;
+const NODE_TOLERANCE_DEG = 0.01;
+
+interface ReferenceCase {
+  label: string;
+  input: AstrolabeBirthInput;
+  expectedLilithLongitude: number;
+  expectedNorthNodeLongitude: number;
+}
+
+const baseInput = {
+  name: '参考用例',
+  latitude: '39.9042',
+  longitude: '116.4074',
+  timezone: '8',
+  locationName: '北京',
+};
+
+const cases: ReferenceCase[] = [
+  {
+    label: '1990-01-01 10:30 UTC（北京时间 18:30）',
+    input: { ...baseInput, year: '1990', month: '1', day: '1', hour: '18', minute: '30' },
+    expectedLilithLongitude: 230.1155,
+    expectedNorthNodeLongitude: 316.8689,
+  },
+  {
+    label: '2008-08-08 12:00 UTC（北京时间 20:00）',
+    input: { ...baseInput, year: '2008', month: '8', day: '8', hour: '20', minute: '0' },
+    expectedLilithLongitude: 252.3543,
+    expectedNorthNodeLongitude: 318.5629,
+  },
+  {
+    label: '1937-07-07 15:30 UTC（北京时间 23:30）',
+    input: { ...baseInput, year: '1937', month: '7', day: '7', hour: '23', minute: '30' },
+    expectedLilithLongitude: 257.2845,
+    expectedNorthNodeLongitude: 254.9239,
+  },
+  {
+    label: '2026-08-31 00:00 UTC（北京时间 08:00）',
+    input: { ...baseInput, year: '2026', month: '8', day: '31', hour: '8', minute: '0' },
+    expectedLilithLongitude: 267.6543,
+    expectedNorthNodeLongitude: 329.8161,
+  },
+];
+
+function angularDifferenceDeg(a: number, b: number): number {
+  const diff = Math.abs(a - b) % 360;
+  return diff > 180 ? 360 - diff : diff;
+}
+
+for (const { label, input, expectedLilithLongitude, expectedNorthNodeLongitude } of cases) {
+  test(`真莉莉丝与真交点应对齐 Swiss Ephemeris：${label}`, () => {
+    const astrolabe = generateAstrolabe(input);
+
+    const lilith = astrolabe.planets.find((point) => point.name === 'True Lilith');
+    const northNode = astrolabe.planets.find((point) => point.name === 'North Node');
+    const southNode = astrolabe.planets.find((point) => point.name === 'South Node');
+
+    assert.ok(lilith, '星盘应包含真莉莉丝');
+    assert.ok(northNode, '星盘应包含北交点');
+    assert.ok(southNode, '星盘应包含南交点');
+
+    const lilithDiff = angularDifferenceDeg(lilith.longitude, expectedLilithLongitude);
+    assert.ok(
+      lilithDiff <= LILITH_TOLERANCE_DEG,
+      `真莉莉丝黄经 ${lilith.longitude.toFixed(4)}° 与 Swiss Ephemeris ${expectedLilithLongitude.toFixed(4)}° 偏差 ${lilithDiff.toFixed(4)}° 超出容差 ${LILITH_TOLERANCE_DEG}°`,
+    );
+
+    const nodeDiff = angularDifferenceDeg(northNode.longitude, expectedNorthNodeLongitude);
+    assert.ok(
+      nodeDiff <= NODE_TOLERANCE_DEG,
+      `真北交点黄经 ${northNode.longitude.toFixed(4)}° 与 Swiss Ephemeris ${expectedNorthNodeLongitude.toFixed(4)}° 偏差 ${nodeDiff.toFixed(4)}° 超出容差 ${NODE_TOLERANCE_DEG}°`,
+    );
+
+    const southDiff = angularDifferenceDeg(southNode.longitude, northNode.longitude + 180);
+    assert.ok(southDiff <= 1e-6, '南交点应与北交点严格相差 180°');
+  });
+}
+
+test('真莉莉丝修正后不应再出现整星座级别的错位', () => {
+  // 修复前该用例真莉莉丝偏差约 16.8°（celestine 给出白羊 16.69°，实际应为双鱼 29.93°），
+  // 星座落位直接错位；修复后应 <0.25° 且星座一致。
+  const astrolabe = generateAstrolabe({
+    ...baseInput,
+    year: '1949',
+    month: '10',
+    day: '1',
+    hour: '15',
+    minute: '0',
+  });
+  const lilith = astrolabe.planets.find((point) => point.name === 'True Lilith');
+  assert.ok(lilith, '星盘应包含真莉莉丝');
+  const expectedSign = Math.floor(359.9288 / 30);
+  assert.equal(
+    Math.floor(lilith.longitude / 30),
+    expectedSign,
+    `真莉莉丝应落在与 Swiss Ephemeris 相同的星座（索引 ${expectedSign}）`,
+  );
+  const diff = angularDifferenceDeg(lilith.longitude, 359.9288);
+  assert.ok(diff <= LILITH_TOLERANCE_DEG, `真莉莉丝偏差 ${diff.toFixed(4)}° 超出容差`);
+});

--- a/tests/astrolabe-native-reference.test.ts
+++ b/tests/astrolabe-native-reference.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { AspectType, calculateChart } from 'celestine';
+import { AspectType, calculateAspects, calculateChart } from 'celestine';
 
 import { generateAstrolabe, computeOsculatingLunarPoints } from 'mingyu-core/divination/astrolabe';
 import type { AstrolabeAspect, AstrolabeBirthInput, AstrolabePoint } from 'mingyu-core/types';
@@ -434,6 +434,27 @@ test('西方星盘18张边界与跨世纪盘面应逐项复现 celestine 原生�
         house: houseForLongitude(chart.houses.cusps, normalized),
       };
     });
+    const correctedAspectBodies = chart.planets.map((planet) => ({
+      name: planet.name,
+      longitude: planet.longitude,
+      longitudeSpeed: planet.longitudeSpeed,
+    }));
+    correctedAspectBodies.push(
+      {
+        name: 'True North Node',
+        longitude: osculating.trueNorthNodeLongitude,
+        longitudeSpeed: 0,
+      },
+      {
+        name: 'True Lilith',
+        longitude: osculating.trueLilithLongitude,
+        longitudeSpeed: 0,
+      },
+    );
+    const correctedAspects = calculateAspects(correctedAspectBodies, {
+      orbs: chart.options.aspectOrbs,
+      minimumStrength: chart.options.minimumAspectStrength,
+    }).aspects.filter((aspect) => chart.options.aspectTypes.includes(aspect.type));
 
     assert.equal(result.planets.length, correctedPoints.length, `${sample.scope}星体数量`);
     for (let index = 0; index < correctedPoints.length; index += 1) {
@@ -480,12 +501,12 @@ test('西方星盘18张边界与跨世纪盘面应逐项复现 celestine 原生�
       ]),
     );
     const expectedAspectsByKey = new Map(
-      chart.aspects.all.map((aspect) => [
+      correctedAspects.map((aspect) => [
         `${chineseBody(aspect.body1)}\u0000${chineseBody(aspect.body2)}\u0000${chineseAspect(aspect.type)}`,
         aspect,
       ]),
     );
-    assert.equal(result.aspects.length, chart.aspects.all.length, `${sample.scope}相位数量`);
+    assert.equal(result.aspects.length, correctedAspects.length, `${sample.scope}相位数量`);
     for (const [key, expected] of expectedAspectsByKey) {
       const actual = actualAspectsByKey.get(key);
       assert.ok(actual, `${sample.scope}相位 ${expected.body1} ${expected.type} ${expected.body2}`);
@@ -503,5 +524,5 @@ test('西方星盘18张边界与跨世纪盘面应逐项复现 celestine 原生�
   assert.equal(checked, 18);
   assert.equal(pointChecked, 432);
   assert.equal(houseChecked, 216);
-  assert.equal(aspectChecked, 551);
+  assert.equal(aspectChecked, 539);
 });

--- a/tests/astrolabe-native-reference.test.ts
+++ b/tests/astrolabe-native-reference.test.ts
@@ -3,8 +3,23 @@ import test from 'node:test';
 
 import { AspectType, calculateChart } from 'celestine';
 
-import { generateAstrolabe } from 'mingyu-core/divination/astrolabe';
+import { generateAstrolabe, computeOsculatingLunarPoints } from 'mingyu-core/divination/astrolabe';
 import type { AstrolabeAspect, AstrolabeBirthInput, AstrolabePoint } from 'mingyu-core/types';
+
+const SIGN_NAME_ORDER = [
+  'Aries',
+  'Taurus',
+  'Gemini',
+  'Cancer',
+  'Leo',
+  'Virgo',
+  'Libra',
+  'Scorpio',
+  'Sagittarius',
+  'Capricorn',
+  'Aquarius',
+  'Pisces',
+] as const;
 
 const PLANET_LABELS: Record<string, string> = {
   Sun: '太阳',
@@ -74,6 +89,23 @@ function chineseSign(name: string): string {
 
 function chineseAspect(type: string): string {
   return ASPECT_LABELS[type] ?? type;
+}
+
+function houseForLongitude(
+  cusps: readonly { house: number; longitude: number }[],
+  longitude: number,
+): number {
+  const sorted = [...cusps].sort((a, b) => a.house - b.house);
+  for (let index = 0; index < sorted.length; index += 1) {
+    const current = sorted[index];
+    const next = sorted[(index + 1) % sorted.length];
+    const span = (((next.longitude - current.longitude) % 360) + 360) % 360 || 360;
+    const offset = (((longitude - current.longitude) % 360) + 360) % 360;
+    if (offset < span) {
+      return current.house;
+    }
+  }
+  return sorted[0]?.house ?? 0;
 }
 
 function assertSamePoint(
@@ -365,9 +397,47 @@ test('西方星盘18张边界与跨世纪盘面应逐项复现 celestine 原生�
       })),
     ];
 
-    assert.equal(result.planets.length, expectedPoints.length, `${sample.scope}星体数量`);
-    for (let index = 0; index < expectedPoints.length; index += 1) {
-      assertSamePoint(result.planets[index], expectedPoints[index], `${sample.scope}星体${index}`);
+    // 真莉莉丝与真交点不再复现 celestine 原生值（其级数误差过大），
+    // 改以月球交切轨道重算值为金标，与 generateAstrolabe 的修正保持一致。
+    const oscUtc = chart.calculated.utcDateTime;
+    const osculating = computeOsculatingLunarPoints(
+      new Date(
+        Date.UTC(
+          oscUtc.year,
+          oscUtc.month - 1,
+          oscUtc.day,
+          oscUtc.hour,
+          oscUtc.minute,
+          oscUtc.second ?? 0,
+        ),
+      ),
+    );
+    const correctedLongitudes: Record<string, number> = {
+      'True Lilith': osculating.trueLilithLongitude,
+      'North Node': osculating.trueNorthNodeLongitude,
+      'South Node': (osculating.trueNorthNodeLongitude + 180) % 360,
+    };
+    const correctedPoints = expectedPoints.map((point) => {
+      const correctedLongitude = correctedLongitudes[point.name];
+      if (correctedLongitude === undefined) {
+        return point;
+      }
+      const normalized = ((correctedLongitude % 360) + 360) % 360;
+      const signIndex = Math.floor(normalized / 30);
+      const degreeInSign = normalized - signIndex * 30;
+      return {
+        ...point,
+        longitude: normalized,
+        signName: SIGN_NAME_ORDER[signIndex],
+        degree: Math.floor(degreeInSign),
+        minute: Math.floor((degreeInSign - Math.floor(degreeInSign)) * 60),
+        house: houseForLongitude(chart.houses.cusps, normalized),
+      };
+    });
+
+    assert.equal(result.planets.length, correctedPoints.length, `${sample.scope}星体数量`);
+    for (let index = 0; index < correctedPoints.length; index += 1) {
+      assertSamePoint(result.planets[index], correctedPoints[index], `${sample.scope}星体${index}`);
       pointChecked += 1;
     }
 


### PR DESCRIPTION
## 关联 Issue

Fixes #233

## 问题与影响

mingyu 生成的西洋本命盘中，真莉莉丝与真交点的黄经和 Swiss Ephemeris 存在系统性偏差。真莉莉丝的偏差可达到近 20°，会造成星座、度数、宫位及相关相位错误；真交点虽主要是角秒级差异，但在星座边界附近仍可能错位。

根因是上游 `celestine@0.2.1` 使用近似公式计算这些月球轨道点，并且原始相位表仍基于未修正的黄经生成。

## 修复内容

- 新增月球交切轨道根数计算，依据月球地心状态向量重算真莉莉丝、真北交点和真南交点。
- 同步修正三个点的黄经、星座、度分和宫位。
- 使用最终修正后的黄经重新计算相位与格局，避免盘面位置正确但相位仍沿用旧值。
- 保持其他行星和相位配置不变。

## 验证

- Swiss Ephemeris 参考样本与 1949 年星座错位回归通过。
- 新增相位几何一致性回归，确保每条相位的实际夹角和容许度都由最终盘面黄经得出。
- 全量验证通过：核心测试 1282 项、集成测试 41 项、API 测试 120 项、MCP 测试 47 项，均为零失败。
- 严格前端类型检查、Prettier、ESLint 和生产构建通过；ESLint 仅保留主分支已有的 3 条非阻断警告。

## 范围说明

#233 中记录的小行星、凯龙星、水星和冥王星等其他上游星历精度问题不在本 PR 范围。
