### PR TITLE
将首页术数与案例选择改为说明卡片弹窗

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
-def mingyuVersionCode = (System.getenv('MINGYU_VERSION_CODE') ?: '5') as Integer
-def mingyuVersionName = System.getenv('MINGYU_VERSION_NAME') ?: '1.1.4'
+def mingyuVersionCode = (System.getenv('MINGYU_VERSION_CODE') ?: '6') as Integer
+def mingyuVersionName = System.getenv('MINGYU_VERSION_NAME') ?: '1.1.5'
 def mingyuSigningStoreFile = System.getenv('MINGYU_SIGNING_STORE_FILE')
 def hasMingyuReleaseSigning = [
     mingyuSigningStoreFile,

--- a/src/pages/HomePage.SelectionDialog.css
+++ b/src/pages/HomePage.SelectionDialog.css
@@ -1,0 +1,110 @@
+.workspace-ui-dialog.home-selection-dialog {
+  width: min(900px, calc(100vw - 32px));
+  max-height: min(780px, calc(100dvh - 32px));
+}
+
+.home-selection-search {
+  padding: 16px 20px 0;
+}
+
+.home-selection-search input {
+  width: 100%;
+}
+
+.home-selection-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.home-selection-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.home-selection-card.is-selected {
+  border-color: var(--accent-strong);
+  background: var(--state-selected-surface);
+}
+
+.home-selection-option {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 9px;
+  width: 100%;
+  padding: 18px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.home-selection-option:hover,
+.home-selection-favorite:hover {
+  background: var(--state-hover-surface);
+}
+
+.home-selection-option:focus-visible,
+.home-selection-favorite:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: -3px;
+}
+
+.home-selection-name {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  font-size: 16px;
+}
+
+.home-selection-status {
+  flex-shrink: 0;
+  color: var(--accent-strong);
+  font-size: 12px;
+}
+
+.home-selection-description {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.home-selection-favorite {
+  align-self: flex-start;
+  min-height: 36px;
+  margin: 0 12px 10px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.home-selection-favorite[aria-pressed='true'] {
+  color: var(--accent-strong);
+}
+
+.home-selection-empty {
+  padding: 24px 0;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+@media (max-width: 600px) {
+  .home-selection-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .home-selection-option {
+    padding: 16px;
+  }
+}

--- a/src/pages/HomePage.SelectionDialog.tsx
+++ b/src/pages/HomePage.SelectionDialog.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useId, useState } from 'react';
+import { WorkspaceButton, WorkspaceDialog } from '@/components/workspace/WorkspaceUI';
+import './HomePage.SelectionDialog.css';
+
+export type HomeSelectionOption = {
+  value: string;
+  label: string;
+  description: string;
+};
+
+export function HomeSelectionDialog(props: {
+  title: string;
+  searchPlaceholder: string;
+  options: HomeSelectionOption[];
+  value: string;
+  onSelect: (value: string) => void;
+  onClose: () => void;
+  favoriteValue?: string;
+  favoriteLabel?: string;
+  onFavoriteChange?: (value: string) => void;
+}) {
+  const titleId = useId();
+  const [search, setSearch] = useState('');
+  const keyword = search.trim().toLocaleLowerCase();
+  const options = props.options.filter((option) =>
+    `${option.label} ${option.description}`.toLocaleLowerCase().includes(keyword),
+  );
+
+  useEffect(() => {
+    const dialog = document.getElementById(titleId)?.closest('[role="dialog"]');
+    if (!dialog) return;
+    const trapFocus = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab') return;
+      const controls = dialog.querySelectorAll<HTMLElement>('button:not(:disabled), input');
+      const first = controls[0];
+      const last = controls[controls.length - 1];
+      if (!first || !last) return;
+      if (
+        event.shiftKey &&
+        (document.activeElement === first || document.activeElement === dialog)
+      ) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', trapFocus);
+    return () => document.removeEventListener('keydown', trapFocus);
+  }, [titleId]);
+
+  return (
+    <WorkspaceDialog className="home-selection-dialog" labelledBy={titleId} onClose={props.onClose}>
+      <header className="workspace-ui-dialog-header">
+        <h2 id={titleId}>{props.title}</h2>
+        <WorkspaceButton
+          variant="ghost"
+          size="small"
+          onClick={props.onClose}
+          aria-label={`关闭${props.title}`}
+        >
+          关闭
+        </WorkspaceButton>
+      </header>
+      <div className="home-selection-search">
+        <input
+          type="search"
+          className="workspace-ui-control"
+          aria-label={props.searchPlaceholder}
+          placeholder={props.searchPlaceholder}
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      </div>
+      <div className="workspace-ui-dialog-body">
+        {options.length ? (
+          <div className="home-selection-grid">
+            {options.map((option) => (
+              <div
+                className={`home-selection-card ${option.value === props.value ? 'is-selected' : ''}`}
+                key={option.value}
+              >
+                <button
+                  type="button"
+                  className="home-selection-option"
+                  aria-pressed={option.value === props.value}
+                  onClick={() => props.onSelect(option.value)}
+                >
+                  <span className="home-selection-name">
+                    <strong>{option.label}</strong>
+                    {option.value === props.value ? (
+                      <span className="home-selection-status">已选</span>
+                    ) : null}
+                  </span>
+                  <span className="home-selection-description">{option.description}</span>
+                </button>
+                {props.onFavoriteChange ? (
+                  <button
+                    type="button"
+                    className="home-selection-favorite"
+                    aria-label={`${option.label}设为${props.favoriteLabel}`}
+                    aria-pressed={option.value === props.favoriteValue}
+                    onClick={() => props.onFavoriteChange?.(option.value)}
+                  >
+                    {option.value === props.favoriteValue ? '★ 默认' : '☆ 设为默认'}
+                  </button>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="home-selection-empty">没有找到匹配项，请换个关键词。</p>
+        )}
+      </div>
+    </WorkspaceDialog>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -44,6 +44,7 @@ import {
   type HomeModeId,
 } from '@/lib/workspace';
 import { BirthPlaceModal } from './InputPage.BirthPlaceModal';
+import { HomeSelectionDialog, type HomeSelectionOption } from './HomePage.SelectionDialog';
 
 const modeCopy: Record<HomeModeId, { heading: string; placeholder: string }> = {
   chart: {
@@ -81,6 +82,7 @@ export function HomePage() {
   const [temporaryBirthYear, setTemporaryBirthYear] = useState('');
   const [isSupplementaryInfoModalOpen, setIsSupplementaryInfoModalOpen] = useState(false);
   const [isQuestionInspirationOpen, setIsQuestionInspirationOpen] = useState(false);
+  const [selectionDialog, setSelectionDialog] = useState<'algorithm' | 'case' | null>(null);
   const [inspirationCategory, setInspirationCategory] = useState('近期');
   const [inspirationSearch, setInspirationSearch] = useState('');
   const [selectedChartFeature, setSelectedChartFeature] = useState<ChartWorkspaceId>(
@@ -127,33 +129,44 @@ export function HomePage() {
     () => orderedFeatures.filter((feature) => isDivinationWorkspaceId(feature.id)),
     [orderedFeatures],
   );
-  const chartOptions = useMemo<DropdownSelectOption<string>[]>(
-    () => chartFeatures.map((feature) => ({ value: feature.id, label: feature.label })),
+  const chartOptions = useMemo<HomeSelectionOption[]>(
+    () =>
+      chartFeatures.map((feature) => ({
+        value: feature.id,
+        label: feature.label,
+        description: feature.description,
+      })),
     [chartFeatures],
   );
-  const divinationOptions = useMemo<DropdownSelectOption<string>[]>(
-    () => divinationFeatures.map((feature) => ({ value: feature.id, label: feature.label })),
+  const divinationOptions = useMemo<HomeSelectionOption[]>(
+    () =>
+      divinationFeatures.map((feature) => ({
+        value: feature.id,
+        label: feature.label,
+        description: feature.description,
+      })),
     [divinationFeatures],
   );
-  const instantOptions = useMemo<DropdownSelectOption<string>[]>(
+  const instantOptions = useMemo<HomeSelectionOption[]>(
     () =>
       INSTANT_CHART_DEFINITIONS.map((definition) => ({
         value: definition.type,
         label: definition.label,
+        description: definition.description,
       })),
     [],
   );
-  const caseOptions = useMemo<DropdownSelectOption<string>[]>(
+  const caseOptions = useMemo<HomeSelectionOption[]>(
     () => [
       {
         value: TEMPORARY_CASE_VALUE,
         label: '不指定案例',
-        triggerLabel: '临时档案',
+        description: '使用临时档案，本次自行填写求测资料。',
       },
       ...sortPersonalCasesForQuickSwitch(cases).map((record) => ({
         value: record.id,
-        label: `${record.name} · ${record.birthText}`,
-        triggerLabel: record.name,
+        label: record.name,
+        description: `${record.input.gender === 'male' ? '男' : '女'} · ${record.birthText}`,
       })),
     ],
     [cases],
@@ -484,28 +497,33 @@ export function HomePage() {
             </div>
             <div className="workspace-home-composer-footer">
               <div className="workspace-home-algorithm">
-                <DropdownSelect<string>
-                  value={selectedAlgorithm}
-                  options={algorithmOptions}
-                  onChange={selectAlgorithm}
-                  ariaLabel="选择算法"
-                  prefix="算法"
-                  variant="field"
-                  favoriteValue={favoriteAlgorithmValue}
-                  favoriteLabel={favoriteAlgorithmLabel}
-                  onFavoriteChange={favoriteAlgorithm}
-                />
+                <button
+                  type="button"
+                  className="workspace-ui-dropdown-trigger is-field"
+                  aria-label="选择术数"
+                  aria-haspopup="dialog"
+                  aria-expanded={selectionDialog === 'algorithm'}
+                  onClick={() => setSelectionDialog('algorithm')}
+                >
+                  <span className="workspace-ui-dropdown-prefix">术数</span>
+                  <span>
+                    {algorithmOptions.find((option) => option.value === selectedAlgorithm)?.label}
+                  </span>
+                </button>
               </div>
               {activeMode !== 'instant' ? (
                 <div className="workspace-home-case-select">
-                  <DropdownSelect<string>
-                    value={activeCaseId ?? TEMPORARY_CASE_VALUE}
-                    options={caseOptions}
-                    onChange={(value) => selectCase(value === TEMPORARY_CASE_VALUE ? null : value)}
-                    ariaLabel="切换案例"
-                    prefix="案例"
-                    variant="field"
-                  />
+                  <button
+                    type="button"
+                    className="workspace-ui-dropdown-trigger is-field"
+                    aria-label="选择案例"
+                    aria-haspopup="dialog"
+                    aria-expanded={selectionDialog === 'case'}
+                    onClick={() => setSelectionDialog('case')}
+                  >
+                    <span className="workspace-ui-dropdown-prefix">案例</span>
+                    <span>{activeCase?.name ?? '临时档案'}</span>
+                  </button>
                 </div>
               ) : (
                 <div className="workspace-home-time-context">
@@ -559,6 +577,30 @@ export function HomePage() {
           </form>
         </div>
       </div>
+      {selectionDialog ? (
+        <HomeSelectionDialog
+          key={selectionDialog}
+          title={selectionDialog === 'algorithm' ? '选择术数' : '选择案例'}
+          searchPlaceholder={
+            selectionDialog === 'algorithm' ? '搜索术数名称或适用场景' : '搜索姓名或出生资料'
+          }
+          options={selectionDialog === 'algorithm' ? algorithmOptions : caseOptions}
+          value={
+            selectionDialog === 'algorithm'
+              ? selectedAlgorithm
+              : (activeCaseId ?? TEMPORARY_CASE_VALUE)
+          }
+          onSelect={(value) => {
+            if (selectionDialog === 'algorithm') selectAlgorithm(value);
+            else selectCase(value === TEMPORARY_CASE_VALUE ? null : value);
+            setSelectionDialog(null);
+          }}
+          onClose={() => setSelectionDialog(null)}
+          favoriteValue={selectionDialog === 'algorithm' ? favoriteAlgorithmValue : undefined}
+          favoriteLabel={favoriteAlgorithmLabel}
+          onFavoriteChange={selectionDialog === 'algorithm' ? favoriteAlgorithm : undefined}
+        />
+      ) : null}
       {instantBirthPlace.isBirthPlaceModalOpen ? (
         <BirthPlaceModal birthPlace={instantBirthPlace} purpose="observer" />
       ) : null}


### PR DESCRIPTION
首页术数与案例选择改为较大的卡片弹窗。占问卡片重新展示现有适用场景说明，排盘及即时盘展示各自说明；案例卡片分开展示姓名、性别和出生资料。

支持按名称、场景或出生资料搜索，点击卡片后选中并关闭；保留三种模式各自的默认术数设置、案例排序、临时档案和既有启动流程。弹窗支持 Escape 关闭、焦点循环与关闭后焦点恢复，手机端使用单列滚动布局。

验证：NAS 生产构建、应用类型检查、相关 ESLint 检查及 22 项工作区/案例回归通过；实际浏览器验证三个模式、默认设置刷新保留、场景搜索、案例搜索与切换、空结果、输入问题保留及 390px 窄屏，控制台无错误。桌面和手机截图保存在本次任务的 .local/issue-255/，内部验证资料未提交。

同时将 Android 默认版本递增至 1.1.5，正式签名包的 versionCode 沿用发布流水线递增规则。不改变排盘算法、公开接口或已有案例数据格式。

Closes #255