### PR TITLE
明确八字流月的节气起始日期

### DIFF
--- a/src/components/BaziFortuneTools/BaziFortuneModal.tsx
+++ b/src/components/BaziFortuneTools/BaziFortuneModal.tsx
@@ -15,6 +15,7 @@ import {
   baziFortuneScopeLabelMap,
   buildCurrentBaziFortuneSelection,
   formatBaziCycleDisplay,
+  formatBaziMonthStart,
 } from './helpers';
 import { WorkspaceButton, WorkspaceDialog } from '@/components/workspace/WorkspaceUI';
 
@@ -289,8 +290,12 @@ export function BaziFortuneModal(props: {
                         setDraftScope('month');
                       }}
                     >
-                      <strong>{monthNumber}月</strong>
-                      <span>{item.month}</span>
+                      <strong>{item.month}</strong>
+                      <span
+                        title={`${item.startTermName ?? ''} ${item.startDateTime ?? item.startDate}`}
+                      >
+                        {formatBaziMonthStart(item)}
+                      </span>
                       <span>
                         {item.startDate} 至 {item.endDate}
                       </span>

--- a/src/components/BaziFortuneTools/BaziFortuneSelector.tsx
+++ b/src/components/BaziFortuneTools/BaziFortuneSelector.tsx
@@ -12,6 +12,7 @@ import {
 import { getDayHourBreakdown } from '@core/bazi/fortuneSelection/helpers/breakdown';
 import {
   formatBaziTenGodAbbreviation,
+  formatBaziMonthStart,
   getCurrentLuckCycle,
   getWuxingClass,
   splitGanZhi,
@@ -244,7 +245,12 @@ export function BaziFortuneSelector(props: {
                   onClick={() => setSelectedMonth(monthNumber)}
                 >
                   <div className="fortune-year">{item.month}</div>
-                  <div className="fortune-age">{monthNumber}月</div>
+                  <div
+                    className="fortune-age"
+                    title={`${item.startTermName ?? ''} ${item.startDateTime ?? item.startDate}`}
+                  >
+                    {formatBaziMonthStart(item)}
+                  </div>
                   <FortuneGanZhi ganZhi={item.ganZhi} dayMaster={result.dayMaster.gan} />
                 </button>
               );

--- a/src/components/BaziFortuneTools/helpers.ts
+++ b/src/components/BaziFortuneTools/helpers.ts
@@ -31,6 +31,11 @@ export function formatBaziTenGodAbbreviation(value: string) {
   return baziTenGodAbbreviationMap[value] ?? value;
 }
 
+export function formatBaziMonthStart(month: { startDate: string; startTermName?: string }) {
+  const [, monthNumber, day] = month.startDate.split('-');
+  return [month.startTermName, `${Number(monthNumber)}/${Number(day)}`].filter(Boolean).join(' ');
+}
+
 export function splitGanZhi(value: string) {
   return [value.charAt(0), value.charAt(1)];
 }


### PR DESCRIPTION
八字流月卡片曾把从寅月起算的第 10 个节令月显示成“10月”，容易被理解成公历十月。现在岁运面板与自选年限弹窗统一显示月支、起始节气及公历日期，例如“亥月 · 立冬 11/7 · 己亥”，并保留准确交节时间和日期范围。

仅调整前端显示，共用日期格式化函数；节令月序号、选择参数、干支计算和公开接口保持兼容。

验证：NAS 生产构建、应用类型检查及日历/运限选择 28 项回归全部通过；实际浏览器验证桌面与 390px 窄屏、亥月选择与流日联动、弹窗确认，控制台无错误。界面截图保存在本次任务本地 .local/issue-259/，未提交内部验证资料。

Closes #259