### PR TITLE
纳入 mingyu-mcp 自动发布流程

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish mingyu-core to npm
+name: Publish mingyu packages to npm
 
 on:
   release:
@@ -21,9 +21,22 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
+      - name: 构建 MCP 发布包
+        run: pnpm run build:mcp
       - run: pnpm run package:check
       - run: pnpm test:ci
-      - name: 发布至 npm
+      - name: 发布 mingyu-core 至 npm
         run: pnpm --filter mingyu-core publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: 检查并发布 mingyu-mcp 至 npm
+        shell: bash
+        run: |
+          mcp_version="$(node -p "require('./packages/mcp/package.json').version")"
+          if npm view "mingyu-mcp@${mcp_version}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo "mingyu-mcp@${mcp_version} 已存在，跳过重复发布"
+          else
+            pnpm --filter mingyu-mcp publish --no-git-checks --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 目标
将 `mingyu-mcp` 纳入现有 npm 自动发布流程，避免只发布 `mingyu-core` 导致独立 MCP 包无法随版本发布。

## 改动
- 工作流安装依赖后先执行 `pnpm run build:mcp`，确保发布包包含最新构建产物。
- 保留 `mingyu-core` 发布步骤，并新增 `mingyu-mcp` 发布步骤。
- 发布前按包版本查询 npm；已存在的版本跳过，避免当前已发布版本重复发布导致流程失败。
- 工作流名称同步调整为覆盖两个 npm 包。

## 验证
- Prettier 工作流格式检查通过。
- `git diff --check` 通过。
- 已在 NAS 验证 `pnpm build:mcp`、MCP 文档测试（1/1）和 MCP 测试（47/47）。
- `mingyu-mcp@0.1.0` 已发布并通过 `npx --yes mingyu-mcp` 实际初始化和工具列表验证。

## 兼容与发布说明
- 当前 `mingyu-mcp@0.1.0` 已存在，因此合并后的首次工作流运行会安全跳过该版本。
- 后续发布 MCP 新版本时，只需先更新 `packages/mcp/package.json` 的版本号。