### PR TITLE
完善双主体补算核验并保留完整解读资料

### DIFF
--- a/packages/core/src/bazi/fortuneSelection/helpers/types.ts
+++ b/packages/core/src/bazi/fortuneSelection/helpers/types.ts
@@ -38,6 +38,7 @@ export interface FortuneSelectionContext {
   yearGanZhi?: string;
   yearAge?: number;
   month?: number;
+  day?: number;
   monthGanZhi?: string;
   monthLabel?: string;
   monthStartDate?: string;

--- a/packages/core/src/bazi/fortuneSelection/index.ts
+++ b/packages/core/src/bazi/fortuneSelection/index.ts
@@ -771,6 +771,7 @@ export function buildFortuneSelectionContext(
     ...baseContext,
     scope: 'day',
     month: normalized.month,
+    day: normalized.day,
     monthGanZhi: monthInfo.ganZhi,
     monthLabel: monthInfo.month,
     hourBreakdown,

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -911,11 +911,18 @@ export async function executeReadingAction(
     };
   }
   const requestInput = calculationInput ?? action.input;
-  const data = await fetchReadingData(path, signal, {
+  const calculationRequest: Record<string, unknown> = {
     ...(locked ?? {}),
     ...requestInput,
     responseMode: 'full',
-  });
+  };
+  if (
+    (action.method === 'bazi' || action.method === 'ziwei') &&
+    calculationRequest.useTrueSolarTime === true
+  ) {
+    delete calculationRequest.timeIndex;
+  }
+  const data = await fetchReadingData(path, signal, calculationRequest);
   if (locked) verifyStructuredCalculation(action.method, data, locked, requestInput);
   if (typeof data.prompt !== 'string' || !data.prompt.trim())
     throw new Error('补算未返回完整盘面。');

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -2,9 +2,10 @@ import {
   READING_CLASSIC_TABLES as TABLES,
   READING_CALCULATION_ROUTES as ROUTES,
 } from './reading-capabilities';
-import type { ReadingAction, ReadingResource } from './reading-workflow';
+import type { ReadingAction, ReadingResource, ReadingTarget } from './reading-workflow';
 import type { ReadingSubjectSnapshot } from './reading-subject';
 import { getAiApiEndpoint } from './stream-client';
+import { getTimeIndexFromClock } from 'mingyu-core/calendar';
 
 const LABELS: Record<string, string> = {
   sourceBook: '典籍',
@@ -364,10 +365,443 @@ function filterCalculationSchema(method: string, value: unknown): Record<string,
 
   return {
     type: 'object',
+    description:
+      '这是补算 input。calculate 动作另带 target，取值为 primary 或 partner；partner 只在当前会话存在伴侣主体快照时使用。',
     properties: filteredProperties,
     ...(filteredRequired.length > 0 ? { required: filteredRequired } : {}),
     additionalProperties: false,
   };
+}
+
+function resolveReadingTarget(action: ReadingAction): ReadingTarget {
+  return action.kind === 'calculate' && action.target === 'partner' ? 'partner' : 'primary';
+}
+
+function resolveLockedInputKey(method: string, target: ReadingTarget) {
+  return target === 'partner' ? `${method}Partner` : method;
+}
+
+function assertStructuredField(
+  label: string,
+  expected: unknown,
+  actual: unknown,
+  options: { allowMissing?: boolean } = {},
+) {
+  if (expected === undefined) return;
+  if (actual === undefined && options.allowMissing) return;
+  if (actual === undefined || stableComparable(expected) !== stableComparable(actual)) {
+    throw new Error(`补算身份核验失败：${label}。`);
+  }
+}
+
+function assertIdentityBirth(
+  method: string,
+  identity: Record<string, unknown>,
+  locked: Record<string, unknown>,
+) {
+  const birth = identity.birth;
+  if (!record(birth)) throw new Error('补算返回缺少结构化出生主体身份。');
+
+  const fields = [
+    'gender',
+    'year',
+    'month',
+    'day',
+    'dateType',
+    'isLeapMonth',
+    'useTrueSolarTime',
+    'timeZoneId',
+    'timezone',
+    'birthPlace',
+    'birthLatitude',
+    'applyChinaDst',
+  ];
+  for (const field of fields) {
+    assertStructuredField(`${method}.${field}`, locked[field], birth[field]);
+  }
+
+  const useTrueSolarTime = locked.useTrueSolarTime === true;
+  if (useTrueSolarTime) {
+    for (const field of ['birthHour', 'birthMinute', 'birthLongitude']) {
+      assertStructuredField(`${method}.${field}`, locked[field], birth[field]);
+    }
+  } else {
+    assertStructuredField(`${method}.timeIndex`, locked.timeIndex, birth.timeIndex);
+  }
+
+  if (method === 'ziwei') {
+    assertStructuredField(`${method}.name`, locked.name, birth.name);
+    assertStructuredField(`${method}.algorithm`, locked.algorithm, birth.algorithm);
+  }
+}
+
+function assertBaziTarget(
+  identity: Record<string, unknown>,
+  result: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  const target = identity.target;
+  if (!record(target)) throw new Error('补算返回缺少结构化目标时段身份。');
+  const fields = [
+    'baziFortuneScope',
+    'baziFortuneCycleIndex',
+    'baziFortuneYear',
+    'baziFortuneMonth',
+    'baziFortuneDay',
+  ];
+  for (const field of fields) {
+    assertStructuredField(`bazi.${field}`, calculationInput[field], target[field]);
+  }
+
+  const selection = result.fortuneSelection;
+  const requestedScope = calculationInput.baziFortuneScope;
+  if (requestedScope !== undefined && requestedScope !== 'natal' && requestedScope !== 'full') {
+    if (!record(selection)) throw new Error('补算返回缺少结构化八字目标运限。');
+    assertStructuredField('bazi.fortuneSelection.scope', target.baziFortuneScope, selection.scope);
+    for (const field of [
+      'baziFortuneCycleIndex',
+      'baziFortuneYear',
+      'baziFortuneMonth',
+      'baziFortuneDay',
+    ]) {
+      const selectionField =
+        field === 'baziFortuneCycleIndex'
+          ? 'cycleIndex'
+          : field.replace('baziFortune', '').replace(/^./u, (value) => value.toLowerCase());
+      assertStructuredField(
+        `bazi.fortuneSelection.${selectionField}`,
+        target[field],
+        selection[selectionField],
+        { allowMissing: field === 'baziFortuneYear' && requestedScope === 'dayun' },
+      );
+    }
+  }
+}
+
+function assertDateParts(label: string, expected: Record<string, unknown>, actual: unknown) {
+  if (!record(actual)) throw new Error(`补算返回缺少结构化${label}。`);
+  for (const field of ['year', 'month', 'day']) {
+    assertStructuredField(`${label}.${field}`, expected[field], actual[field]);
+  }
+}
+
+function assertTrueSolarEvidence(
+  label: string,
+  timing: Record<string, unknown> | undefined,
+): {
+  standardTime: Record<string, unknown>;
+  correctedTime: Record<string, unknown>;
+} {
+  if (!timing || timing.enabled !== true) {
+    throw new Error(`补算返回缺少${label}真太阳时证据。`);
+  }
+  const standardTime = timing.standardTime;
+  if (
+    !record(standardTime) ||
+    ['year', 'month', 'day', 'hour', 'minute'].some(
+      (field) => typeof standardTime[field] !== 'number',
+    )
+  ) {
+    throw new Error(`补算返回缺少${label}真太阳时标准时间。`);
+  }
+  const correctedTime = timing.correctedTime;
+  if (
+    !record(correctedTime) ||
+    ['year', 'month', 'day', 'hour', 'minute'].some(
+      (field) => typeof correctedTime[field] !== 'number',
+    )
+  ) {
+    throw new Error(`补算返回缺少${label}真太阳时校正结果。`);
+  }
+  const evidence = timing.evidence;
+  if (!record(evidence) || typeof evidence.key !== 'string' || !evidence.key.trim()) {
+    throw new Error(`补算返回缺少${label}真太阳时计算证据。`);
+  }
+  return { standardTime, correctedTime };
+}
+
+function assertBaziResultFacts(
+  result: Record<string, unknown>,
+  identity: Record<string, unknown>,
+  locked: Record<string, unknown>,
+) {
+  assertStructuredField('bazi.result.gender', locked.gender, result.gender);
+  const birth = identity.birth;
+  if (!record(birth)) throw new Error('补算返回缺少结构化出生主体身份。');
+  const dateType = birth.dateType;
+  const useTrueSolarTime = locked.useTrueSolarTime === true;
+  const timeInfo = result.timeInfo;
+  if (!record(timeInfo)) throw new Error('补算返回缺少八字实际出生时辰。');
+  if (!useTrueSolarTime) {
+    if (dateType === 'lunar') {
+      assertDateParts('八字实际农历出生日期', birth, result.lunarDate);
+    } else {
+      assertDateParts('八字实际公历出生日期', birth, result.solarDate);
+    }
+    assertStructuredField('bazi.result.timeInfo.index', locked.timeIndex, timeInfo.index);
+    return;
+  }
+
+  const timing = record(result.timing) ? result.timing : undefined;
+  const { standardTime, correctedTime } = assertTrueSolarEvidence('八字', timing);
+  assertDateParts('八字实际校正公历出生日期', correctedTime, result.solarDate);
+  assertStructuredField(
+    'bazi.result.timeInfo.index',
+    getTimeIndexFromClock(Number(correctedTime.hour), Number(correctedTime.minute)),
+    timeInfo.index,
+  );
+  if (dateType === 'solar') {
+    for (const field of ['year', 'month', 'day']) {
+      assertStructuredField(`bazi.timing.standardTime.${field}`, birth[field], standardTime[field]);
+    }
+    assertStructuredField('bazi.timing.standardTime.hour', locked.birthHour, standardTime.hour);
+    assertStructuredField(
+      'bazi.timing.standardTime.minute',
+      locked.birthMinute,
+      standardTime.minute,
+    );
+  }
+}
+
+function normalizeDateKey(value: unknown) {
+  if (typeof value !== 'string') return undefined;
+  const match = value.match(/(\d{4})\D+(\d{1,2})\D+(\d{1,2})/u);
+  if (!match) return undefined;
+  return [match[1], match[2].padStart(2, '0'), match[3].padStart(2, '0')].join('-');
+}
+
+function assertZiweiResultFacts(
+  result: Record<string, unknown>,
+  identity: Record<string, unknown>,
+  locked: Record<string, unknown>,
+) {
+  const basicInfo = result.basicInfo;
+  if (!record(basicInfo)) throw new Error('补算返回缺少紫微实际本命资料。');
+  const expectedGender =
+    locked.gender === 'male' ? '男' : locked.gender === 'female' ? '女' : locked.gender;
+  assertStructuredField('ziwei.result.basicInfo.gender', expectedGender, basicInfo.gender);
+
+  const birth = identity.birth;
+  if (!record(birth)) throw new Error('补算返回缺少结构化出生主体身份。');
+  if (birth.dateType === 'solar' && locked.useTrueSolarTime !== true) {
+    const actualDate = normalizeDateKey(basicInfo.solar_date);
+    const expectedDate = [birth.year, birth.month, birth.day]
+      .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, '0')))
+      .join('-');
+    assertStructuredField('ziwei.result.basicInfo.solar_date', expectedDate, actualDate);
+  }
+
+  if (locked.useTrueSolarTime === true) {
+    const evidence = result.trueSolarEvidence;
+    if (!record(evidence) || typeof evidence.key !== 'string' || !evidence.key.trim()) {
+      throw new Error('补算返回缺少紫微真太阳时计算证据。');
+    }
+  }
+}
+
+function assertZiweiTarget(
+  identity: Record<string, unknown>,
+  result: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  const target = identity.target;
+  if (!record(target)) throw new Error('补算返回缺少结构化目标时段身份。');
+  assertStructuredField('ziwei.promptScope', calculationInput.promptScope, target.promptScope);
+  assertStructuredField('ziwei.scopeDate', calculationInput.scopeDate, target.scopeDate);
+  assertStructuredField(
+    'ziwei.scopeHourIndex',
+    calculationInput.scopeHourIndex,
+    target.scopeHourIndex,
+  );
+
+  const timeline = result.fortuneTimeline;
+  if (record(timeline)) {
+    assertStructuredField(
+      'ziwei.fortuneTimeline.targetDateStr',
+      target.scopeDate,
+      timeline.targetDateStr,
+    );
+    assertStructuredField(
+      'ziwei.fortuneTimeline.targetHourIndex',
+      target.scopeHourIndex,
+      timeline.targetHourIndex,
+    );
+  }
+
+  const scope = target.promptScope;
+  if (typeof scope === 'string' && scope !== 'full') {
+    const payloadByScope = result.payloadByScope;
+    const payload = record(payloadByScope) ? payloadByScope[scope] : undefined;
+    if (!record(payload) || !record(payload.active_scope)) {
+      throw new Error('补算返回缺少紫微实际目标宫限资料。');
+    }
+    assertStructuredField('ziwei.result.active_scope.scope', scope, payload.active_scope.scope);
+    if (scope !== 'origin' && target.scopeDate !== undefined) {
+      const actualDate = normalizeDateKey(payload.active_scope.solar_date);
+      assertStructuredField('ziwei.result.active_scope.solar_date', target.scopeDate, actualDate);
+    }
+  }
+}
+
+function assertBaziOrZiweiResult(
+  method: 'bazi' | 'ziwei',
+  data: Record<string, unknown>,
+  locked: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  const result = data.result;
+  if (!record(result)) throw new Error('补算未返回结构化盘面结果。');
+  const identity = result.calculationIdentity;
+  if (!record(identity)) throw new Error('补算未返回结构化身份，无法确认目标主体。');
+  assertStructuredField('calculationIdentity.method', method, identity.method);
+  assertIdentityBirth(method, identity, locked);
+  if (method === 'bazi') {
+    assertBaziResultFacts(result, identity, locked);
+    assertBaziTarget(identity, result, calculationInput);
+  } else {
+    assertZiweiResultFacts(result, identity, locked);
+    assertZiweiTarget(identity, result, calculationInput);
+  }
+}
+
+function assertAstrolabeResult(
+  data: Record<string, unknown>,
+  locked: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  const result = data.result;
+  if (!record(result) || !record(result.birth)) throw new Error('补算未返回结构化星盘主体身份。');
+  const birth = result.birth;
+  for (const field of ['name', 'gender']) {
+    assertStructuredField(`astrolabe.${field}`, locked[field] || undefined, birth[field]);
+  }
+  for (const field of ['latitude', 'longitude', 'timezone', 'timeZoneId']) {
+    assertStructuredField(`astrolabe.${field}`, locked[field], birth[field], {
+      allowMissing: field === 'timezone' && locked.timeZoneId !== undefined,
+    });
+  }
+  assertStructuredField(
+    'astrolabe.isTrueSolarTime',
+    locked.useTrueSolarTime,
+    birth.isTrueSolarTime,
+  );
+
+  if (locked.year !== undefined && locked.month !== undefined && locked.day !== undefined) {
+    const dateTime = birth.standardDateTime ?? birth.dateTime;
+    if (typeof dateTime !== 'string') throw new Error('补算返回缺少标准出生时间。');
+    const expectedDateTime = [locked.year, locked.month, locked.day]
+      .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, '0')))
+      .join('-');
+    const expectedClock =
+      locked.hour === undefined
+        ? undefined
+        : `${String(locked.hour).padStart(2, '0')}:${String(locked.minute ?? 0).padStart(2, '0')}`;
+    if (expectedClock) {
+      assertStructuredField(
+        'astrolabe.standardDateTime',
+        `${expectedDateTime} ${expectedClock}`,
+        dateTime,
+      );
+    }
+  }
+
+  const evidence = result.scopeEvidence;
+  const scope =
+    typeof calculationInput.astrolabeScopeText === 'string' &&
+    calculationInput.astrolabeScopeText.trim()
+      ? 'custom'
+      : (calculationInput.astrolabeScope ?? 'natal');
+  if (record(evidence)) {
+    assertStructuredField('astrolabe.scopeEvidence.scope', scope, evidence.scope);
+    const expectedDate = calculationInput.astrolabeScopeDate;
+    if (expectedDate !== undefined && scope !== 'custom') {
+      const actualDate = evidence.referenceDate ?? evidence.dateStr;
+      assertStructuredField('astrolabe.scopeEvidence.date', expectedDate, actualDate);
+    }
+  } else if (scope !== 'natal') {
+    throw new Error('补算返回缺少结构化目标时段身份。');
+  }
+}
+
+function assertQizhengResult(
+  data: Record<string, unknown>,
+  locked: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  const result = data.result;
+  if (!record(result) || !record(result.calculationContext))
+    throw new Error('补算未返回结构化七政计算口径。');
+  const context = result.calculationContext;
+  for (const field of ['latitude', 'longitude']) {
+    assertStructuredField(`qi-zheng.${field}`, locked[field], context[field]);
+  }
+  const flow = result.flowingStars;
+  const flowFields = ['flowYear', 'flowMonth', 'flowDay', 'flowHour', 'flowMinute'];
+  if (flowFields.some((field) => calculationInput[field] !== undefined)) {
+    if (!record(flow)) throw new Error('补算返回缺少结构化七政目标时段身份。');
+    for (const field of flowFields) {
+      const resultField = field.replace('flow', '').toLowerCase();
+      assertStructuredField(`qi-zheng.${field}`, calculationInput[field], flow[resultField]);
+    }
+  }
+}
+
+function verifyStructuredCalculation(
+  method: string,
+  data: Record<string, unknown>,
+  locked: Record<string, unknown>,
+  calculationInput: Record<string, unknown>,
+) {
+  if (method === 'bazi' || method === 'ziwei') {
+    assertBaziOrZiweiResult(method, data, locked, calculationInput);
+  } else if (method === 'astrolabe') {
+    assertAstrolabeResult(data, locked, calculationInput);
+  } else if (method === 'qi-zheng') {
+    assertQizhengResult(data, locked, calculationInput);
+  }
+}
+
+function buildCalculationResourceTitle(
+  method: string,
+  target: ReadingTarget,
+  locked: Record<string, unknown> | undefined,
+  calculationInput: Record<string, unknown>,
+  data: Record<string, unknown>,
+) {
+  const subjectName =
+    typeof locked?.name === 'string' && locked.name.trim()
+      ? locked.name.trim()
+      : target === 'partner'
+        ? '第二人'
+        : '第一人';
+  const methodName: Record<string, string> = {
+    bazi: '八字',
+    ziwei: '紫微',
+    astrolabe: '星盘',
+    'qi-zheng': '七政',
+  };
+  let range = '';
+  const result = record(data.result) ? data.result : undefined;
+  const identity = record(result?.calculationIdentity) ? result.calculationIdentity : undefined;
+  const identityTarget = record(identity?.target) ? identity.target : undefined;
+  if (method === 'bazi') {
+    const year = identityTarget?.baziFortuneYear ?? calculationInput.baziFortuneYear;
+    range = typeof year === 'number' || typeof year === 'string' ? `${year}年` : '';
+  } else if (method === 'ziwei') {
+    const date = identityTarget?.scopeDate ?? calculationInput.scopeDate;
+    const hour = identityTarget?.scopeHourIndex ?? calculationInput.scopeHourIndex;
+    range = typeof date === 'string' ? date : '';
+    if (typeof hour === 'number') range += `${range ? ' ' : ''}时辰${hour}`;
+  } else if (method === 'astrolabe') {
+    range =
+      typeof calculationInput.astrolabeScopeDate === 'string'
+        ? calculationInput.astrolabeScopeDate
+        : '';
+  } else if (method === 'qi-zheng') {
+    const year = calculationInput.flowYear;
+    range = typeof year === 'number' || typeof year === 'string' ? `${year}年` : '';
+  }
+  return `${subjectName}·${methodName[method] ?? method}${range}`;
 }
 
 async function fetchReadingData(
@@ -438,11 +872,18 @@ export async function executeReadingAction(
   if (!path) throw new Error('此方法暂不支持自动补算。');
   let locked: Record<string, unknown> | undefined;
   let calculationInput: Record<string, unknown> | undefined;
+  const target = resolveReadingTarget(action);
   if (subject) {
     if (!subject.allowedMethods.includes(action.method))
       throw new Error('补算方法与当前命盘类型不一致。');
-    locked = subject.lockedInputs[action.method];
-    if (!locked) throw new Error('当前会话缺少该方法的主体快照。');
+    locked = subject.lockedInputs[resolveLockedInputKey(action.method, target)];
+    if (!locked) {
+      throw new Error(
+        target === 'partner'
+          ? '当前会话没有第二人主体快照，已拒绝使用主主体替代。'
+          : '当前会话缺少该方法的主体快照。',
+      );
+    }
     if (action.kind === 'calculate') {
       calculationInput = prepareCalculationInput(action.method, action.input, locked);
     }
@@ -469,14 +910,22 @@ export async function executeReadingAction(
       usable: false,
     };
   }
+  const requestInput = calculationInput ?? action.input;
   const data = await fetchReadingData(path, signal, {
     ...(locked ?? {}),
-    ...(calculationInput ?? action.input),
-    responseMode: 'prompt-only',
+    ...requestInput,
+    responseMode: 'full',
   });
+  if (locked) verifyStructuredCalculation(action.method, data, locked, requestInput);
   if (typeof data.prompt !== 'string' || !data.prompt.trim())
     throw new Error('补算未返回完整盘面。');
-  return { key: '', title: '目标时段补充盘面', text: data.prompt, usable: true };
+  return {
+    key: '',
+    title: buildCalculationResourceTitle(action.method, target, locked, requestInput, data),
+    text: data.prompt,
+    usable: true,
+    structured: record(data.result) ? data.result : undefined,
+  };
 }
 
 function stableComparable(value: unknown): string {

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -343,7 +343,7 @@ export async function runReadingWorkflow(
     for (let round = 0; round < (isSimpleFollowup ? 0 : 2); round += 1) {
       let needsRefinement = false;
       guard();
-      const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。兼容双盘时每个补算动作都必须明确 target；primary 使用主主体快照，partner 使用伴侣主体快照，两个目标分别填写自己的目标时段。target 仅是动作选择，不写入公共 API 参数。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。没有伴侣主体快照或目标不明确时不执行 partner 补算。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
+      const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
       const schemas = schemaResources.length
         ? `\n\n【补算参数】\n${schemaResources.map((item) => `${item.title}\n${item.text}`).join('\n\n')}`
         : '';

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -5,10 +5,17 @@ import { verifyReadingAnswer } from './reading-verification';
 import type { ReadingSubjectSnapshot } from './reading-subject';
 import { FRONTEND_DEFAULT_TIME_ZONE_ID } from '@/lib/time-policy';
 
+export type ReadingTarget = 'primary' | 'partner';
+
 export type ReadingAction =
   | { kind: 'classic'; method: string; query: string }
   | { kind: 'schema'; method: string }
-  | { kind: 'calculate'; method: string; input: Record<string, unknown> };
+  | {
+      kind: 'calculate';
+      method: string;
+      target?: ReadingTarget;
+      input: Record<string, unknown>;
+    };
 export type ReadingResource = {
   key: string;
   title: string;
@@ -16,6 +23,7 @@ export type ReadingResource = {
   usable: boolean;
   kind?: 'evidence' | 'schema';
   sourceIds?: string[];
+  structured?: Record<string, unknown>;
 };
 export type ReadingMemory = { resources: ReadingResource[]; schemas?: ReadingResource[] };
 export type { ReadingSubjectSnapshot } from './reading-subject';
@@ -40,7 +48,6 @@ export interface ReadingOptions extends StreamOptions {
 }
 
 const MAX_CONTEXT = 49_000;
-const MAX_RESOURCES = 18_000;
 const MAX_ACTIONS = 4;
 const CALCULATIONS = Object.keys(READING_CALCULATION_ROUTES);
 
@@ -191,12 +198,17 @@ export function parseReadingPlan(text: string): ReadingAction[] {
         item.input &&
         typeof item.input === 'object' &&
         !Array.isArray(item.input)
-      )
+      ) {
+        if (item.target !== undefined && item.target !== 'primary' && item.target !== 'partner') {
+          throw new Error('资料准备的目标主体必须是 primary 或 partner。');
+        }
         return {
           kind: 'calculate',
           method: item.method,
+          target: item.target === undefined ? 'primary' : item.target,
           input: item.input as Record<string, unknown>,
         };
+      }
     }
     throw new Error('资料准备包含暂不支持的操作。');
   });
@@ -213,6 +225,44 @@ export function fitReadingMessages(messages: ChatMessage[], addition: string): C
   }
   if (size() > MAX_CONTEXT) throw new Error('本次盘面和问题超出解读容量，请缩小运限范围后继续。');
   return result;
+}
+
+function formatReadingResources(resources: ReadingResource[]) {
+  return resources.map((item) => `${item.title}\n${item.text}`).join('\n\n');
+}
+
+function formatCapacityNotice(stage: string, omitted: ReadingResource[]) {
+  if (!omitted.length) return '';
+  return `\n\n【资料覆盖】${stage}尚未覆盖以下资料，待后续补足：\n${omitted.map((item) => `- ${item.title}`).join('\n')}`;
+}
+
+type ResourceSelection = { selected: ReadingResource[]; omitted: ReadingResource[] };
+
+function selectResourcesForMessages(
+  messages: ChatMessage[],
+  resources: ReadingResource[],
+  buildAddition: (selected: ReadingResource[], omitted: ReadingResource[]) => string,
+): ResourceSelection {
+  const fits = (selected: ReadingResource[], omitted: ReadingResource[]) => {
+    try {
+      fitReadingMessages(messages, buildAddition(selected, omitted));
+      return true;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('解读容量')) return false;
+      throw error;
+    }
+  };
+
+  if (fits(resources, [])) return { selected: resources, omitted: [] };
+
+  const selected: ReadingResource[] = [];
+  const omitted: ReadingResource[] = [];
+  for (const resource of resources) {
+    if (fits([...selected, resource], omitted)) selected.push(resource);
+    else omitted.push(resource);
+  }
+  while (!fits(selected, omitted) && selected.length) omitted.push(selected.pop()!);
+  return { selected, omitted };
 }
 
 function collectResponse(
@@ -293,13 +343,20 @@ export async function runReadingWorkflow(
     for (let round = 0; round < (isSimpleFollowup ? 0 : 2); round += 1) {
       let needsRefinement = false;
       guard();
-      const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","input":{}}，按已读取的参数格式补算。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
+      const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。兼容双盘时每个补算动作都必须明确 target；primary 使用主主体快照，partner 使用伴侣主体快照，两个目标分别填写自己的目标时段。target 仅是动作选择，不写入公共 API 参数。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。没有伴侣主体快照或目标不明确时不执行 partner 补算。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
       const schemas = schemaResources.length
         ? `\n\n【补算参数】\n${schemaResources.map((item) => `${item.title}\n${item.text}`).join('\n\n')}`
         : '';
+      const planningMessages = [...messages, { role: 'user' as const, content: catalog }];
+      const planningSelection = selectResourcesForMessages(
+        planningMessages,
+        resources,
+        (selected, omitted) =>
+          `${guide}${currentTimeContext}${schemas}${formatCapacityNotice('资料准备', omitted)}\n\n${formatReadingResources(selected)}`,
+      );
       const prepared = fitReadingMessages(
-        [...messages, { role: 'user', content: catalog }],
-        `${guide}${currentTimeContext}${schemas}\n\n${resources.map((item) => `${item.title}\n${item.text}`).join('\n\n')}`,
+        planningMessages,
+        `${guide}${currentTimeContext}${schemas}${formatCapacityNotice('资料准备', planningSelection.omitted)}\n\n${formatReadingResources(planningSelection.selected)}`,
       );
       let actions: ReadingAction[];
       try {
@@ -320,7 +377,10 @@ export async function runReadingWorkflow(
       for (const action of actions) {
         guard();
         if (calls >= MAX_ACTIONS) break;
-        const key = JSON.stringify(action);
+        const key =
+          action.kind === 'calculate'
+            ? JSON.stringify({ ...action, target: action.target ?? 'primary' })
+            : JSON.stringify(action);
         if (seen.has(key)) continue;
         if (subjectMethods && !subjectMethods.has(action.method)) {
           options.onNotice(mismatchedMethodNotice);
@@ -329,6 +389,15 @@ export async function runReadingWorkflow(
         if (action.kind === 'calculate' && !options.subject) {
           notes.push('当前会话缺少主体快照，无法安全补算目标时段；请重新开始解读。');
           options.onNotice('当前对话缺少主体快照，已跳过自动补算。');
+          continue;
+        }
+        if (
+          action.kind === 'calculate' &&
+          action.target === 'partner' &&
+          !options.subject?.lockedInputs[`${action.method}Partner`]
+        ) {
+          notes.push('当前会话没有第二人主体快照，无法安全补算伴侣目标时段。');
+          options.onNotice('当前会话没有第二人主体快照，已跳过伴侣补算。');
           continue;
         }
         if (
@@ -358,17 +427,6 @@ export async function runReadingWorkflow(
             notes.push(describeReadingFailure(action, new Error('未命中')));
             options.onNotice(`“${action.query}”未查到对应条文，已保留原有盘面资料。`);
           }
-          if (resource.text.length > MAX_RESOURCES) {
-            notes.push(`${resource.title}尚未加入解读资料，可按具体阶段进一步补齐。`);
-            options.onNotice('这份补充资料超出本轮容量，尚未加入解读；可以按具体阶段继续查询。');
-            continue;
-          }
-          while (
-            resources.length &&
-            resources.reduce((sum, item) => sum + item.text.length, 0) + resource.text.length >
-              MAX_RESOURCES
-          )
-            seen.delete(resources.shift()?.key ?? '');
           resources.push({ ...resource, key, kind: 'evidence' });
         } catch (error) {
           guard();
@@ -383,16 +441,38 @@ export async function runReadingWorkflow(
     guard();
     options.memory.resources = resources;
     options.memory.schemas = schemaResources;
-    const material = resources
-      .filter((item) => item.usable)
-      .map((item) => `${item.title}\n${item.text}`)
-      .join('\n\n');
-    const status = notes.length
-      ? `\n\n【资料状态】\n${notes.map((note) => `- ${note}`).join('\n')}\n已取得的完整盘面与补充资料仍可用于完成判断。`
-      : '';
+    const finalResources = resources.filter((item) => item.usable);
+    const getFinalStatusNotes = (omitted: ReadingResource[]) => {
+      const capacityNote = formatCapacityNotice('本轮解读', omitted).trim();
+      return [...notes, ...(capacityNote ? [capacityNote] : [])];
+    };
+    const buildFinalAddition = (
+      selected: ReadingResource[],
+      omitted: ReadingResource[],
+      statusNotes = getFinalStatusNotes(omitted),
+    ) => {
+      const status = statusNotes.length
+        ? `\n\n【资料状态】\n${statusNotes.map((note) => `- ${note}`).join('\n')}${
+            omitted.length || statusNotes.some((note) => note.includes('【资料覆盖】'))
+              ? '\n已纳入资料可用于完成判断，未纳入资料保留供后续阶段。'
+              : '\n已取得的完整盘面与补充资料仍可用于完成判断。'
+          }`
+        : '';
+      const material = formatReadingResources(selected);
+      return `${guide}${currentTimeContext}${material ? `\n\n【补充资料】\n${material}` : ''}${status}\n\n【本轮解读】\n${isSimpleFollowup ? '请结合当前盘面、已有补充资料和上一轮解读直接回答用户的追问，保持原盘主体与计算口径，说明判断依据和适用条件。' : '请完整回答用户最近的问题，将已知盘面与查得传统条文结合具体情境推导。'}先说明主要判断，再展开支持依据、变化条件与关键时段。对影响当前结论的缺项，具体说明所需资料，同时完成已知部分。`;
+    };
+    const finalSelection = selectResourcesForMessages(messages, finalResources, buildFinalAddition);
+    const finalStatusNotes = getFinalStatusNotes(finalSelection.omitted);
+    if (finalSelection.omitted.length) {
+      options.onNotice(
+        `本轮解读资料容量不足，以下范围未纳入本轮判断：${finalSelection.omitted
+          .map((item) => item.title)
+          .join('、')}。`,
+      );
+    }
     const finalMessages = fitReadingMessages(
       messages,
-      `${guide}${currentTimeContext}${material ? `\n\n【补充资料】\n${material}` : ''}${status}\n\n【本轮解读】\n${isSimpleFollowup ? '请结合当前盘面、已有补充资料和上一轮解读直接回答用户的追问，保持原盘主体与计算口径，说明判断依据和适用条件。' : '请完整回答用户最近的问题，将已知盘面与查得传统条文结合具体情境推导。'}先说明主要判断，再展开支持依据、变化条件与关键时段。对影响当前结论的缺项，具体说明所需资料，同时完成已知部分。`,
+      buildFinalAddition(finalSelection.selected, [], finalStatusNotes),
     );
     if (finalMessages.length < messages.length)
       options.onNotice('对话较长，本轮保留原始盘面与最近的问答。');

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -3721,6 +3721,60 @@ function buildBaziFortuneContextFromInput(
   }
 }
 
+function readOptionalIdentityNumber(input: JsonRecord, key: string) {
+  const value = input[key];
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value === 'string' && /^[-+]?(?:\d+(?:\.\d+)?|\.\d+)$/.test(value.trim())) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function buildBaziCalculationIdentity(
+  input: JsonRecord,
+  fortuneScope: (typeof BAZI_FORTUNE_SCOPES)[number],
+  fortuneSelectionContext: ReturnType<typeof buildFortuneSelectionContext>,
+) {
+  const person = readBaziPerson(input);
+  const birth: JsonRecord = {
+    gender: person.gender,
+    year: person.year,
+    month: person.month,
+    day: person.day,
+    dateType: person.isLunar ? 'lunar' : 'solar',
+    isLeapMonth: Boolean(person.isLeapMonth),
+    useTrueSolarTime: Boolean(person.useTrueSolarTime),
+    birthPlace: person.birthPlace ?? '',
+  };
+  if (person.useTrueSolarTime) {
+    birth.birthHour = person.birthHour;
+    birth.birthMinute = person.birthMinute;
+    birth.birthLongitude = person.birthLongitude;
+  } else {
+    birth.timeIndex = person.timeIndex;
+  }
+  if (person.timezone !== undefined) birth.timezone = person.timezone;
+  if (person.timeZoneId !== undefined) birth.timeZoneId = person.timeZoneId;
+  if (person.applyChinaDst !== undefined) birth.applyChinaDst = person.applyChinaDst;
+  const birthLatitude = readOptionalIdentityNumber(input, 'birthLatitude');
+  if (birthLatitude !== undefined) birth.birthLatitude = birthLatitude;
+
+  const target: JsonRecord = { baziFortuneScope: fortuneScope };
+  if (fortuneSelectionContext) {
+    const targetFields: Record<string, unknown> = {
+      baziFortuneCycleIndex: fortuneSelectionContext.cycleIndex,
+      baziFortuneYear: fortuneSelectionContext.year,
+      baziFortuneMonth: fortuneSelectionContext.month,
+      baziFortuneDay: fortuneSelectionContext.day,
+    };
+    for (const [key, value] of Object.entries(targetFields)) {
+      if (value !== undefined) target[key] = value;
+    }
+  }
+  return { method: 'bazi', birth, target };
+}
+
 function buildBaziPrompt(input: JsonRecord) {
   const result = calculateBazi(input);
   const selection = readSharedPromptSelection(input, 'bazi');
@@ -3768,6 +3822,11 @@ function buildBaziPrompt(input: JsonRecord) {
     prompt,
     fullResult: {
       ...result,
+      calculationIdentity: buildBaziCalculationIdentity(
+        input,
+        fortuneScope,
+        fortuneSelectionContext,
+      ),
       ...(fortuneSelectionContext ? { fortuneSelection: fortuneSelectionContext } : {}),
     },
     resultSummary: {
@@ -3941,6 +4000,53 @@ async function calculateZiwei(input: JsonRecord) {
   return input.detailMode === 'compact' ? buildCompactZiweiResult(result) : result;
 }
 
+function buildZiweiCalculationIdentity(
+  input: JsonRecord,
+  scope: ZiweiPromptScope,
+  result: ReturnType<typeof buildSerializableZiweiResult>,
+) {
+  const birthDate = readBirthDate(input, { asString: true });
+  const useTrueSolarTime = readBoolean(input, 'useTrueSolarTime', false);
+  const birth: JsonRecord = {
+    name: readString(input, 'name', ''),
+    gender: readEnum(input, 'gender', ['male', 'female']),
+    year: birthDate.year,
+    month: birthDate.month,
+    day: birthDate.day,
+    dateType: birthDate.dateType,
+    isLeapMonth: readBoolean(input, 'isLeapMonth', false),
+    useTrueSolarTime,
+    birthPlace: readString(input, 'birthPlace', ''),
+  };
+  if (useTrueSolarTime) {
+    birth.birthHour = readIntegerLike(input, 'birthHour', 0, 23);
+    birth.birthMinute = readIntegerLike(input, 'birthMinute', 0, 59);
+    birth.birthLongitude = readNumberLike(input, 'birthLongitude', -180, 180);
+  } else {
+    birth.timeIndex = readInteger(input, 'timeIndex', 0, 12);
+  }
+  const birthLatitude = readOptionalIdentityNumber(input, 'birthLatitude');
+  if (birthLatitude !== undefined) birth.birthLatitude = birthLatitude;
+  if (input.timezone !== undefined) birth.timezone = readNumberLike(input, 'timezone', -12, 14);
+  if (input.timeZoneId !== undefined) birth.timeZoneId = readRequiredString(input, 'timeZoneId');
+  if (input.applyChinaDst !== undefined)
+    birth.applyChinaDst = readBoolean(input, 'applyChinaDst', false);
+  birth.algorithm = readEnum(input, 'algorithm', ['default', 'zhongzhou'], 'default');
+
+  const target: JsonRecord = { promptScope: scope };
+  if (input.scopeDate !== undefined) {
+    target.scopeDate = readOptionalZiweiScopeDate(input);
+  } else if (result.fortuneTimeline) {
+    target.scopeDate = result.fortuneTimeline.targetDateStr;
+  }
+  if (input.scopeHourIndex !== undefined) {
+    target.scopeHourIndex = optInt(input, 'scopeHourIndex', 0, 12);
+  } else if (result.fortuneTimeline) {
+    target.scopeHourIndex = result.fortuneTimeline.targetHourIndex;
+  }
+  return { method: 'ziwei', birth, target };
+}
+
 async function buildZiweiPrompt(input: JsonRecord) {
   const selection = readSharedPromptSelection(input, 'ziwei');
   const selectedScope = toZiweiPromptScope(selection?.scope);
@@ -3980,7 +4086,10 @@ async function buildZiweiPrompt(input: JsonRecord) {
   return buildPromptApiResult({
     responseMode: readPromptResponseMode(input),
     prompt,
-    fullResult: serializableResult,
+    fullResult: {
+      ...serializableResult,
+      calculationIdentity: buildZiweiCalculationIdentity(input, scope, serializableResult),
+    },
     resultSummary: {
       ...buildCompactZiweiResult(serializableResult),
       ...(selection ? { selection } : {}),

--- a/tests/ai-reading-partner-targets.test.ts
+++ b/tests/ai-reading-partner-targets.test.ts
@@ -1,0 +1,495 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { executeReadingAction } from '../src/lib/ai/reading-resources';
+import { parseReadingPlan, type ReadingSubjectSnapshot } from '../src/lib/ai/reading-workflow';
+import { getTimeIndexFromClock } from 'mingyu-core/calendar';
+
+const baziCompatibilitySubject: ReadingSubjectSnapshot = {
+  id: 'partner-target-bazi',
+  source: 'bazi',
+  lockedInputs: {
+    bazi: {
+      gender: 'male',
+      year: 1990,
+      month: 5,
+      day: 15,
+      timeIndex: 8,
+      dateType: 'solar',
+      isLeapMonth: false,
+      useTrueSolarTime: false,
+      timeZoneId: 'Asia/Shanghai',
+    },
+    baziPartner: {
+      gender: 'female',
+      year: 1992,
+      month: 6,
+      day: 16,
+      timeIndex: 2,
+      dateType: 'solar',
+      isLeapMonth: false,
+      useTrueSolarTime: false,
+      timeZoneId: 'Asia/Shanghai',
+    },
+  },
+  allowedMethods: ['bazi'],
+  range: {},
+};
+
+const ziweiCompatibilitySubject: ReadingSubjectSnapshot = {
+  id: 'partner-target-ziwei',
+  source: 'ziwei',
+  lockedInputs: {
+    ziwei: {
+      name: '甲',
+      gender: 'male',
+      year: 1990,
+      month: 5,
+      day: 15,
+      timeIndex: 8,
+      dateType: 'solar',
+      isLeapMonth: false,
+      useTrueSolarTime: false,
+      timeZoneId: 'Asia/Shanghai',
+    },
+    ziweiPartner: {
+      name: '乙',
+      gender: 'female',
+      year: 1992,
+      month: 6,
+      day: 16,
+      timeIndex: 2,
+      dateType: 'solar',
+      isLeapMonth: false,
+      useTrueSolarTime: false,
+      timeZoneId: 'Asia/Shanghai',
+    },
+  },
+  allowedMethods: ['ziwei'],
+  range: {},
+};
+
+function baziResult(request: Record<string, unknown>, year = request.year) {
+  const correctedHour = Number(request.birthHour ?? 0);
+  const correctedMinute = Number(request.birthMinute ?? 0);
+  return {
+    gender: request.gender,
+    solarDate: { year: request.year, month: request.month, day: request.day },
+    lunarDate: { year: request.year, month: request.month, day: request.day },
+    timeInfo: {
+      index:
+        request.useTrueSolarTime === true
+          ? getTimeIndexFromClock(correctedHour, correctedMinute)
+          : request.timeIndex,
+    },
+    ...(request.useTrueSolarTime === true
+      ? {
+          timing: {
+            enabled: true,
+            standardTime: {
+              year: request.year,
+              month: request.month,
+              day: request.day,
+              hour: correctedHour,
+              minute: correctedMinute,
+            },
+            correctedTime: {
+              year: request.year,
+              month: request.month,
+              day: request.day,
+              hour: correctedHour,
+              minute: correctedMinute,
+            },
+            evidence: { key: 'true-solar-time:evidence' },
+          },
+        }
+      : {}),
+    calculationIdentity: {
+      method: 'bazi',
+      birth: {
+        gender: request.gender,
+        year: request.year,
+        month: request.month,
+        day: request.day,
+        dateType: request.dateType,
+        isLeapMonth: request.isLeapMonth,
+        useTrueSolarTime: request.useTrueSolarTime,
+        ...(request.timeIndex === undefined ? {} : { timeIndex: request.timeIndex }),
+        ...(request.birthHour === undefined ? {} : { birthHour: request.birthHour }),
+        ...(request.birthMinute === undefined ? {} : { birthMinute: request.birthMinute }),
+        ...(request.birthLongitude === undefined ? {} : { birthLongitude: request.birthLongitude }),
+        ...(request.birthLatitude === undefined ? {} : { birthLatitude: request.birthLatitude }),
+        ...(request.birthPlace === undefined ? {} : { birthPlace: request.birthPlace }),
+        timeZoneId: request.timeZoneId,
+      },
+      target: {
+        baziFortuneScope: request.baziFortuneScope,
+        baziFortuneYear: year,
+      },
+    },
+    fortuneSelection: {
+      scope: request.baziFortuneScope,
+      year,
+    },
+  };
+}
+
+async function withFullResponse(
+  resultFactory: (request: Record<string, unknown>) => Record<string, unknown>,
+  callback: (requests: Record<string, unknown>[]) => Promise<void>,
+) {
+  const original = globalThis.fetch;
+  const requests: Record<string, unknown>[] = [];
+  globalThis.fetch = (async (_input, init) => {
+    const request = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    requests.push(request);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          result: resultFactory(request),
+          prompt: '正文写着另一人的年份，但结构化身份保持当前请求。',
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  }) as typeof fetch;
+  try {
+    await callback(requests);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+test('补算动作默认主主体并明确拒绝未知目标', () => {
+  assert.deepEqual(
+    parseReadingPlan(
+      JSON.stringify({
+        actions: [{ kind: 'calculate', method: 'bazi', input: { baziFortuneScope: 'year' } }],
+      }),
+    ),
+    [
+      {
+        kind: 'calculate',
+        method: 'bazi',
+        target: 'primary',
+        input: { baziFortuneScope: 'year' },
+      },
+    ],
+  );
+  assert.deepEqual(
+    parseReadingPlan(
+      JSON.stringify({
+        actions: [
+          {
+            kind: 'calculate',
+            method: 'bazi',
+            target: 'partner',
+            input: { baziFortuneScope: 'year' },
+          },
+        ],
+      }),
+    )[0],
+    {
+      kind: 'calculate',
+      method: 'bazi',
+      target: 'partner',
+      input: { baziFortuneScope: 'year' },
+    },
+  );
+  assert.throws(
+    () =>
+      parseReadingPlan(
+        JSON.stringify({
+          actions: [{ kind: 'calculate', method: 'bazi', target: 'other', input: {} }],
+        }),
+      ),
+    /目标主体必须是 primary 或 partner/u,
+  );
+});
+
+test('伴侣八字补算只使用伴侣快照并保留独立目标年份', async () => {
+  await withFullResponse(
+    (request) => baziResult(request, request.baziFortuneYear),
+    async (requests) => {
+      const resource = await executeReadingAction(
+        {
+          kind: 'calculate',
+          method: 'bazi',
+          target: 'partner',
+          input: { baziFortuneScope: 'year', baziFortuneYear: 2031 },
+        },
+        undefined,
+        baziCompatibilitySubject,
+      );
+      assert.equal(requests.length, 1);
+      assert.equal(requests[0].year, 1992);
+      assert.equal(requests[0].gender, 'female');
+      assert.equal(requests[0].timeIndex, 2);
+      assert.equal(requests[0].baziFortuneYear, 2031);
+      assert.equal(requests[0].responseMode, 'full');
+      assert.equal(resource.title, '第二人·八字2031年');
+      const structured = resource.structured as
+        { calculationIdentity?: { method?: string } } | undefined;
+      assert.equal(structured?.calculationIdentity?.method, 'bazi');
+    },
+  );
+});
+
+test('伴侣紫微补算可使用自己的目标日期和 0 时辰', async () => {
+  await withFullResponse(
+    (request) => ({
+      basicInfo: {
+        gender:
+          request.gender === 'male' ? '男' : request.gender === 'female' ? '女' : request.gender,
+        solar_date: [request.year, request.month, request.day]
+          .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, '0')))
+          .join('-'),
+      },
+      payloadByScope: {
+        hourly: {
+          active_scope: { scope: 'hourly', solar_date: request.scopeDate },
+        },
+      },
+      fortuneTimeline: {
+        targetDateStr: request.scopeDate,
+        targetHourIndex: request.scopeHourIndex,
+      },
+      calculationIdentity: {
+        method: 'ziwei',
+        birth: {
+          name: request.name,
+          gender: request.gender,
+          year: request.year,
+          month: request.month,
+          day: request.day,
+          dateType: request.dateType,
+          isLeapMonth: request.isLeapMonth,
+          useTrueSolarTime: request.useTrueSolarTime,
+          timeIndex: request.timeIndex,
+          timeZoneId: request.timeZoneId,
+        },
+        target: {
+          promptScope: request.promptScope,
+          scopeDate: request.scopeDate,
+          scopeHourIndex: request.scopeHourIndex,
+        },
+      },
+    }),
+    async (requests) => {
+      await executeReadingAction(
+        {
+          kind: 'calculate',
+          method: 'ziwei',
+          target: 'partner',
+          input: { promptScope: 'hourly', scopeDate: '2031-06-16', scopeHourIndex: 0 },
+        },
+        undefined,
+        ziweiCompatibilitySubject,
+      );
+      assert.equal(requests[0].year, 1992);
+      assert.equal(requests[0].name, '乙');
+      assert.equal(requests[0].scopeDate, '2031-06-16');
+      assert.equal(requests[0].scopeHourIndex, 0);
+      assert.equal(requests[0].responseMode, 'full');
+    },
+  );
+});
+
+test('真太阳时补算按原始钟表资料核验，不把校正后的时辰误判为主体不一致', async () => {
+  const subject: ReadingSubjectSnapshot = {
+    ...baziCompatibilitySubject,
+    lockedInputs: {
+      bazi: {
+        ...baziCompatibilitySubject.lockedInputs.bazi,
+        useTrueSolarTime: true,
+        birthHour: 10,
+        birthMinute: 30,
+        birthLongitude: 116.4,
+      },
+    },
+  };
+  await withFullResponse(
+    (request) => baziResult(request, request.baziFortuneYear),
+    async (requests) => {
+      await executeReadingAction(
+        {
+          kind: 'calculate',
+          method: 'bazi',
+          input: { baziFortuneScope: 'year', baziFortuneYear: 2030 },
+        },
+        undefined,
+        subject,
+      );
+      assert.equal(requests[0].useTrueSolarTime, true);
+      assert.equal(requests[0].birthHour, 10);
+      assert.equal(requests[0].birthMinute, 30);
+      assert.equal(requests[0].birthLongitude, 116.4);
+      assert.equal(requests[0].timeIndex, undefined);
+    },
+  );
+});
+
+test('真太阳时返回缺少标准时间证据时拒绝补算', async () => {
+  const subject: ReadingSubjectSnapshot = {
+    ...baziCompatibilitySubject,
+    lockedInputs: {
+      bazi: {
+        ...baziCompatibilitySubject.lockedInputs.bazi,
+        useTrueSolarTime: true,
+        birthHour: 10,
+        birthMinute: 30,
+        birthLongitude: 116.4,
+      },
+    },
+  };
+  await withFullResponse(
+    (request) => {
+      const result = baziResult(request) as Record<string, unknown>;
+      const timing = result.timing as Record<string, unknown>;
+      return { ...result, timing: { ...timing, standardTime: undefined } };
+    },
+    async () => {
+      await assert.rejects(
+        () =>
+          executeReadingAction(
+            {
+              kind: 'calculate',
+              method: 'bazi',
+              input: { baziFortuneScope: 'year', baziFortuneYear: 2030 },
+            },
+            undefined,
+            subject,
+          ),
+        /标准时间/u,
+      );
+    },
+  );
+});
+
+test('真太阳时身份回显正确但实际校正时辰串盘时拒绝补算', async () => {
+  const subject: ReadingSubjectSnapshot = {
+    ...baziCompatibilitySubject,
+    lockedInputs: {
+      bazi: {
+        ...baziCompatibilitySubject.lockedInputs.bazi,
+        useTrueSolarTime: true,
+        birthHour: 10,
+        birthMinute: 30,
+        birthLongitude: 116.4,
+      },
+    },
+  };
+  await withFullResponse(
+    (request) => ({
+      ...baziResult(request),
+      timeInfo: { index: 8 },
+    }),
+    async () => {
+      await assert.rejects(
+        () =>
+          executeReadingAction(
+            {
+              kind: 'calculate',
+              method: 'bazi',
+              input: { baziFortuneScope: 'year', baziFortuneYear: 2030 },
+            },
+            undefined,
+            subject,
+          ),
+        /身份核验/u,
+      );
+    },
+  );
+});
+
+test('伴侣目标没有快照时拒绝回退主主体，正文内容不能替代结构化身份', async () => {
+  let called = false;
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    called = true;
+    return new Response('{}', { status: 500 });
+  }) as typeof fetch;
+  try {
+    await assert.rejects(
+      () =>
+        executeReadingAction(
+          {
+            kind: 'calculate',
+            method: 'bazi',
+            target: 'partner',
+            input: { baziFortuneScope: 'year', baziFortuneYear: 2031 },
+          },
+          undefined,
+          {
+            ...baziCompatibilitySubject,
+            lockedInputs: { bazi: baziCompatibilitySubject.lockedInputs.bazi },
+          },
+        ),
+      /第二人主体快照/u,
+    );
+    assert.equal(called, false);
+  } finally {
+    globalThis.fetch = original;
+  }
+
+  await withFullResponse(
+    (request) => ({
+      ...baziResult(request),
+      calculationIdentity: {
+        method: 'bazi',
+        birth: {
+          gender: 'male',
+          year: 1990,
+          month: 5,
+          day: 15,
+          dateType: 'solar',
+          isLeapMonth: false,
+          useTrueSolarTime: false,
+          timeIndex: 8,
+          timeZoneId: 'Asia/Shanghai',
+        },
+        target: { baziFortuneScope: request.baziFortuneScope },
+      },
+    }),
+    async () => {
+      await assert.rejects(
+        () =>
+          executeReadingAction(
+            {
+              kind: 'calculate',
+              method: 'bazi',
+              input: { baziFortuneScope: 'year', baziFortuneYear: 2031 },
+            },
+            undefined,
+            baziCompatibilitySubject,
+          ),
+        /身份核验/u,
+      );
+    },
+  );
+});
+
+test('结构化身份回显正确但实际八字结果串盘时拒绝补算', async () => {
+  await withFullResponse(
+    (request) => ({
+      ...baziResult(request),
+      gender: 'female',
+      solarDate: { year: 1991, month: request.month, day: request.day },
+    }),
+    async () => {
+      await assert.rejects(
+        () =>
+          executeReadingAction(
+            {
+              kind: 'calculate',
+              method: 'bazi',
+              input: { baziFortuneScope: 'year', baziFortuneYear: 2031 },
+            },
+            undefined,
+            baziCompatibilitySubject,
+          ),
+        /身份核验/u,
+      );
+    },
+  );
+});

--- a/tests/ai-reading-resources-second-batch.test.ts
+++ b/tests/ai-reading-resources-second-batch.test.ts
@@ -94,9 +94,143 @@ async function withRequestCapture<T>(
 ) {
   const original = globalThis.fetch;
   let request: Record<string, unknown> | undefined;
-  globalThis.fetch = (async (_input, init) => {
+  globalThis.fetch = (async (input, init) => {
     request = JSON.parse(String(init?.body)) as Record<string, unknown>;
-    return new Response(JSON.stringify({ success: true, data: { prompt: '补算盘面' } }), {
+    const path = String(input);
+    let result: Record<string, unknown>;
+    if (path.includes('/bazi/prompt')) {
+      const birth = {
+        gender: request.gender,
+        year: request.year,
+        month: request.month,
+        day: request.day,
+        dateType: request.dateType,
+        isLeapMonth: request.isLeapMonth,
+        useTrueSolarTime: request.useTrueSolarTime,
+        ...(request.timeIndex === undefined ? {} : { timeIndex: request.timeIndex }),
+        ...(request.birthHour === undefined ? {} : { birthHour: request.birthHour }),
+        ...(request.birthMinute === undefined ? {} : { birthMinute: request.birthMinute }),
+        ...(request.birthLongitude === undefined ? {} : { birthLongitude: request.birthLongitude }),
+        ...(request.birthLatitude === undefined ? {} : { birthLatitude: request.birthLatitude }),
+        ...(request.birthPlace === undefined ? {} : { birthPlace: request.birthPlace }),
+        ...(request.timezone === undefined ? {} : { timezone: request.timezone }),
+        ...(request.timeZoneId === undefined ? {} : { timeZoneId: request.timeZoneId }),
+        ...(request.applyChinaDst === undefined ? {} : { applyChinaDst: request.applyChinaDst }),
+      };
+      const target = Object.fromEntries(
+        [
+          'baziFortuneScope',
+          'baziFortuneCycleIndex',
+          'baziFortuneYear',
+          'baziFortuneMonth',
+          'baziFortuneDay',
+        ]
+          .filter((key) => request[key] !== undefined)
+          .map((key) => [key, request[key]]),
+      );
+      result = {
+        gender: request.gender,
+        solarDate: { year: request.year, month: request.month, day: request.day },
+        lunarDate: { year: request.year, month: request.month, day: request.day },
+        timeInfo: { index: request.timeIndex },
+        calculationIdentity: { method: 'bazi', birth, target },
+      };
+    } else if (path.includes('/ziwei/prompt')) {
+      const birth = {
+        name: request.name,
+        gender: request.gender,
+        year: request.year,
+        month: request.month,
+        day: request.day,
+        dateType: request.dateType,
+        isLeapMonth: request.isLeapMonth,
+        useTrueSolarTime: request.useTrueSolarTime,
+        ...(request.timeIndex === undefined ? {} : { timeIndex: request.timeIndex }),
+        ...(request.birthHour === undefined ? {} : { birthHour: request.birthHour }),
+        ...(request.birthMinute === undefined ? {} : { birthMinute: request.birthMinute }),
+        ...(request.birthLongitude === undefined ? {} : { birthLongitude: request.birthLongitude }),
+        ...(request.birthLatitude === undefined ? {} : { birthLatitude: request.birthLatitude }),
+        ...(request.birthPlace === undefined ? {} : { birthPlace: request.birthPlace }),
+        ...(request.timezone === undefined ? {} : { timezone: request.timezone }),
+        ...(request.timeZoneId === undefined ? {} : { timeZoneId: request.timeZoneId }),
+        ...(request.applyChinaDst === undefined ? {} : { applyChinaDst: request.applyChinaDst }),
+        ...(request.algorithm === undefined ? {} : { algorithm: request.algorithm }),
+      };
+      const target = Object.fromEntries(
+        ['promptScope', 'scopeDate', 'scopeHourIndex']
+          .filter((key) => request[key] !== undefined)
+          .map((key) => [key, request[key]]),
+      );
+      const promptScope = request.promptScope ?? 'decadal';
+      result = {
+        basicInfo: {
+          gender:
+            request.gender === 'male' ? '男' : request.gender === 'female' ? '女' : request.gender,
+          solar_date: [request.year, request.month, request.day]
+            .map((value, index) => (index === 0 ? String(value) : String(value).padStart(2, '0')))
+            .join('-'),
+        },
+        payloadByScope: {
+          [String(promptScope)]: {
+            active_scope: {
+              scope: promptScope,
+              solar_date:
+                request.scopeDate ??
+                [request.year, request.month, request.day]
+                  .map((value, index) =>
+                    index === 0 ? String(value) : String(value).padStart(2, '0'),
+                  )
+                  .join('-'),
+            },
+          },
+        },
+        ...(request.useTrueSolarTime === true
+          ? { trueSolarEvidence: { key: 'true-solar-time:evidence' } }
+          : {}),
+        calculationIdentity: { method: 'ziwei', birth, target },
+      };
+    } else if (path.includes('/astrolabe/prompt')) {
+      const month = String(request.month).padStart(2, '0');
+      const day = String(request.day).padStart(2, '0');
+      const hour = String(request.hour).padStart(2, '0');
+      const minute = String(request.minute ?? 0).padStart(2, '0');
+      result = {
+        birth: {
+          name: request.name,
+          gender: request.gender,
+          latitude: request.latitude,
+          longitude: request.longitude,
+          timeZoneId: request.timeZoneId,
+          isTrueSolarTime: request.useTrueSolarTime,
+          standardDateTime: `${request.year}-${month}-${day} ${hour}:${minute}`,
+        },
+        scopeEvidence: {
+          scope: request.astrolabeScope ?? 'natal',
+          ...(request.astrolabeScopeDate === undefined
+            ? {}
+            : { dateStr: request.astrolabeScopeDate }),
+        },
+      };
+    } else {
+      result = {
+        calculationContext: {
+          latitude: request.latitude,
+          longitude: request.longitude,
+        },
+        ...(request.flowYear === undefined
+          ? {}
+          : {
+              flowingStars: {
+                year: request.flowYear,
+                month: request.flowMonth,
+                day: request.flowDay,
+                hour: request.flowHour,
+                minute: request.flowMinute,
+              },
+            }),
+      };
+    }
+    return new Response(JSON.stringify({ success: true, data: { result, prompt: '补算盘面' } }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
     });
@@ -123,6 +257,88 @@ async function withPublicApiFetch<T>(callback: () => Promise<T>) {
     globalThis.fetch = original;
   }
 }
+
+test('补算经真实公共 API 返回可核验的八字与紫微盘面事实', async () => {
+  await withPublicApiFetch(async () => {
+    const baziResource = await executeReadingAction(
+      {
+        kind: 'calculate',
+        method: 'bazi',
+        input: { baziFortuneScope: 'year', baziFortuneYear: 2030, question: '流年事业' },
+      },
+      undefined,
+      baziSubject,
+    );
+    const bazi = baziResource.structured as Record<string, unknown>;
+    assert.equal(bazi.gender, 'male');
+    assert.deepEqual(bazi.solarDate, { year: 1990, month: 5, day: 15 });
+    assert.equal((bazi.timeInfo as Record<string, unknown>).index, 8);
+    assert.equal(
+      ((bazi.calculationIdentity as Record<string, unknown>).target as Record<string, unknown>)
+        .baziFortuneYear,
+      2030,
+    );
+
+    const ziweiResource = await executeReadingAction(
+      {
+        kind: 'calculate',
+        method: 'ziwei',
+        input: {
+          promptScope: 'hourly',
+          scopeDate: '2030-06-16',
+          scopeHourIndex: 0,
+          question: '目标时辰',
+        },
+      },
+      undefined,
+      ziweiSubject,
+    );
+    const ziwei = ziweiResource.structured as Record<string, unknown>;
+    const basicInfo = ziwei.basicInfo as Record<string, unknown>;
+    assert.equal(basicInfo.gender, '男');
+    assert.equal(basicInfo.solar_date, '1990-05-15');
+    const activeScope = (
+      (ziwei.payloadByScope as Record<string, unknown>).hourly as Record<string, unknown>
+    ).active_scope as Record<string, unknown>;
+    assert.equal(activeScope.scope, 'hourly');
+    assert.equal(activeScope.solar_date, '2030-06-16');
+    assert.deepEqual(
+      ziwei.fortuneTimeline && {
+        targetDateStr: (ziwei.fortuneTimeline as Record<string, unknown>).targetDateStr,
+        targetHourIndex: (ziwei.fortuneTimeline as Record<string, unknown>).targetHourIndex,
+      },
+      { targetDateStr: '2030-06-16', targetHourIndex: 0 },
+    );
+
+    const { timeIndex: _timeIndex, ...trueSolarBaziInputs } = baziInputs;
+    const trueSolarSubject: ReadingSubjectSnapshot = {
+      ...baziSubject,
+      lockedInputs: {
+        bazi: {
+          ...trueSolarBaziInputs,
+          useTrueSolarTime: true,
+          birthHour: 10,
+          birthMinute: 30,
+          birthLongitude: 116.4,
+        },
+      },
+    };
+    const trueSolarResource = await executeReadingAction(
+      {
+        kind: 'calculate',
+        method: 'bazi',
+        input: { baziFortuneScope: 'year', baziFortuneYear: 2030, question: '真太阳时' },
+      },
+      undefined,
+      trueSolarSubject,
+    );
+    const trueSolar = trueSolarResource.structured as Record<string, unknown>;
+    const timing = trueSolar.timing as Record<string, unknown>;
+    assert.equal(timing.enabled, true);
+    assert.match(String((timing.evidence as Record<string, unknown>).key), /true-solar|solar/u);
+    assert.match(String((timing.correctedTime as Record<string, unknown>).year), /^\d{4}$/u);
+  });
+});
 
 function assertSchemaHasNoReferences(value: unknown): void {
   if (Array.isArray(value)) {
@@ -237,7 +453,7 @@ test('各术式保留真实目标时限字段并拒绝改动主体口径', async
     assert.equal(request.flowMinute, 6);
     assert.equal(request.question, '流年事业');
     assert.equal(request.promptScope, 'yearly');
-    assert.equal(request.responseMode, 'prompt-only');
+    assert.equal(request.responseMode, 'full');
   });
 
   await withRequestCapture(async (getRequest) => {
@@ -380,11 +596,13 @@ test('schema 动作只暴露各术式可修改字段并清理公共 OpenAPI 引�
     for (const method of Object.keys(expectedProperties)) {
       const resource = await executeReadingAction({ kind: 'schema', method });
       const schema = JSON.parse(resource.text) as {
+        description?: unknown;
         properties?: Record<string, unknown>;
         required?: string[];
         additionalProperties?: unknown;
       };
       const properties = schema.properties ?? {};
+      assert.match(String(schema.description), /target.*primary.*partner/u, method);
       assert.deepEqual(Object.keys(properties).sort(), expectedProperties[method].sort(), method);
       assert.deepEqual(schema.required ?? [], expectedRequired[method], `${method} required`);
       assert.equal(schema.additionalProperties, false, `${method} additionalProperties`);

--- a/tests/ai-reading-second-batch.test.ts
+++ b/tests/ai-reading-second-batch.test.ts
@@ -281,10 +281,13 @@ test('超容量补充资料未进入解读时明确提示实际缺项', async ()
   ]);
   await runReadingWorkflow([{ role: 'user', content: '八字盘面' }], harness.options, {
     stream: harness.stream,
-    execute: async () => ({ key: '', title: '格局条文', text: '资料'.repeat(10000), usable: true }),
+    execute: async () => ({ key: '', title: '格局条文', text: '资料'.repeat(25000), usable: true }),
   });
-  assert.equal(harness.memory.resources.length, 0);
-  assert.ok(harness.notices.some((notice) => notice.includes('尚未加入解读')));
-  assert.match(harness.sent.at(-1)?.[0].content ?? '', /格局条文尚未加入解读资料/u);
+  assert.equal(harness.memory.resources.length, 1);
+  assert.equal(harness.memory.resources[0].text.length, 50000);
+  assert.ok(
+    harness.notices.some((notice) => notice.includes('格局条文') && notice.includes('未纳入')),
+  );
+  assert.match(harness.sent.at(-1)?.[0].content ?? '', /资料覆盖[\s\S]*格局条文/u);
   assert.doesNotMatch(harness.sent.at(-1)?.[0].content ?? '', /资料资料资料/u);
 });

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -204,6 +204,13 @@ test('查询失败保留盘面且明确说明', async () => {
 test('取消准备后不执行补查或最终解读，也不写入其他会话资料', async () => {
   const h = harness([]),
     controller = new AbortController();
+  const existing = {
+    key: 'existing',
+    title: '既有资料',
+    text: '既有事实'.repeat(6000),
+    usable: true,
+  };
+  h.options.memory.resources = [existing];
   h.options.signal = controller.signal;
   await runReadingWorkflow([{ role: 'user', content: '八字盘面' }], h.options, {
     stream: async (_messages, callbacks) => {
@@ -216,7 +223,7 @@ test('取消准备后不执行补查或最终解读，也不写入其他会话�
     },
   });
   assert.equal(h.done(), 0);
-  assert.deepEqual(h.options.memory.resources, []);
+  assert.deepEqual(h.options.memory.resources, [existing]);
   assert.deepEqual(h.errors, []);
 });
 
@@ -294,6 +301,8 @@ test('补算使用真实公开契约且只返回完整提示词', async (t) => {
   );
   assert.ok(data.usable);
   assert.match(data.text, /1990|庚午/);
+  const structured = data.structured as { calculationIdentity?: { method?: string } } | undefined;
+  assert.equal(structured?.calculationIdentity?.method, 'bazi');
 });
 
 test('自动补算拒绝更换主体并保留当前主体字段', async (t) => {
@@ -301,10 +310,38 @@ test('自动补算拒绝更换主体并保留当前主体字段', async (t) => {
   let request: Record<string, unknown> | undefined;
   globalThis.fetch = (async (input, init) => {
     request = JSON.parse(String(init?.body)) as Record<string, unknown>;
-    return new Response(JSON.stringify({ success: true, data: { prompt: '目标流年' } }), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          result: {
+            gender: request.gender,
+            solarDate: { year: request.year, month: request.month, day: request.day },
+            lunarDate: { year: request.year, month: request.month, day: request.day },
+            timeInfo: { index: request.timeIndex },
+            calculationIdentity: {
+              method: 'bazi',
+              birth: {
+                gender: request.gender,
+                year: request.year,
+                month: request.month,
+                day: request.day,
+                dateType: request.dateType,
+                isLeapMonth: request.isLeapMonth,
+                useTrueSolarTime: request.useTrueSolarTime,
+                timeIndex: request.timeIndex,
+              },
+              target: { baziFortuneYear: request.baziFortuneYear },
+            },
+          },
+          prompt: '目标流年',
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
   }) as typeof fetch;
   t.after(() => {
     globalThis.fetch = original;
@@ -327,17 +364,86 @@ test('自动补算拒绝更换主体并保留当前主体字段', async (t) => {
   assert.equal(request?.baziFortuneYear, 2026);
 });
 
-test('过大的补充资料整项提示，原始盘面始终完整保留', async () => {
+test('超过18000但低于最终上下文的完整资料仍进入解读', async () => {
   const h = harness(['{"actions":[{"kind":"classic","method":"bazi","query":"甲"}]}', '解读']);
+  const text = '精确完整事实'.repeat(3500);
   await runReadingWorkflow([{ role: 'user', content: '完整原盘' }], h.options, {
     stream: h.stream,
-    execute: async () => ({ key: '', title: '长条文', text: '长条文'.repeat(7000), usable: true }),
+    execute: async () => ({ key: '', title: '精确完整资料', text, usable: true }),
   });
-  assert.deepEqual(h.options.memory.resources, []);
-  assert.ok(h.notices.some((text) => text.includes('超出本轮容量，尚未加入解读')));
-  assert.ok(h.sent.at(-1)![0].content.startsWith('完整原盘'));
-  assert.match(h.sent.at(-1)![0].content, /长条文尚未加入解读资料/);
-  assert.doesNotMatch(h.sent.at(-1)![0].content, /长条文长条文/);
+  assert.equal(h.options.memory.resources.length, 1);
+  assert.equal(h.options.memory.resources[0].text, text);
+  assert.match(h.sent.at(-1)![0].content, /精确完整资料/);
+  assert.match(h.sent.at(-1)![0].content, /精确完整事实/);
+  assert.doesNotMatch(h.sent.at(-1)![0].content, /资料覆盖/);
+});
+
+test('两份合计超过18000的完整资料同时保留', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"classic","method":"bazi","query":"甲"},{"kind":"classic","method":"bazi","query":"乙"}]}',
+    '解读',
+  ]);
+  const first = '第一完整事实'.repeat(1900);
+  const second = '第二完整事实'.repeat(1900);
+  await runReadingWorkflow([{ role: 'user', content: '完整原盘' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => ({
+      key: '',
+      title: action.kind === 'classic' && action.query === '甲' ? '第一资料' : '第二资料',
+      text: action.kind === 'classic' && action.query === '甲' ? first : second,
+      usable: true,
+    }),
+  });
+  assert.equal(h.options.memory.resources.length, 2);
+  assert.match(h.sent.at(-1)![0].content, /第一完整事实/);
+  assert.match(h.sent.at(-1)![0].content, /第二完整事实/);
+  assert.doesNotMatch(h.sent.at(-1)![0].content, /资料覆盖/);
+});
+
+test('真实超出最终上下文时不静默丢弃成功资料并明确覆盖范围', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"classic","method":"bazi","query":"甲"},{"kind":"classic","method":"bazi","query":"乙"}]}',
+    '解读',
+  ]);
+  const first = '第一阶段完整事实'.repeat(5000);
+  const second = '第二阶段完整事实'.repeat(4000);
+  await runReadingWorkflow([{ role: 'user', content: '完整原盘' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => ({
+      key: '',
+      title: action.kind === 'classic' && action.query === '甲' ? '第一阶段' : '第二阶段',
+      text: action.kind === 'classic' && action.query === '甲' ? first : second,
+      usable: true,
+    }),
+  });
+  assert.equal(h.options.memory.resources.length, 2);
+  assert.match(h.sent.at(-1)![0].content, /第一阶段完整事实/);
+  assert.match(h.sent.at(-1)![0].content, /【资料状态】/);
+  assert.match(h.sent.at(-1)![0].content, /第二阶段/);
+  assert.match(h.sent.at(-1)![0].content, /待后续补足/);
+  assert.ok(h.notices.some((text) => text.includes('未纳入本轮判断')));
+  assert.doesNotMatch(h.sent.at(-1)![0].content, /第二阶段完整事实/);
+});
+
+test('历史消息有余量时保留完整补充资料并按现有规则裁剪旧消息', async () => {
+  const h = harness(['{"actions":[{"kind":"classic","method":"bazi","query":"甲"}]}', '解读']);
+  const messages = [
+    { role: 'user' as const, content: '原始盘面' },
+    ...Array.from({ length: 30 }, (_, index) => ({
+      role: index % 2 ? ('user' as const) : ('assistant' as const),
+      content: `历史第${index}条` + '历史内容'.repeat(1000),
+    })),
+  ];
+  const text = '阶段完整事实'.repeat(3500);
+  await runReadingWorkflow(messages, h.options, {
+    stream: h.stream,
+    execute: async () => ({ key: '', title: '阶段资料', text, usable: true }),
+  });
+  const final = h.sent.at(-1)!;
+  assert.match(final[0].content, /原始盘面/);
+  assert.match(final[0].content, /阶段完整事实/);
+  assert.deepEqual(final.at(-1), messages.at(-1));
+  assert.ok(final.reduce((sum, item) => sum + item.content.length, 0) <= 49000);
 });
 
 test('模型输出达到上限时返回可辨认的中断错误', async (t) => {

--- a/tests/fortune-selection.test.ts
+++ b/tests/fortune-selection.test.ts
@@ -292,6 +292,8 @@ test('流日可显式保留旧版早晚子时拆分', () => {
   );
 
   assert.equal(context?.hourBreakdown?.length, 13);
+  assert.equal(context?.day, 5);
+  assert.equal(context?.dayBreakdown?.[0]?.date, '2008-02-08');
   assert.match(context?.hourBreakdown?.[0]?.label ?? '', /晚子时/);
   assert.match(context?.hourBreakdown?.[1]?.label ?? '', /早子时/);
 });


### PR DESCRIPTION
双人 AI 解读现在能明确选择第一人或第二人补算，并根据实际返回的出生日期、性别、时辰和目标运限核对结果。缺少第二人资料或实际结果串盘时返回明确错误；真太阳时使用原始钟表资料和校正证据核验，合法跨日保留。

补充资料改为按最终请求的实际容量选择完整资料，取消 18,000 字符提前拒绝与按加入顺序静默淘汰。可以容纳的长资料完整发送，确实超限时保留已取得资料并明确本轮未覆盖范围。自动分阶段阅读另在后续工作树实施，本改动不宣称已完成全范围分段消费。

基础运限结果补充流日序号，以便核验节令月内的所选流日，公历日期仍由原有流日记录提供。

验证：类型检查与70项定向测试通过；1781项全量单元测试通过。集成、公开 API、MCP、静态检查、格式、前端/Pages/服务端/MCP 构建、提示词审查、包内容及运行时检查均通过。真实 handler 补算采样确认15510字符完整资料进入18911字符的最终请求；规划输出受控，未调用真实模型。

基于 PR #267，未合并或发布。