### PR TITLE
同步 AOV skill 实际接口口径

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,8 @@
 - 发现元数据：[https://aov.cc/.well-known/aov-mingyu-api.json](https://aov.cc/.well-known/aov-mingyu-api.json)
 - Skill 文档：[https://aov.cc/skills/aov-mingyu-api/SKILL.md](https://aov.cc/skills/aov-mingyu-api/SKILL.md)
 
+`GET /openapi.json` 返回统一的 `{ "ok": true, "data": {}, "meta": {} }` 封装；读取完整 OpenAPI 定义时，端点正文位于 `spec["data"]["paths"]`。
+
 ## 返回格式
 
 成功响应：
@@ -49,6 +51,8 @@
 | `GET /health`                                 | 健康检查                                                       |
 | `GET /manifest`                               | 获取 API 元数据                                                |
 | `GET /openapi.json`                           | 获取 OpenAPI 文档                                              |
+| `POST /calendar/true-solar-time`              | 将当地钟表时间换算为真太阳时                                   |
+| `POST /calendar/true-solar-birth`             | 统一处理出生日期类型、真太阳时、跨日与时辰                     |
 | `POST /bazi/calculate`                        | 八字排盘                                                       |
 | `POST /bazi/prompt`                           | 八字排盘并生成 AI 解读提示词                                   |
 | `POST /bazi/compatibility`                    | 八字双盘交叉关系、十神、喜忌覆盖与证据计算                     |
@@ -122,6 +126,7 @@
 | 用户问题类型                       | 首选接口                                     | 推荐参数                                                                                                                                                    | 说明                                                             |
 | ---------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | 换算真太阳时                       | `POST /calendar/true-solar-time`             | `localDateTime`、`longitude`，可选 `timezone`、`timeZoneId`、`applyChinaDst`                                                                                | 支持固定偏移或 IANA 历史时区，返回修正明细、跨日状态和对应时辰   |
+| 出生时间、真太阳时与时辰           | `POST /calendar/true-solar-birth`            | 公历或农历出生日期、时分、`longitude`，可选 `timezone`、`timeZoneId`、`applyChinaDst`                                                                        | 统一处理出生日期类型、真太阳时换算、跨日与时辰，供排盘前使用   |
 | 计算太阳光照证据                   | `POST /calendar/solar-illumination`          | `year`、`month`、`day`、`latitude`、`longitude`，并提供 `timezone` 或 `timeZoneId`；可选参考时分秒                                                          | 返回太阳高度、方位、视太阳正午、日出日落与三类曙暮光             |
 | 查六十甲子、纳音、藏干和合冲       | `POST /foundation/ganzhi`                    | `ganZhi`，如“甲子”                                                                                                                                          | 返回统一公共地基资料，不需重复实现                               |
 | 统计天干地支五行分布               | `POST /foundation/wuxing`                    | `items`、可选 `weightHidden`                                                                                                                                | 默认计入地支藏干权重                                             |
@@ -176,6 +181,16 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-time \
 ```
 
 `localDateTime` 是当地钟表时间，不要附带 `Z` 或 `+08:00`。未传 `timeZoneId` 时，`timezone` 默认是 `8`；历史日期或实行夏令时的地区可传 IANA 时区（如 `America/New_York`），系统会解析当时的法定偏移。秋季回拨的重复当地时间必须再传与原始记录一致的 `timezone` 消歧，固定偏移与 IANA 规则冲突时会拒绝计算。`timeZoneId` 已包含历史夏令时规则，不能同时启用 `applyChinaDst`；中国 1986–1991 年记录也可只用固定 `timezone: 8` 配合 `applyChinaDst: true` 走兼容口径。
+
+出生真太阳时换算：
+
+```bash
+curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
+  -H "Content-Type: application/json" \
+  -d '{"dateType":"lunar","year":1990,"month":5,"day":23,"hour":12,"minute":0,"longitude":116.4074,"timezone":8}'
+```
+
+该接口统一处理公历或农历出生日期、真太阳时换算、跨日和时辰变化；返回数据位于响应的 `data` 字段。
 
 六十甲子基础资料：
 

--- a/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
+++ b/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
@@ -7,11 +7,14 @@
 ## 一、基础服务地址与响应格式
 
 - **官方公开 API**：`https://aov.cc/api/v1`
+- **AOV REST 响应封装**：成功响应使用 `{ "ok": true, "data": {}, "meta": {} }`；接口结果在 `data` 中读取。
+- **OpenAPI 发现**：`GET /openapi.json` 返回的 JSON 也使用 `data` 包装层，端点正文位于 `spec["data"]["paths"]`；不要从顶层 `spec["paths"]` 读取。
+- **实际出生接口**：八字排盘使用 `POST /bazi/calculate`，出生真太阳时换算使用 `POST /calendar/true-solar-birth`；`/calendar/true-solar-time` 仅用于一般当地钟表时间换算。
 - **Remote MCP 服务地址（支持 CORS）**：
   - **Streamable HTTP 端点**：`https://aov.cc/mcp`（或本地 `http://localhost:3000/mcp`）
   - **SSE 通信端点**：`https://aov.cc/sse`（消息投递：`/message`）
   - **本地 STDIO 启动**：`npx mingyu-mcp` 或 `pnpm mcp`
-- **统一成功响应与 Envelope 契约**：
+- **MCP 成功响应与 Envelope 契约**：
   ```json
   {
     "result": {},
@@ -19,7 +22,7 @@
     "warnings": ["缺时辰已安全启用三柱降级分析"]
   }
   ```
-- **统一结构化业务错误响应**：
+- **MCP 结构化业务错误响应**：
   ```json
   {
     "error": "缺少必要出生时辰",

--- a/public/skills/mingyu/references/providers/aov-mingyu.md
+++ b/public/skills/mingyu/references/providers/aov-mingyu.md
@@ -7,11 +7,14 @@
 ## 一、基础服务地址与响应格式
 
 - **官方公开 API**：`https://aov.cc/api/v1`
+- **AOV REST 响应封装**：成功响应使用 `{ "ok": true, "data": {}, "meta": {} }`；接口结果在 `data` 中读取。
+- **OpenAPI 发现**：`GET /openapi.json` 返回的 JSON 也使用 `data` 包装层，端点正文位于 `spec["data"]["paths"]`；不要从顶层 `spec["paths"]` 读取。
+- **实际出生接口**：八字排盘使用 `POST /bazi/calculate`，出生真太阳时换算使用 `POST /calendar/true-solar-birth`；`/calendar/true-solar-time` 仅用于一般当地钟表时间换算。
 - **Remote MCP 服务地址（支持 CORS）**：
   - **Streamable HTTP 端点**：`https://aov.cc/mcp`（或本地 `http://localhost:3000/mcp`）
   - **SSE 通信端点**：`https://aov.cc/sse`（消息投递：`/message`）
   - **本地 STDIO 启动**：`npx mingyu-mcp` 或 `pnpm mcp`
-- **统一成功响应与 Envelope 契约**：
+- **MCP 成功响应与 Envelope 契约**：
   ```json
   {
     "result": {},
@@ -19,7 +22,7 @@
     "warnings": ["缺时辰已安全启用三柱降级分析"]
   }
   ```
-- **统一结构化业务错误响应**：
+- **MCP 结构化业务错误响应**：
   ```json
   {
     "error": "缺少必要出生时辰",

--- a/skills/mingyu/references/providers/aov-mingyu.md
+++ b/skills/mingyu/references/providers/aov-mingyu.md
@@ -1,33 +1,101 @@
-# AOV 公开 API 与 Mingyu MCP 适配手册
+# AOV / Mingyu 数据提供方适配实现指南（AOV & Mingyu Provider Reference）
 
-## 1. 架构总览
-
-本提供方适配层将所有术数推演请求映射到 **AOV 公开 API (`https://aov.cc/api/v1`)** 或本地 **Mingyu MCP Server**。
+本文档为 AOV 命理公开 API 与 Mingyu MCP Server 的具体端点、工具与参数映射参考。上层算命通用 Skill 通过本文档与具体服务对接。当更换为人工录入盘面或未来其他排盘器时，上层工作流不受影响。
 
 ---
 
-## 2. 核心端点与能力全览
+## 一、基础服务地址与响应格式
 
-| 术数分类 | 功能名称 | REST API 路径 (POST) | 核心入参参数 |
+- **官方公开 API**：`https://aov.cc/api/v1`
+- **AOV REST 响应封装**：成功响应使用 `{ "ok": true, "data": {}, "meta": {} }`；接口结果在 `data` 中读取。
+- **OpenAPI 发现**：`GET /openapi.json` 返回的 JSON 也使用 `data` 包装层，端点正文位于 `spec["data"]["paths"]`；不要从顶层 `spec["paths"]` 读取。
+- **实际出生接口**：八字排盘使用 `POST /bazi/calculate`，出生真太阳时换算使用 `POST /calendar/true-solar-birth`；`/calendar/true-solar-time` 仅用于一般当地钟表时间换算。
+- **Remote MCP 服务地址（支持 CORS）**：
+  - **Streamable HTTP 端点**：`https://aov.cc/mcp`（或本地 `http://localhost:3000/mcp`）
+  - **SSE 通信端点**：`https://aov.cc/sse`（消息投递：`/message`）
+  - **本地 STDIO 启动**：`npx mingyu-mcp` 或 `pnpm mcp`
+- **MCP 成功响应与 Envelope 契约**：
+  ```json
+  {
+    "result": {},
+    "meta": { "tool": "bazi_calculate", "durationMs": 12, "system": "mingyu-mcp" },
+    "warnings": ["缺时辰已安全启用三柱降级分析"]
+  }
+  ```
+- **MCP 结构化业务错误响应**：
+  ```json
+  {
+    "error": "缺少必要出生时辰",
+    "code": "MISSING_BIRTH_TIME",
+    "missingFields": ["timeIndex"],
+    "retryable": true,
+    "fallback": "可选择三柱降级模式仅排年月日三柱"
+  }
+  ```
+
+---
+
+## 二、API 与 MCP 工具全量映射速查表
+
+| 功能领域 | REST API 端点 (`POST /api/v1/...`) | MCP Tool 名称 | 核心功能与关键参数建议 |
 | :--- | :--- | :--- | :--- |
-| **基础授时** | 真太阳时换算 | `/calendar/true-solar-time` | `localDateTime`, `longitude`, `timezone`, `timeZoneId` |
-| **先天命理** | 八字四柱排盘 | `/bazi/chart` | `gender`, `year`, `month`, `day`, `timeIndex`, `useTrueSolarTime` |
-| **先天命理** | 八字提示词生成 | `/bazi/prompt` | 同上 + `question`, `topic` |
-| **先天命理** | 紫微斗数排盘 | `/ziwei/chart` | 同上 |
-| **先天命理** | 紫微提示词生成 | `/ziwei/prompt` | 同上 |
-| **综合合参** | 八字紫微合参提示词 | `/bazi-ziwei/prompt` | 同上 + `synthesisOptions` |
-| **事态占问** | 六爻排盘/提示词 | `/divination/liuyao/prompt` | `question`, `coins` 或 `autoCast: true` |
-| **事态占问** | 时家奇门遁甲 | `/divination/qimen/prompt` | `question`, `date`, `method` (拆补/置闰) |
-| **人事气象** | 大六壬排盘 | `/divination/liuren/prompt` | `question`, `date`, `monthGeneral` |
-| **象意推演** | 梅花易数 | `/divination/meihua/prompt` | `question`, `method`, `numbers` |
-| **时空择吉** | 黄历择日 | `/divination/almanac/prompt` | `topic`, `startDate`, `endDate`, `person1` |
-| **环境风水** | 住宅风水合参 | `/residential/prompt` | `sitMountain`, `facingDegree`, `periodYear` |
-| **姓名数理** | 姓名五格三才分析 | `/name/analyze/prompt` | `surname`, `givenName`, `gender` |
-| **神示启迪** | 三山国王灵签 | `/divination/sanshan/prompt` | `question` |
-
----
-
-## 3. 轻量化调用最佳实践
-
-1. 若仅需直接交付在线大模型解读，优先使用各端点的 `/prompt` 版本，设置 `responseMode: "prompt-only"`，直接获取自包含任务书。
-2. 若需前端渲染图表或深入交互，使用 `/chart` 端点，设置 `detailMode: "compact"` 获取精简结构化 JSON。
+| **基础与时间** | `/calendar/true-solar-time` | `calendar_true_solar_time` | 真太阳时校正，支持 `longitude`、`timeZoneId`、`applyChinaDst` |
+| **统一出生时间**| `/calendar/true-solar-birth`| `calendar_true_solar_birth` | 统一处理公历/农历、时差与跨日时辰 |
+| **天文时间尺度**| `/calendar/astronomical-time`| `calendar_astronomical_time` | 儒略日、近似 UT1、ΔT 与近似 TT 证据 |
+| **月相证据** | `/calendar/moon-phase` | `calendar_moon_phase` | 月相角、照明比例、朔弦望事件 |
+| **节气证据** | `/calendar/solar-term` | `calendar_solar_term` | 历表时刻、黄经度数与独立求根核验 |
+| **地基能力** | `/foundation/capabilities` | `foundation_capabilities` | 历法干支五行方位常量目录 |
+| **通用神煞** | `/foundation/shensha` | `foundation_shensha` | 严格核验四柱，返回空亡、驿马、桃花命中与来源 |
+| **即时排盘** | `/instant/calculate` | `instant_chart` | 当刻排八字/紫微/合参/星盘/七政盘，无需性别 |
+| **八字排盘** | `/bazi/calculate` | `bazi_calculate` | 四柱十神藏干大运神煞旺衰 |
+| **八字提示词** | `/bazi/prompt` | `bazi_prompt` | `promptTopic`、`baziFortuneScope`、`schools` |
+| **八字双盘** | `/bazi/compatibility` | `bazi_compatibility` | 双方日主十神交叉与喜忌互补 |
+| **八字双盘提示词**| `/bazi/compatibility/prompt` | `bazi_compatibility_prompt`| 八字合盘自包含结构化证据提示词 |
+| **紫微排盘** | `/ziwei/calculate` | `ziwei_calculate` | 十二宫星曜、生年四化、大限流年 |
+| **紫微提示词** | `/ziwei/prompt` | `ziwei_prompt` | `promptTopic`、`promptScope`、`schools` |
+| **紫微双盘** | `/ziwei/compatibility` | `ziwei_compatibility` | 关键宫位叠盘、生年四化跨盘落宫 |
+| **紫微双盘提示词**| `/ziwei/compatibility/prompt` | `ziwei_compatibility_prompt`| 紫微双盘自包含结构化证据提示词 |
+| **八字紫微合参** | `/bazi-ziwei/prompt` | `bazi_ziwei_prompt` | 同一出生资料，八字定主线，紫微校验运限 |
+| **大类主题咨询** | `/consultation/thematic/prompt` | `thematic_consultation_prompt` | 8大类主题（感情、事业、财运等）自动提取盘面焦点要素生成自包含任务书 |
+| **六爻起卦** | `/divination/liuyao` | `divine_liuyao` | 六爻排卦、世应动变、月日生克 |
+| **六爻提示词** | `/divination/liuyao/prompt` | `liuyao_prompt` | 六爻自包含提示词，支持 `liuyaoTemplate` |
+| **梅花易数** | `/divination/meihua` | `divine_meihua` | 体用互变卦象，支持时间/数字/随机起卦 |
+| **梅花提示词** | `/divination/meihua/prompt` | `meihua_prompt` | 梅花易数体用生克推进提示词 |
+| **小六壬** | `/divination/xiaoliuren` | `divine_xiaoliuren` | 月日时三宫顺数课，以时宫为主证 |
+| **小六壬提示词** | `/divination/xiaoliuren/prompt` | `xiaoliuren_prompt` | 小六壬自包含提示词 |
+| **金口诀** | `/divination/jinkoujue` | `divine_jinkoujue` | 人元贵神将神地分四位课盘 |
+| **金口诀提示词** | `/divination/jinkoujue/prompt` | `jinkoujue_prompt` | 金口诀四位发用提示词，支持指定地分 |
+| **奇门遁甲** | `/divination/qimen` | `divine_qimen` | 时/日/月/年家，转盘/飞盘，拆补/置闰 |
+| **奇门提示词** | `/divination/qimen/prompt` | `qimen_prompt` | 奇门时空时局自包含提示词 |
+| **奇门终身局** | `/divination/qimen/lifetime` | `qimen_lifetime` | 本命基础盘、个人标记、阶段卡与事件簇 |
+| **奇门终身提示词**| `/divination/qimen/lifetime/prompt`| `qimen_lifetime_prompt`| 奇门终身局自包含解读提示词 |
+| **大六壬** | `/divination/liuren` | `divine_liuren` | 四课三传、天地盘、十二天将 |
+| **大六壬提示词** | `/divination/liuren/prompt` | `liuren_prompt` | 大六壬课体与三传推进提示词 |
+| **塔罗抽牌** | `/divination/tarot` | `divine_tarot` | 78 张全牌，支持 18 种丰富牌阵 |
+| **塔罗提示词** | `/divination/tarot/prompt` | `tarot_prompt` | 塔罗结构化牌位联动提示词 |
+| **雷诺曼抽牌** | `/divination/lenormand` | `divine_lenormand` | 36 张日常符码，支持 8 种专业牌阵 |
+| **雷诺曼提示词** | `/divination/lenormand/prompt` | `lenormand_prompt` | 雷诺曼相邻合读与指示牌提示词 |
+| **三山国王灵签** | `/divination/ssgw` | `divine_ssgw` | 纯正民间签谱，签号、签题、签诗、典故 |
+| **灵签提示词** | `/divination/ssgw/prompt` | `ssgw_prompt` | 纯净灵签任务书提示词，不加派系 |
+| **黄历择日** | `/divination/almanac` | `divine_almanac` | 建除十二神、丛辰吉凶、多参与人冲煞 |
+| **黄历提示词** | `/divination/almanac/prompt` | `almanac_prompt` | 黄历候选优选与自包含提示词，支持分页 |
+| **西洋星盘** | `/divination/astrolabe` | `divine_astrolabe` | 本命星体、相位、分宫制，支持真太阳时 |
+| **星盘提示词** | `/divination/astrolabe/prompt` | `astrolabe_prompt` | 本命与行运过境提示词，需指定行运日期 |
+| **西占双盘** | `/divination/astrolabe/synastry`| `astrolabe_synastry` | 双方行星跨盘相位、角距、落宫 |
+| **西占双盘提示词**| `/divination/astrolabe/synastry/prompt`| `astrolabe_synastry_prompt`| 西占关系合盘自包含提示词 |
+| **八宅排盘** | `/metaphysics/bazhai/calculate`| `metaphysics_bazhai` | 命卦、宅卦、大游年、磁偏角与真北 |
+| **八宅提示词** | `/metaphysics/bazhai/prompt` | `bazhai_prompt` | 八宅风水自包含解读提示词 |
+| **住宅风水合参** | `/metaphysics/residential/calculate`| 住宅风水合参计算 | 八宅命宅相配与玄空飞星九运合参 |
+| **住宅风水提示词**| `/metaphysics/residential/prompt`| 住宅风水合参提示词 | 住宅风水综合自包含提示词 |
+| **生肖流年** | `/metaphysics/zodiac/calculate`| `metaphysics_zodiac` | 刑冲克害破、三合六合生肖关系 |
+| **生肖提示词** | `/metaphysics/zodiac/prompt` | `zodiac_prompt` | 生肖流年运势自包含提示词 |
+| **太乙神数** | `/metaphysics/taiyi/calculate` | `metaphysics_taiyi` | 年月日时四计七十二局式盘 |
+| **太乙提示词** | `/metaphysics/taiyi/prompt` | `taiyi_prompt` | 太乙主客胜负时势提示词 |
+| **五运六气** | `/metaphysics/wuyun-liuqi/calculate`| `metaphysics_wuyun-liuqi`| 五步主客运、司天在泉、天符岁会五类符会 |
+| **五运六气提示词**| `/metaphysics/wuyun-liuqi/prompt`| `wuyun_liuqi_prompt` | 年度五运六气气候与节律自包含提示词 |
+| **皇极经世** | `/metaphysics/huangji-jingshi/calculate`| `metaphysics_huangji-jingshi`| 元会运世、值年卦、月经卦、日经卦 |
+| **皇极经世提示词**| `/metaphysics/huangji-jingshi/prompt`| `huangji_jingshi_prompt` | 皇极经世自包含宏观时势提示词 |
+| **七政四余** | `/metaphysics/qizheng/calculate`| `metaphysics_qizheng` | 十一星、二十八宿界、度主命主、行限流曜 |
+| **七政四余提示词**| `/metaphysics/qizheng/prompt` | `qizheng_prompt` | 七政四余天星自包含解读提示词 |
+| **AI 运行流** | `/ai/analyze` | - | SSE 流式 AI 问答接口 |
+| **AI 可用模型** | `/ai/models` | - | 查询内置或外部模型列表 |

--- a/tests/api/public-api-docs.test.ts
+++ b/tests/api/public-api-docs.test.ts
@@ -8,6 +8,28 @@ const aovProviderRef = readFileSync(
   'public/skills/aov-mingyu-api/references/providers/aov-mingyu.md',
   'utf8',
 );
+const skillProviderRefs = [
+  readFileSync('skills/mingyu/references/providers/aov-mingyu.md', 'utf8'),
+  readFileSync('public/skills/mingyu/references/providers/aov-mingyu.md', 'utf8'),
+  aovProviderRef,
+];
+
+test('所有 AOV Provider 手册必须使用当前 REST 端点和 OpenAPI 包装层', () => {
+  for (const content of skillProviderRefs) {
+    assert.doesNotMatch(content, /\/bazi\/chart|\/ziwei\/chart/);
+    assert.match(content, /\/bazi\/calculate/);
+    assert.match(content, /\/calendar\/true-solar-birth/);
+    assert.match(content, /spec\["data"\]\["paths"\]/);
+    assert.match(content, /AOV REST 响应封装/);
+    assert.match(content, /MCP 成功响应与 Envelope 契约/);
+  }
+});
+
+test('公开 API 文档必须同步出生真太阳时端点与 OpenAPI 包装层', () => {
+  assert.match(publicApiDocs, /POST \/calendar\/true-solar-birth/);
+  assert.match(publicApiDocs, /POST \/bazi\/calculate/);
+  assert.match(publicApiDocs, /spec\["data"\]\["paths"\]/);
+});
 
 test('公开 API 文档和 provider 适配层应写明 AI 接口', () => {
   for (const content of [publicApiDocs, aovProviderRef]) {


### PR DESCRIPTION
修复用户反馈的 AOV Skill 与实际服务不一致问题。

主要修改：
- 将源目录 Provider 手册中的过期 /bazi/chart、/ziwei/chart 更新为当前 /bazi/calculate、/ziwei/calculate。
- 补充 /calendar/true-solar-birth 出生真太阳时接口及 MCP 映射。
- 明确 AOV REST 响应和 OpenAPI 的 data 包装层，端点正文读取 spec["data"]["paths"]。
- 同步公开 API 文档、Skill 发布目录和源目录，并增加旧端点回归检查。

验证：
- 文档测试 10/10 通过。
- 全仓库未发现 /bazi/chart、/ziwei/chart。
- git diff --check 通过。

本次仅涉及文档与文档回归测试，不需要升级 npm 包或 Android APK。