### PR TITLE
补充 AOV 真太阳时参数说明

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,7 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-time \
   -d '{"localDateTime":"1988-07-15T12:00:00","longitude":116.4074,"timezone":8,"applyChinaDst":true}'
 ```
 
-`localDateTime` 是当地钟表时间，不要附带 `Z` 或 `+08:00`。未传 `timeZoneId` 时，`timezone` 默认是 `8`；历史日期或实行夏令时的地区可传 IANA 时区（如 `America/New_York`），系统会解析当时的法定偏移。秋季回拨的重复当地时间必须再传与原始记录一致的 `timezone` 消歧，固定偏移与 IANA 规则冲突时会拒绝计算。`timeZoneId` 已包含历史夏令时规则，不能同时启用 `applyChinaDst`；中国 1986–1991 年记录也可只用固定 `timezone: 8` 配合 `applyChinaDst: true` 走兼容口径。
+`localDateTime` 是当地钟表时间，不要附带 `Z` 或 `+08:00`。`timezone` 是固定 UTC 偏移，单位为小时，范围为 `-12` 到 `14`，支持 `5.5` 等小数；未传 `timeZoneId` 时默认是 `8`。历史日期或实行夏令时的地区可传 IANA 时区（如 `America/New_York`），系统会解析当时的法定偏移。秋季回拨的重复当地时间必须再传与原始记录一致的 `timezone` 消歧，固定偏移与 IANA 规则冲突时会拒绝计算。`timeZoneId` 已包含历史夏令时规则，不能同时启用 `applyChinaDst`；中国 1986–1991 年记录也可只用固定 `timezone: 8` 配合 `applyChinaDst: true` 走兼容口径。
 
 出生真太阳时换算：
 
@@ -191,6 +191,16 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
 ```
 
 该接口统一处理公历或农历出生日期、真太阳时换算、跨日和时辰变化；返回数据位于响应的 `data` 字段。
+
+八字真太阳时排盘：
+
+```bash
+curl -X POST https://aov.cc/api/v1/bazi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"gender":"male","year":1990,"month":6,"day":15,"dateType":"solar","useTrueSolarTime":true,"birthHour":14,"birthMinute":30,"birthPlace":"上海","birthLongitude":121.47,"timeZoneId":"Asia/Shanghai","shenShaScope":"all","detailMode":"full"}'
+```
+
+启用 `useTrueSolarTime: true` 时，提供 `birthHour`、`birthMinute` 和 `birthLongitude` 后可省略 `timeIndex`，接口会自动推导真太阳时对应的时辰。`timeZoneId` 推荐使用 IANA 时区；`timezone` 仅在使用固定 UTC 小时偏移或为夏令时回拨重复时刻消歧时传入。`detailMode: "compact"` 适合前端和常规调用，`detailMode: "full"` 返回完整证据链与计算过程，适合审计或研究。
 
 六十甲子基础资料：
 

--- a/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
+++ b/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
@@ -163,6 +163,32 @@
 
 ---
 
+## 三、出生时间、时区与真太阳时参数
+
+- `timezone` 表示固定 UTC 偏移，单位为小时，范围为 `-12` 到 `14`，支持 `5.5` 等小数；`timezone: 8` 表示 UTC+8，不是分钟偏移 `480`。
+- `timeZoneId` 使用 IANA 时区标识（例如 `Asia/Shanghai` 或 `America/New_York`），优先用于需要按出生日期解析历史时区或夏令时的场景。
+- `useTrueSolarTime: true` 用于八字或紫微真太阳时排盘。提供 `birthHour`、`birthMinute`、`birthLongitude` 后可省略 `timeIndex`，接口会自动推导真太阳时对应的时辰。
+- `POST /calendar/true-solar-birth` 是出生资料专用的真太阳时换算接口；一般当地钟表时间换算使用 `POST /calendar/true-solar-time`。两个接口的结果都从 AOV REST 响应的 `data` 字段读取。
+- `detailMode: "compact"` 适合常规调用和前端展示；`detailMode: "full"` 返回完整证据链与计算过程，适合审计或研究。
+
+八字真太阳时排盘示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/bazi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"gender":"male","year":1990,"month":6,"day":15,"dateType":"solar","useTrueSolarTime":true,"birthHour":14,"birthMinute":30,"birthPlace":"上海","birthLongitude":121.47,"timeZoneId":"Asia/Shanghai","shenShaScope":"all","detailMode":"full"}'
+```
+
+出生真太阳时换算示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
+  -H "Content-Type: application/json" \
+  -d '{"dateType":"solar","year":1990,"month":6,"day":15,"hour":14,"minute":30,"longitude":121.47,"timeZoneId":"Asia/Shanghai"}'
+```
+
+---
+
 ## 四、牌阵与参数完整契约
 
 - **塔罗牌阵 `spreadType` 支持全部 18 种**：

--- a/public/skills/mingyu/references/providers/aov-mingyu.md
+++ b/public/skills/mingyu/references/providers/aov-mingyu.md
@@ -99,3 +99,29 @@
 | **七政四余提示词**| `/metaphysics/qizheng/prompt` | `qizheng_prompt` | 七政四余天星自包含解读提示词 |
 | **AI 运行流** | `/ai/analyze` | - | SSE 流式 AI 问答接口 |
 | **AI 可用模型** | `/ai/models` | - | 查询内置或外部模型列表 |
+
+---
+
+## 三、出生时间、时区与真太阳时参数
+
+- `timezone` 表示固定 UTC 偏移，单位为小时，范围为 `-12` 到 `14`，支持 `5.5` 等小数；`timezone: 8` 表示 UTC+8，不是分钟偏移 `480`。
+- `timeZoneId` 使用 IANA 时区标识（例如 `Asia/Shanghai` 或 `America/New_York`），优先用于需要按出生日期解析历史时区或夏令时的场景。
+- `useTrueSolarTime: true` 用于八字或紫微真太阳时排盘。提供 `birthHour`、`birthMinute`、`birthLongitude` 后可省略 `timeIndex`，接口会自动推导真太阳时对应的时辰。
+- `POST /calendar/true-solar-birth` 是出生资料专用的真太阳时换算接口；一般当地钟表时间换算使用 `POST /calendar/true-solar-time`。两个接口的结果都从 AOV REST 响应的 `data` 字段读取。
+- `detailMode: "compact"` 适合常规调用和前端展示；`detailMode: "full"` 返回完整证据链与计算过程，适合审计或研究。
+
+八字真太阳时排盘示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/bazi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"gender":"male","year":1990,"month":6,"day":15,"dateType":"solar","useTrueSolarTime":true,"birthHour":14,"birthMinute":30,"birthPlace":"上海","birthLongitude":121.47,"timeZoneId":"Asia/Shanghai","shenShaScope":"all","detailMode":"full"}'
+```
+
+出生真太阳时换算示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
+  -H "Content-Type: application/json" \
+  -d '{"dateType":"solar","year":1990,"month":6,"day":15,"hour":14,"minute":30,"longitude":121.47,"timeZoneId":"Asia/Shanghai"}'
+```

--- a/skills/mingyu/references/providers/aov-mingyu.md
+++ b/skills/mingyu/references/providers/aov-mingyu.md
@@ -99,3 +99,29 @@
 | **七政四余提示词**| `/metaphysics/qizheng/prompt` | `qizheng_prompt` | 七政四余天星自包含解读提示词 |
 | **AI 运行流** | `/ai/analyze` | - | SSE 流式 AI 问答接口 |
 | **AI 可用模型** | `/ai/models` | - | 查询内置或外部模型列表 |
+
+---
+
+## 三、出生时间、时区与真太阳时参数
+
+- `timezone` 表示固定 UTC 偏移，单位为小时，范围为 `-12` 到 `14`，支持 `5.5` 等小数；`timezone: 8` 表示 UTC+8，不是分钟偏移 `480`。
+- `timeZoneId` 使用 IANA 时区标识（例如 `Asia/Shanghai` 或 `America/New_York`），优先用于需要按出生日期解析历史时区或夏令时的场景。
+- `useTrueSolarTime: true` 用于八字或紫微真太阳时排盘。提供 `birthHour`、`birthMinute`、`birthLongitude` 后可省略 `timeIndex`，接口会自动推导真太阳时对应的时辰。
+- `POST /calendar/true-solar-birth` 是出生资料专用的真太阳时换算接口；一般当地钟表时间换算使用 `POST /calendar/true-solar-time`。两个接口的结果都从 AOV REST 响应的 `data` 字段读取。
+- `detailMode: "compact"` 适合常规调用和前端展示；`detailMode: "full"` 返回完整证据链与计算过程，适合审计或研究。
+
+八字真太阳时排盘示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/bazi/calculate \
+  -H "Content-Type: application/json" \
+  -d '{"gender":"male","year":1990,"month":6,"day":15,"dateType":"solar","useTrueSolarTime":true,"birthHour":14,"birthMinute":30,"birthPlace":"上海","birthLongitude":121.47,"timeZoneId":"Asia/Shanghai","shenShaScope":"all","detailMode":"full"}'
+```
+
+出生真太阳时换算示例：
+
+```bash
+curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
+  -H "Content-Type: application/json" \
+  -d '{"dateType":"solar","year":1990,"month":6,"day":15,"hour":14,"minute":30,"longitude":121.47,"timeZoneId":"Asia/Shanghai"}'
+```

--- a/tests/api/public-api-docs.test.ts
+++ b/tests/api/public-api-docs.test.ts
@@ -31,6 +31,23 @@ test('公开 API 文档必须同步出生真太阳时端点与 OpenAPI 包装层
   assert.match(publicApiDocs, /spec\["data"\]\["paths"\]/);
 });
 
+test('AOV Provider 手册必须说明真太阳时出生参数和 timezone 单位', () => {
+  for (const content of skillProviderRefs) {
+    assert.match(content, /timezone.*单位为小时/);
+    assert.match(content, /-12.*14/);
+    assert.match(content, /useTrueSolarTime.*birthHour.*birthMinute.*birthLongitude/);
+    assert.match(content, /可省略 `timeIndex`/);
+    assert.match(content, /timeZoneId.*Asia\/Shanghai/);
+    assert.match(content, /detailMode: \"full\".*完整证据链/);
+    assert.match(content, /curl -X POST https:\/\/aov\.cc\/api\/v1\/bazi\/calculate/);
+  }
+
+  assert.match(publicApiDocs, /timezone.*单位为小时/);
+  assert.match(publicApiDocs, /useTrueSolarTime.*birthHour.*birthMinute.*birthLongitude/);
+  assert.match(publicApiDocs, /timeZoneId.*Asia\/Shanghai/);
+  assert.match(publicApiDocs, /detailMode: \"full\".*完整证据链/);
+});
+
 test('公开 API 文档和 provider 适配层应写明 AI 接口', () => {
   for (const content of [publicApiDocs, aovProviderRef]) {
     assert.match(content, /POST \/ai\/analyze/);


### PR DESCRIPTION
补充 Issue #251 中未覆盖的 AOV 真太阳时参数口径。

主要修改：
- 明确 timezone 是小时制固定 UTC 偏移，范围 -12 到 14，支持 5.5 等小数；timezone: 8 不是分钟偏移 480。
- 补充 timeZoneId 的 IANA 时区用法和 Asia/Shanghai 示例。
- 说明 useTrueSolarTime 启用后，提供 birthHour、birthMinute、birthLongitude 时可省略 timeIndex。
- 补充八字真太阳时排盘与 calendar/true-solar-birth 的可直接运行 curl 示例。
- 补充 detailMode compact/full 的适用场景，并增加参数文档回归测试。

验证：
- 文档测试 11/11 通过。
- pnpm format:check 通过。
- git diff --check 通过。
- 两个真实 AOV 请求均返回 HTTP 200、ok: true 且包含 data。
- 全仓库未发现 /bazi/chart 或 /ziwei/chart。