### PR TITLE
接入统一 APK 分发服务

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -128,6 +128,37 @@ jobs:
               --title "命语 Android ${ANDROID_VERSION}" \
               --generate-notes
           fi
+      - name: 同步到统一 APK 分发
+        env:
+          APP_RELEASE_PUBLISH_TOKEN: ${{ secrets.APP_RELEASE_PUBLISH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          if [[ -z "$APP_RELEASE_PUBLISH_TOKEN" ]]; then
+            echo "缺少 APP_RELEASE_PUBLISH_TOKEN，已停止发布。" >&2
+            exit 1
+          fi
+          apk_name="mingyu-${ANDROID_VERSION}.apk"
+          apk_path="release/${apk_name}"
+          asset_url="https://github.com/Brhiza/mingyu/releases/download/${GITHUB_REF_NAME}/${apk_name}"
+          release_url="https://github.com/Brhiza/mingyu/releases/tag/${GITHUB_REF_NAME}"
+          release_notes="$(gh release view "$GITHUB_REF_NAME" --json body --jq '.body // ""')"
+          jq -n \
+            --arg version "$ANDROID_VERSION" \
+            --argjson versionCode "$MINGYU_VERSION_CODE" \
+            --arg fileName "$apk_name" \
+            --arg sha256 "$(sha256sum "$apk_path" | cut -d' ' -f1)" \
+            --arg assetUrl "$asset_url" \
+            --arg releaseUrl "$release_url" \
+            --arg releaseNotes "$release_notes" \
+            '{version: $version, versionCode: $versionCode, channel: "latest", fileName: $fileName, sha256: $sha256, assetUrl: $assetUrl, releaseUrl: $releaseUrl, releaseNotes: $releaseNotes}' \
+            > release/app-release-payload.json
+          curl --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
+            --header "Authorization: Bearer ${APP_RELEASE_PUBLISH_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data-binary @release/app-release-payload.json \
+            https://download.aov.cc/v1/publish/mingyu
       - name: 上传到蓝奏云线路
         env:
           LANZOU_API_TOKEN: ${{ secrets.LANZOU_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ npx skills add Brhiza/mingyu --skill aov-mingyu-api -g -y
 
 提供适配移动端的 Android 原生 APK，支持在生成排盘后**一键唤起已安装的 AI 应用**（如 ChatGPT、Claude、Kimi 等）直接对话，API Key 仅保存在本地设备。
 
+正式 APK 发布后会同步到 `download.aov.cc` 并由 Cloudflare CDN 分发；应用优先使用统一下载，同时保留蓝奏云、GitHub Release 和加速线路作为回退。
+
 ```bash
 # 同步 Web 资源到 Android 工程
 pnpm android:sync

--- a/src/lib/android-app-update.ts
+++ b/src/lib/android-app-update.ts
@@ -4,6 +4,8 @@ import { buildAndroidDownloadRoutes, type AndroidDownloadRoute } from '@/lib/and
 
 const RELEASE_API_URL = 'https://api.github.com/repos/Brhiza/mingyu/releases?per_page=100';
 const RELEASE_DOWNLOAD_PREFIX = 'https://github.com/Brhiza/mingyu/releases/download/';
+const RELEASE_MANIFEST_URL = 'https://download.aov.cc/apps/mingyu/android/latest.json';
+const RELEASE_CDN_PREFIX = 'https://download.aov.cc/apps/mingyu/android/';
 const VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
 
 export interface AndroidAppInfo {
@@ -33,6 +35,17 @@ type GitHubRelease = {
   tag_name?: unknown;
   html_url?: unknown;
   assets?: unknown;
+};
+
+type AndroidReleaseManifest = {
+  appId?: unknown;
+  packageName?: unknown;
+  channel?: unknown;
+  version?: unknown;
+  fileName?: unknown;
+  apkUrl?: unknown;
+  checksumUrl?: unknown;
+  releaseUrl?: unknown;
 };
 
 const AndroidAppUpdate = registerPlugin<AndroidAppUpdatePlugin>('AndroidAppUpdate');
@@ -96,6 +109,39 @@ export function normalizeAndroidRelease(value: unknown): AndroidReleaseInfo | nu
     apkUrl,
     checksumUrl,
     releaseUrl,
+    downloadRoutes: buildAndroidDownloadRoutes(
+      version,
+      `${RELEASE_CDN_PREFIX}${version}/mingyu-${version}.apk`,
+    ),
+  };
+}
+
+export function normalizeAndroidManifest(value: unknown): AndroidReleaseInfo | null {
+  if (!value || typeof value !== 'object') return null;
+  const manifest = value as AndroidReleaseManifest;
+  const version = typeof manifest.version === 'string' ? manifest.version.trim() : '';
+  if (!parseVersion(version)) return null;
+  const fileName = `mingyu-${version}.apk`;
+  const apkUrl = `${RELEASE_CDN_PREFIX}${version}/${fileName}`;
+  const checksumUrl = `${apkUrl}.sha256`;
+  if (
+    manifest.appId !== 'mingyu' ||
+    manifest.packageName !== 'cc.aov.mingyu' ||
+    manifest.channel !== 'latest' ||
+    manifest.fileName !== fileName ||
+    manifest.apkUrl !== apkUrl ||
+    manifest.checksumUrl !== checksumUrl
+  ) {
+    return null;
+  }
+  const tagName = `android-v${version}`;
+  const expectedReleaseUrl = `https://github.com/Brhiza/mingyu/releases/tag/${tagName}`;
+  return {
+    version,
+    tagName,
+    apkUrl,
+    checksumUrl,
+    releaseUrl: manifest.releaseUrl === expectedReleaseUrl ? expectedReleaseUrl : '',
     downloadRoutes: buildAndroidDownloadRoutes(version, apkUrl),
   };
 }
@@ -113,6 +159,18 @@ export async function getAndroidAppInfo(): Promise<AndroidAppInfo | null> {
 export async function fetchLatestAndroidRelease(
   fetcher: typeof fetch = fetch,
 ): Promise<AndroidReleaseInfo | null> {
+  try {
+    const manifestResponse = await fetcher(RELEASE_MANIFEST_URL, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (manifestResponse.ok) {
+      const manifest = normalizeAndroidManifest(await manifestResponse.json());
+      if (manifest) return manifest;
+    }
+  } catch {
+    // Continue with the existing GitHub Release source.
+  }
   const response = await fetcher(RELEASE_API_URL, {
     headers: { Accept: 'application/vnd.github+json' },
     cache: 'no-store',

--- a/src/lib/android-update-routes.ts
+++ b/src/lib/android-update-routes.ts
@@ -1,4 +1,4 @@
-export type AndroidDownloadRouteId = 'lanzou' | 'github' | 'gh-proxy' | 'ghfast';
+export type AndroidDownloadRouteId = 'rng-cdn' | 'lanzou' | 'github' | 'gh-proxy' | 'ghfast';
 
 export type AndroidDownloadRoute = {
   id: AndroidDownloadRouteId;
@@ -38,28 +38,30 @@ async function fetchRouteProbe(
 
 export function buildAndroidDownloadRoutes(
   version: string,
-  githubUrl: string,
+  apkUrl: string,
 ): AndroidDownloadRoute[] {
   const encodedVersion = encodeURIComponent(version);
+  const githubUrl = `https://github.com/Brhiza/mingyu/releases/download/android-v${encodedVersion}/mingyu-${encodedVersion}.apk`;
   return [
+    { id: 'rng-cdn', name: '线路 1 · 官方下载', url: apkUrl, priority: 1 },
     {
       id: 'lanzou',
-      name: '线路 1 · 蓝奏云',
+      name: '线路 2 · 蓝奏云',
       url: `https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/${encodedVersion}`,
-      priority: 1,
+      priority: 2,
     },
-    { id: 'github', name: '线路 2 · GitHub 直连', url: githubUrl, priority: 2 },
+    { id: 'github', name: '线路 3 · GitHub 直连', url: githubUrl, priority: 3 },
     {
       id: 'gh-proxy',
-      name: '线路 3 · GitHub 加速',
+      name: '线路 4 · GitHub 加速',
       url: `https://gh-proxy.com/${githubUrl}`,
-      priority: 3,
+      priority: 4,
     },
     {
       id: 'ghfast',
-      name: '线路 4 · GitHub 加速',
+      name: '线路 5 · GitHub 加速',
       url: `https://ghfast.top/${githubUrl}`,
-      priority: 4,
+      priority: 5,
     },
   ];
 }

--- a/tests/android-app-update.test.ts
+++ b/tests/android-app-update.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   compareAndroidVersions,
   fetchLatestAndroidRelease,
+  normalizeAndroidManifest,
   normalizeAndroidRelease,
 } from '../src/lib/android-app-update.ts';
 import {
@@ -49,6 +50,22 @@ test('只接受正式 Android Release 的成对官方文件', () => {
   assert.equal(normalizeAndroidRelease(redirected), null);
 });
 
+test('统一 APK 清单必须匹配命语的应用、版本和固定下载路径', () => {
+  const manifest = {
+    appId: 'mingyu',
+    packageName: 'cc.aov.mingyu',
+    channel: 'latest',
+    version: '1.2.3',
+    fileName: 'mingyu-1.2.3.apk',
+    apkUrl: 'https://download.aov.cc/apps/mingyu/android/1.2.3/mingyu-1.2.3.apk',
+    checksumUrl: 'https://download.aov.cc/apps/mingyu/android/1.2.3/mingyu-1.2.3.apk.sha256',
+    releaseUrl: 'https://github.com/Brhiza/mingyu/releases/tag/android-v1.2.3',
+  };
+  assert.equal(normalizeAndroidManifest(manifest)?.version, '1.2.3');
+  assert.equal(normalizeAndroidManifest({ ...manifest, appId: 'other' }), null);
+  assert.equal(normalizeAndroidManifest({ ...manifest, apkUrl: 'https://example.com/app.apk' }), null);
+});
+
 test('更新检查会跳过其他用途的 GitHub Release', async () => {
   const result = await fetchLatestAndroidRelease(
     (async () =>
@@ -60,23 +77,23 @@ test('更新检查会跳过其他用途的 GitHub Release', async () => {
   assert.equal(result?.version, '2.0.0');
 });
 
-test('Android 更新生成蓝奏云、GitHub 直连和两个加速线路', () => {
-  const githubUrl =
-    'https://github.com/Brhiza/mingyu/releases/download/android-v1.2.3/mingyu-1.2.3.apk';
-  const routes = buildAndroidDownloadRoutes('1.2.3', githubUrl);
+test('Android 更新生成统一下载、蓝奏云、GitHub 直连和两个加速线路', () => {
+  const cdnUrl = 'https://download.aov.cc/apps/mingyu/android/1.2.3/mingyu-1.2.3.apk';
+  const routes = buildAndroidDownloadRoutes('1.2.3', cdnUrl);
   assert.deepEqual(
     routes.map((route) => route.id),
-    ['lanzou', 'github', 'gh-proxy', 'ghfast'],
+    ['rng-cdn', 'lanzou', 'github', 'gh-proxy', 'ghfast'],
   );
+  assert.equal(routes[0]?.url, cdnUrl);
   assert.equal(
-    routes[0]?.url,
+    routes[1]?.url,
     'https://lanzou-cloudflare-api.brhiza.workers.dev/v1/public/mingyu/1.2.3',
   );
 });
 
 test('线路测速会跳过失败线路并自动选择最低延迟', async () => {
   const routes = buildAndroidDownloadRoutes('1.2.3', 'https://github.com/example.apk');
-  const probes = await probeAndroidDownloadRoutes(routes.slice(0, 3), (async (
+  const probes = await probeAndroidDownloadRoutes(routes.slice(1, 4), (async (
     url: RequestInfo | URL,
   ) => {
     const value = String(url);
@@ -90,14 +107,14 @@ test('线路测速会跳过失败线路并自动选择最低延迟', async () =>
     selectBestAndroidRoute([
       { ...routes[0]!, status: 'available', latencyMs: 40 },
       { ...routes[1]!, status: 'unavailable', latencyMs: null },
-      { ...routes[2]!, status: 'available', latencyMs: 12 },
+      { ...routes[3]!, status: 'available', latencyMs: 12 },
     ])?.id,
     'gh-proxy',
   );
 });
 
 test('GitHub 加速线路拒绝 HEAD 时改用单字节 Range 测速', async () => {
-  const route = buildAndroidDownloadRoutes('1.2.3', 'https://github.com/example.apk')[2]!;
+  const route = buildAndroidDownloadRoutes('1.2.3', 'https://download.aov.cc/example.apk')[3]!;
   const methods: string[] = [];
   const probes = await probeAndroidDownloadRoutes([route], (async (
     _url: RequestInfo | URL,
@@ -120,6 +137,8 @@ test('APK 工作流覆盖调试构建、正式签名、校验文件和 Release',
   assert.match(workflow, /sha256sum/);
   assert.match(workflow, /gh release create/);
   assert.match(workflow, /LANZOU_API_TOKEN/);
+  assert.match(workflow, /APP_RELEASE_PUBLISH_TOKEN/);
+  assert.match(workflow, /download\.aov\.cc\/v1\/publish\/mingyu/);
 });
 
 test('更新面板应使用蓝奏云直达链接与自动复制密码契约，且移除测速按钮', async () => {


### PR DESCRIPTION
## 改动内容
- 更新检查优先读取 download.aov.cc 统一清单
- 统一下载加入首选线路，保留蓝奏云和 GitHub 回退
- Android 正式发布后自动同步统一分发
- 增加清单校验与工作流回归测试

## 验证
- pnpm exec tsx --tsconfig tsconfig.app.json --test tests/android-app-update.test.ts
- pnpm build