### PR TITLE
核验七政 AI 补算的出生身份与行限主体

### DIFF
--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -6,7 +6,11 @@ import type { ReadingAction, ReadingResource, ReadingTarget } from './reading-wo
 import type { ReadingSubjectSnapshot } from './reading-subject';
 import { getDefaultAstrolabeScopeDate } from '../astrolabe-scope';
 import { getAiApiEndpoint } from './stream-client';
-import { getTimeIndexFromClock } from 'mingyu-core/calendar';
+import {
+  DEFAULT_CHINA_TIMEZONE_HOURS,
+  getTimeIndexFromClock,
+  resolveCivilTime,
+} from 'mingyu-core/calendar';
 
 const LABELS: Record<string, string> = {
   sourceBook: '典籍',
@@ -740,6 +744,56 @@ function assertQizhengResult(
   const context = result.calculationContext;
   for (const field of ['latitude', 'longitude']) {
     assertStructuredField(`qi-zheng.${field}`, locked[field], context[field]);
+  }
+  const birthFields = ['year', 'month', 'day', 'hour'];
+  if (birthFields.some((field) => locked[field] === undefined)) {
+    throw new Error('当前会话缺少七政出生日期或时刻。');
+  }
+  const birthTime = resolveCivilTime(
+    {
+      year: Number(locked.year),
+      month: Number(locked.month),
+      day: Number(locked.day),
+      hour: Number(locked.hour),
+      minute: Number(locked.minute ?? 0),
+      second: 0,
+      timezone: locked.timezone === undefined ? undefined : Number(locked.timezone),
+      timeZoneId: typeof locked.timeZoneId === 'string' ? locked.timeZoneId : undefined,
+    },
+    { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
+  );
+  assertStructuredField('qi-zheng.localDateTime', birthTime.localDateTime, context.localDateTime);
+  assertStructuredField('qi-zheng.utcDateTime', birthTime.utcDateTime, context.utcDateTime);
+  assertStructuredField('qi-zheng.timezone', birthTime.timezone, context.timezone);
+  const astronomicalTime = context.astronomicalTime;
+  if (!record(astronomicalTime)) throw new Error('补算返回缺少七政出生时间证据。');
+  assertStructuredField('qi-zheng.timeZoneId', locked.timeZoneId, astronomicalTime.timeZoneId);
+  assertStructuredField(
+    'qi-zheng.astronomicalTime.localDateTime',
+    birthTime.localDateTime.replace('T', ' '),
+    astronomicalTime.localDateTime,
+  );
+  if (typeof context.utcDateTime !== 'string' || typeof context.timezone !== 'number') {
+    throw new Error('补算返回缺少七政 UTC 时刻或有效时区。');
+  }
+  assertStructuredField(
+    'qi-zheng.astronomicalTime.utcDateTime',
+    context.utcDateTime,
+    astronomicalTime.utcDateTime,
+  );
+  assertStructuredField(
+    'qi-zheng.astronomicalTime.timezone',
+    context.timezone,
+    astronomicalTime.timezone,
+  );
+  assertStructuredField(
+    'qi-zheng.palaceTimeMode',
+    locked.useTrueSolarTime === true ? '真太阳时混合口径' : '民用时间',
+    context.palaceTimeMode,
+  );
+  if (locked.gender !== undefined && calculationInput.flowYear !== undefined) {
+    if (!record(result.timeLords)) throw new Error('补算返回缺少七政行限主体资料。');
+    assertStructuredField('qi-zheng.timeLords.gender', locked.gender, result.timeLords.gender);
   }
   const flow = result.flowingStars;
   const flowFields = ['flowYear', 'flowMonth', 'flowDay', 'flowHour', 'flowMinute'];

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -778,7 +778,7 @@ function assertQizhengResult(
   }
   assertStructuredField(
     'qi-zheng.astronomicalTime.utcDateTime',
-    context.utcDateTime,
+    birthTime.utcDateTime.replace('T', ' ').replace('.000Z', 'Z'),
     astronomicalTime.utcDateTime,
   );
   assertStructuredField(

--- a/tests/ai-reading-qizheng-identity.test.ts
+++ b/tests/ai-reading-qizheng-identity.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { executeReadingAction } from '../src/lib/ai/reading-resources';
+import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import type { ReadingSubjectSnapshot } from '../src/lib/ai/reading-subject';
+
+const subject: ReadingSubjectSnapshot = {
+  id: 'qizheng-real-identity',
+  source: 'qizheng',
+  allowedMethods: ['qi-zheng'],
+  range: {},
+  lockedInputs: {
+    'qi-zheng': {
+      year: 1990,
+      month: 5,
+      day: 15,
+      hour: 10,
+      minute: 30,
+      gender: 'male',
+      latitude: 39.9,
+      longitude: 116.4,
+      timeZoneId: 'Asia/Shanghai',
+      useTrueSolarTime: false,
+    },
+  },
+};
+const action = {
+  kind: 'calculate' as const,
+  method: 'qi-zheng',
+  input: {
+    flowYear: 2030,
+    flowMonth: 6,
+    flowDay: 16,
+    flowHour: 0,
+    flowMinute: 0,
+    question: '当前阶段变化',
+  },
+};
+
+async function withRealApi(callback: () => Promise<void>, change?: Record<string, unknown>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    const request = new Request(new URL(String(input), 'https://aov.cc'), init);
+    if (!change) return handlePublicApiRequest(request);
+    const body = await request.json();
+    return handlePublicApiRequest(
+      new Request(request.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...body, ...change }),
+      }),
+    );
+  }) as typeof fetch;
+  try {
+    await callback();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+for (const useTrueSolarTime of [false, true]) {
+  test(`七政真实补算保留出生身份、零时分与${useTrueSolarTime ? '真太阳时' : '民用时间'}口径`, async () => {
+    await withRealApi(async () => {
+      const actualSubject = {
+        ...subject,
+        lockedInputs: { 'qi-zheng': { ...subject.lockedInputs['qi-zheng'], useTrueSolarTime } },
+      };
+      const resource = await executeReadingAction(action, undefined, actualSubject);
+      const context = resource.structured?.calculationContext as Record<string, unknown>;
+      assert.equal(context.localDateTime, '1990-05-15T10:30:00');
+      assert.equal(context.palaceTimeMode, useTrueSolarTime ? '真太阳时混合口径' : '民用时间');
+      const flow = resource.structured?.flowingStars as Record<string, unknown>;
+      assert.equal(flow.hour, 0);
+      assert.equal(flow.minute, 0);
+      assert.equal(flow.year, 2030);
+    });
+  });
+}
+
+test('七政相同地点和目标时段但另一出生日期的实际盘面被拒绝', async () => {
+  await withRealApi(
+    async () => {
+      await assert.rejects(
+        executeReadingAction(action, undefined, subject),
+        /qi-zheng.localDateTime/u,
+      );
+    },
+    { year: 1991 },
+  );
+});
+
+test('七政相同出生时刻但另一性别的实际行限被拒绝', async () => {
+  await withRealApi(
+    async () => {
+      await assert.rejects(
+        executeReadingAction(action, undefined, subject),
+        /qi-zheng.timeLords.gender/u,
+      );
+    },
+    { gender: 'female' },
+  );
+});
+
+test('七政相同钟表日期但另一时区的实际盘面被拒绝', async () => {
+  await withRealApi(
+    async () => {
+      await assert.rejects(
+        executeReadingAction(action, undefined, subject),
+        /qi-zheng.utcDateTime/u,
+      );
+    },
+    { timeZoneId: 'UTC' },
+  );
+});

--- a/tests/ai-reading-resources-second-batch.test.ts
+++ b/tests/ai-reading-resources-second-batch.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { executeReadingAction } from '../src/lib/ai/reading-resources';
 import type { ReadingSubjectSnapshot } from '../src/lib/ai/reading-subject';
 import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import { resolveCivilTime } from 'mingyu-core/calendar';
 
 const baziInputs = {
   gender: 'male',
@@ -212,14 +213,39 @@ async function withRequestCapture<T>(
         },
       };
     } else {
+      const localDateTime = `${request.year}-${String(request.month).padStart(2, '0')}-${String(request.day).padStart(2, '0')}T${String(request.hour).padStart(2, '0')}:${String(request.minute ?? 0).padStart(2, '0')}:00`;
+      const { timezone, utcDateTime } = resolveCivilTime(
+        {
+          year: Number(request.year),
+          month: Number(request.month),
+          day: Number(request.day),
+          hour: Number(request.hour),
+          minute: Number(request.minute ?? 0),
+          second: 0,
+          timezone: request.timezone === undefined ? undefined : Number(request.timezone),
+          timeZoneId: typeof request.timeZoneId === 'string' ? request.timeZoneId : undefined,
+        },
+        { defaultTimezone: 8 },
+      );
       result = {
         calculationContext: {
           latitude: request.latitude,
           longitude: request.longitude,
+          localDateTime,
+          utcDateTime,
+          timezone,
+          palaceTimeMode: request.useTrueSolarTime ? '真太阳时混合口径' : '民用时间',
+          astronomicalTime: {
+            localDateTime: localDateTime.replace('T', ' '),
+            utcDateTime,
+            timezone,
+            timeZoneId: request.timeZoneId,
+          },
         },
         ...(request.flowYear === undefined
           ? {}
           : {
+              timeLords: { gender: request.gender },
               flowingStars: {
                 year: request.flowYear,
                 month: request.flowMonth,

--- a/tests/ai-reading-resources-second-batch.test.ts
+++ b/tests/ai-reading-resources-second-batch.test.ts
@@ -237,7 +237,7 @@ async function withRequestCapture<T>(
           palaceTimeMode: request.useTrueSolarTime ? '真太阳时混合口径' : '民用时间',
           astronomicalTime: {
             localDateTime: localDateTime.replace('T', ' '),
-            utcDateTime,
+            utcDateTime: utcDateTime.replace('T', ' ').replace('.000Z', 'Z'),
             timezone,
             timeZoneId: request.timeZoneId,
           },


### PR DESCRIPTION
AI 七政补算此前只核对地点和目标时段，相同地点下返回另一出生日期的盘面仍可能被接收。现在同时核对出生钟表时间、UTC 时刻、历史时区、真太阳时口径和行限性别，确保补充资料属于当前主体。

沿用现有民用时间解析器，兼容天文资料使用的时间文本格式。新增真实公共接口回归，覆盖民用时间、真太阳时、零时零分，以及错误出生日期、性别和时区的拒绝路径。

验证：NAS 应用类型检查、AI 资料与工作流相关回归、定向 lint/格式、生产构建通过；其中新增真实接口与补算回归共 12 项通过。未调用真实模型，未合并或发布。本 PR 基于 #269。