### PR TITLE
发布 mingyu-core 0.2.3 与 mingyu-mcp 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mingyu",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "AGPL-3.0-only",
   "description": "免费开源的在线算命、占卜、玄学排盘与 AI 解读提示词工具",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingyu-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript 算命、占卜与玄学算法：八字、紫微斗数、起名、姓名汉字与数字能量、诸葛神数等",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/shared/version.ts
+++ b/packages/core/src/shared/version.ts
@@ -1,5 +1,5 @@
 /** 核心包版本；发布前由版本一致性测试校验。 */
-export const MINGYU_CORE_VERSION = '0.2.2';
+export const MINGYU_CORE_VERSION = '0.2.3';
 
 /** 公共结果协议版本，与 npm 包版本分开演进。 */
 export const MINGYU_SCHEMA_VERSION = '1.0.0';

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mingyu-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "命语 (Mingyu) 官方 Model Context Protocol (MCP) 服务端 CLI，通过 npx 开箱即用",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## 目标\n- 将核心包版本提升至 0.2.3，并同步能力清单版本。\n- 将独立 MCP 包版本提升至 0.2.1。\n\n## 验证\n- NAS：pnpm build:mcp\n- NAS：pnpm build\n- NAS：pnpm package:check\n- NAS：pnpm test:ci（1608 项核心/主回归、138 项公开 API、58 项 MCP 全部通过）\n\n合并后将发布 npm 包并创建 Android 1.1.3 发布标签。