### PR TITLE
统一奇门终身局时区与真太阳时交节计算

### DIFF
--- a/packages/core/src/calendar/historical-timezone.ts
+++ b/packages/core/src/calendar/historical-timezone.ts
@@ -176,6 +176,17 @@ function offsetHoursAt(formatter: Intl.DateTimeFormat, timestamp: number) {
   return Number(((representedAsUtc - Math.floor(timestamp / 1000) * 1000) / 3600000).toFixed(6));
 }
 
+/** 读取指定真实瞬时点在 IANA 时区中的历史 UTC 偏移。 */
+export function getHistoricalTimezoneOffsetAt(date: Date, timeZoneId: string): number {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error('历史时区参考时间不是有效日期。');
+  }
+  if (!timeZoneId?.trim()) {
+    throw new Error('IANA 时区名不能为空。');
+  }
+  return offsetHoursAt(getFormatter(timeZoneId.trim()), date.getTime());
+}
+
 function toIso(timestamp: number) {
   return new Date(timestamp).toISOString();
 }

--- a/packages/core/src/calendar/timeManager.ts
+++ b/packages/core/src/calendar/timeManager.ts
@@ -4,6 +4,7 @@
  */
 import type { TimeInfo, GanZhiInfo } from './lunar';
 import { SolarTime } from 'tyme4ts';
+import { DEFAULT_CHINA_TIMEZONE_HOURS } from './civil-time';
 import type { RandomOptions } from '../shared/random';
 import { createRandomSource, randomInt } from '../shared/random';
 
@@ -42,7 +43,17 @@ export class TimeManager {
   /**
    * 获取目标时区偏移（分钟）
    */
-  private static getTimezoneOffsetMinutes(date: Date): number {
+  private static getTimezoneOffsetMinutes(date: Date, explicitOffsetMinutes?: number): number {
+    if (explicitOffsetMinutes !== undefined) {
+      if (
+        !Number.isFinite(explicitOffsetMinutes) ||
+        explicitOffsetMinutes < -720 ||
+        explicitOffsetMinutes > 840
+      ) {
+        throw new Error('时区偏移分钟数需为 -720 到 840 之间的有效数字。');
+      }
+      return explicitOffsetMinutes;
+    }
     const override = this.timezoneOffsetMinutesOverride;
     if (typeof override === 'number' && Number.isFinite(override)) {
       return override;
@@ -97,18 +108,37 @@ export class TimeManager {
     };
   }
 
+  /** 按采用历表的标准时区读取真实瞬时点，用于节气与月令边界。 */
+  private static getTermSolarTime(date: Date, offsetMinutes: number): SolarTime {
+    const parts = this.getDatePartsInOffset(date, offsetMinutes);
+    return SolarTime.fromYmdHms(
+      parts.year,
+      parts.month,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+    );
+  }
+
   /**
    * 获取占卜用的统一时间数据
    * @param customTime 自定义时间（可选）
+   * @param explicitOffsetMinutes 可选的本次计算时区偏移；传入时不读取全局默认值
    * @returns 统一的时间数据
    */
-  static getDivinationTime(customTime?: Date): DivinationTime {
+  static getDivinationTime(customTime?: Date, explicitOffsetMinutes?: number): DivinationTime {
     const targetTime = customTime === undefined ? new Date() : customTime;
     if (!(targetTime instanceof Date) || Number.isNaN(targetTime.getTime())) {
       throw new Error('自定义时间不是有效日期。');
     }
-    const timeInfo = this.getTimeInfo(targetTime);
-    const ganzhi = this.getGanZhi(targetTime);
+    const offsetMinutes = this.getTimezoneOffsetMinutes(targetTime, explicitOffsetMinutes);
+    // 显式地点时区下，节气仍按采用历表的中国标准时瞬时点定位；未显式传入时保留原有全局口径。
+    const termOffsetMinutes =
+      explicitOffsetMinutes === undefined ? offsetMinutes : DEFAULT_CHINA_TIMEZONE_HOURS * 60;
+    const termSolarTime = this.getTermSolarTime(targetTime, termOffsetMinutes);
+    const timeInfo = this.getTimeInfo(targetTime, offsetMinutes, termSolarTime);
+    const ganzhi = this.getGanZhi(targetTime, offsetMinutes, termSolarTime);
     const timestamp = targetTime.getTime();
 
     return { timeInfo, ganzhi, timestamp };
@@ -118,7 +148,10 @@ export class TimeManager {
    * 按统一时区策略提取墙上时间的年月日时分秒（默认东八区）。
    * 供紫微、奇门等模块取"当前时刻"，避免直接读运行环境本地时区导致跨模块日期/时辰不一致。
    */
-  static getWallClockParts(date: Date = new Date()): {
+  static getWallClockParts(
+    date: Date = new Date(),
+    explicitOffsetMinutes?: number,
+  ): {
     year: number;
     month: number;
     day: number;
@@ -129,7 +162,10 @@ export class TimeManager {
     if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
       throw new Error('当前时间不是有效日期。');
     }
-    return this.getDatePartsInOffset(date, this.getTimezoneOffsetMinutes(date));
+    return this.getDatePartsInOffset(
+      date,
+      this.getTimezoneOffsetMinutes(date, explicitOffsetMinutes),
+    );
   }
 
   /**
@@ -192,8 +228,11 @@ export class TimeManager {
   /**
    * 获取指定时间的干支信息
    */
-  private static getGanZhi(date: Date): GanZhiInfo {
-    const offsetMinutes = this.getTimezoneOffsetMinutes(date);
+  private static getGanZhi(
+    date: Date,
+    offsetMinutes: number,
+    termSolarTime: SolarTime,
+  ): GanZhiInfo {
     const parts = this.getDatePartsInOffset(date, offsetMinutes);
     const solarTime = SolarTime.fromYmdHms(
       parts.year,
@@ -205,10 +244,11 @@ export class TimeManager {
     );
     const lunarHour = solarTime.getLunarHour();
     const eightChar = lunarHour.getEightChar();
+    const termEightChar = termSolarTime.getLunarHour().getEightChar();
 
     return {
-      year: eightChar.getYear().getName(),
-      month: eightChar.getMonth().getName(),
+      year: termEightChar.getYear().getName(),
+      month: termEightChar.getMonth().getName(),
       day: eightChar.getDay().getName(),
       hour: eightChar.getHour().getName(),
     };
@@ -217,8 +257,11 @@ export class TimeManager {
   /**
    * 获取指定时间的完整信息
    */
-  private static getTimeInfo(date: Date): TimeInfo {
-    const offsetMinutes = this.getTimezoneOffsetMinutes(date);
+  private static getTimeInfo(
+    date: Date,
+    offsetMinutes: number,
+    termSolarTime: SolarTime,
+  ): TimeInfo {
     const parts = this.getDatePartsInOffset(date, offsetMinutes);
     const solarTime = SolarTime.fromYmdHms(
       parts.year,
@@ -232,8 +275,9 @@ export class TimeManager {
     const lunarHour = solarTime.getLunarHour();
     const lunarDay = lunarHour.getLunarDay();
     const eightChar = lunarHour.getEightChar();
+    const termEightChar = termSolarTime.getLunarHour().getEightChar();
     const lunarDayText = lunarDay.toString().replace(/^农历/, '');
-    const jieQi = solarTime.getTerm();
+    const jieQi = termSolarTime.getTerm();
 
     return {
       solar: {
@@ -244,8 +288,8 @@ export class TimeManager {
         minute: parts.minute,
       },
       lunar: {
-        year: eightChar.getYear().getName(),
-        month: eightChar.getMonth().getName(),
+        year: termEightChar.getYear().getName(),
+        month: termEightChar.getMonth().getName(),
         day: eightChar.getDay().getName(),
         hour: eightChar.getHour().getName(),
         yearInChinese: lunarDayText.split('年')[0] + '年',
@@ -257,14 +301,14 @@ export class TimeManager {
         dayNumber: lunarDay.getDay(),
       },
       ganzhi: {
-        year: eightChar.getYear().getName(),
-        month: eightChar.getMonth().getName(),
+        year: termEightChar.getYear().getName(),
+        month: termEightChar.getMonth().getName(),
         day: eightChar.getDay().getName(),
         hour: eightChar.getHour().getName(),
       },
       eightChar: {
-        year: eightChar.getYear().getName(),
-        month: eightChar.getMonth().getName(),
+        year: termEightChar.getYear().getName(),
+        month: termEightChar.getMonth().getName(),
         day: eightChar.getDay().getName(),
         hour: eightChar.getHour().getName(),
       },

--- a/packages/core/src/calendar/timeManager.ts
+++ b/packages/core/src/calendar/timeManager.ts
@@ -109,7 +109,7 @@ export class TimeManager {
   }
 
   /** 按采用历表的标准时区读取真实瞬时点，用于节气与月令边界。 */
-  private static getTermSolarTime(date: Date, offsetMinutes: number): SolarTime {
+  private static getTermSolarTime(date: Date, offsetMinutes: number) {
     const parts = this.getDatePartsInOffset(date, offsetMinutes);
     return SolarTime.fromYmdHms(
       parts.year,
@@ -231,7 +231,7 @@ export class TimeManager {
   private static getGanZhi(
     date: Date,
     offsetMinutes: number,
-    termSolarTime: SolarTime,
+    termSolarTime: ReturnType<typeof SolarTime.fromYmdHms>,
   ): GanZhiInfo {
     const parts = this.getDatePartsInOffset(date, offsetMinutes);
     const solarTime = SolarTime.fromYmdHms(
@@ -260,7 +260,7 @@ export class TimeManager {
   private static getTimeInfo(
     date: Date,
     offsetMinutes: number,
-    termSolarTime: SolarTime,
+    termSolarTime: ReturnType<typeof SolarTime.fromYmdHms>,
   ): TimeInfo {
     const parts = this.getDatePartsInOffset(date, offsetMinutes);
     const solarTime = SolarTime.fromYmdHms(

--- a/packages/core/src/calendar/timeManager.ts
+++ b/packages/core/src/calendar/timeManager.ts
@@ -127,7 +127,11 @@ export class TimeManager {
    * @param explicitOffsetMinutes 可选的本次计算时区偏移；传入时不读取全局默认值
    * @returns 统一的时间数据
    */
-  static getDivinationTime(customTime?: Date, explicitOffsetMinutes?: number): DivinationTime {
+  static getDivinationTime(
+    customTime?: Date,
+    explicitOffsetMinutes?: number,
+    referenceDate?: Date,
+  ): DivinationTime {
     const targetTime = customTime === undefined ? new Date() : customTime;
     if (!(targetTime instanceof Date) || Number.isNaN(targetTime.getTime())) {
       throw new Error('自定义时间不是有效日期。');
@@ -136,7 +140,11 @@ export class TimeManager {
     // 显式地点时区下，节气仍按采用历表的中国标准时瞬时点定位；未显式传入时保留原有全局口径。
     const termOffsetMinutes =
       explicitOffsetMinutes === undefined ? offsetMinutes : DEFAULT_CHINA_TIMEZONE_HOURS * 60;
-    const termSolarTime = this.getTermSolarTime(targetTime, termOffsetMinutes);
+    const termDate = referenceDate ?? targetTime;
+    if (!(termDate instanceof Date) || Number.isNaN(termDate.getTime())) {
+      throw new Error('节气参考时间不是有效日期。');
+    }
+    const termSolarTime = this.getTermSolarTime(termDate, termOffsetMinutes);
     const timeInfo = this.getTimeInfo(targetTime, offsetMinutes, termSolarTime);
     const ganzhi = this.getGanZhi(targetTime, offsetMinutes, termSolarTime);
     const timestamp = targetTime.getTime();

--- a/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
@@ -27,7 +27,8 @@
 import { SolarDay, SolarTerm, SolarTime } from 'tyme4ts';
 import { tiangan, jiazi, qimen } from '../../../../divination/divination-data';
 import { SIX_XUN_HEADS } from '../../../../ganzhi/data';
-import { DEFAULT_CHINA_TIMEZONE_HOURS } from '../../../../calendar/civil-time';
+import { DEFAULT_CHINA_TIMEZONE_HOURS, resolveCivilTime } from '../../../../calendar/civil-time';
+import { getHistoricalTimezoneOffsetAt } from '../../../../calendar/historical-timezone';
 import { TimeManager } from '../../../../calendar/timeManager';
 import { sanQiLiuYi } from './_constants';
 
@@ -152,10 +153,16 @@ export interface QimenTermContext {
   referenceDate: Date;
   /** 将交节瞬时点换算为当地民用日期，以判断交节所在日与晚子时。 */
   localOffsetMinutes: number;
+  /** IANA 时区；历史节气逐项按交节真实瞬时点读取当地偏移。 */
+  timeZoneId?: string;
 }
 
 /** 精确交节所在的奇门干支日；23 点后按晚子时换日。 */
-function getQimenDayForTerm(term: TymeSolarTerm, localOffsetMinutes?: number): TymeSolarDay {
+function getQimenDayForTerm(
+  term: TymeSolarTerm,
+  localOffsetMinutes?: number,
+  timeZoneId?: string,
+): TymeSolarDay {
   const termTime = term.getJulianDay().getSolarTime();
   const localTermTime =
     localOffsetMinutes === undefined
@@ -163,17 +170,20 @@ function getQimenDayForTerm(term: TymeSolarTerm, localOffsetMinutes?: number): T
       : (() => {
           const chinaTime = termTime;
           const termUtcDate = new Date(
-            Date.UTC(
-              chinaTime.getYear(),
-              chinaTime.getMonth() - 1,
-              chinaTime.getDay(),
-              chinaTime.getHour(),
-              chinaTime.getMinute(),
-              chinaTime.getSecond(),
-            ) -
-              DEFAULT_CHINA_TIMEZONE_HOURS * 60 * 60 * 1000,
+            resolveCivilTime({
+              year: chinaTime.getYear(),
+              month: chinaTime.getMonth(),
+              day: chinaTime.getDay(),
+              hour: chinaTime.getHour(),
+              minute: chinaTime.getMinute(),
+              second: chinaTime.getSecond(),
+              timezone: DEFAULT_CHINA_TIMEZONE_HOURS,
+            }).utcTimestamp,
           );
-          const localParts = TimeManager.getWallClockParts(termUtcDate, localOffsetMinutes);
+          const resolvedOffsetMinutes = timeZoneId
+            ? getHistoricalTimezoneOffsetAt(termUtcDate, timeZoneId) * 60
+            : localOffsetMinutes;
+          const localParts = TimeManager.getWallClockParts(termUtcDate, resolvedOffsetMinutes);
           return SolarTime.fromYmdHms(
             localParts.year,
             localParts.month,
@@ -202,13 +212,14 @@ function resolveZhirunSegment(
   today: TymeSolarDay,
   currentTerm: TymeSolarTerm,
   localOffsetMinutes?: number,
+  timeZoneId?: string,
 ): ZhirunSegment {
   let anchorTerm = currentTerm;
   let anchorDay: TymeSolarDay | undefined;
 
   // 四个上元符头每十五日一遇，天然正授通常一年可见；十年上限用于防止历法异常。
   for (let i = 0; i < 240; i++) {
-    const candidateDay = getQimenDayForTerm(anchorTerm, localOffsetMinutes);
+    const candidateDay = getQimenDayForTerm(anchorTerm, localOffsetMinutes, timeZoneId);
     if (!candidateDay.isAfter(today) && isUpperYuanFuTou(candidateDay)) {
       anchorDay = candidateDay;
       break;
@@ -230,7 +241,10 @@ function resolveZhirunSegment(
   for (let i = 0; i < segmentCount; i++) {
     const nextStartDay = segment.startDay.next(15);
     const nextTerm = segment.term.next(1);
-    const leadDays = dayDiff(nextStartDay, getQimenDayForTerm(nextTerm, localOffsetMinutes));
+    const leadDays = dayDiff(
+      nextStartDay,
+      getQimenDayForTerm(nextTerm, localOffsetMinutes, timeZoneId),
+    );
     const shouldIntercalate =
       !segment.isIntercalary && ZHIRUN_TERMS.has(segment.term.getName()) && leadDays >= 8;
 
@@ -368,11 +382,20 @@ export function getQimenJuShu(
       throw new Error(`找不到节气 "${jieQi}" 对应的局数规则。`);
     }
 
-    const jieQiDay = getQimenDayForTerm(term, termContext?.localOffsetMinutes);
+    const jieQiDay = getQimenDayForTerm(
+      term,
+      termContext?.localOffsetMinutes,
+      termContext?.timeZoneId,
+    );
     const yuanNames = ['上元', '中元', '下元'] as const;
 
     if (juMethod === 'zhirun') {
-      const segment = resolveZhirunSegment(today, term, termContext?.localOffsetMinutes);
+      const segment = resolveZhirunSegment(
+        today,
+        term,
+        termContext?.localOffsetMinutes,
+        termContext?.timeZoneId,
+      );
       const activeJieQi = segment.term.getName();
       const activeRule = jieQiJuShuMap[activeJieQi as keyof typeof jieQiJuShuMap];
       if (!activeRule) {
@@ -383,7 +406,11 @@ export function getQimenJuShu(
       const yuanIndex = Math.floor(daysFromUpperFuTou / 5);
       const activeFuTouDay = segment.startDay.next(yuanIndex * 5);
       const activeFuTou = getDayGanZhi(activeFuTouDay);
-      const termDay = getQimenDayForTerm(segment.term, termContext?.localOffsetMinutes);
+      const termDay = getQimenDayForTerm(
+        segment.term,
+        termContext?.localOffsetMinutes,
+        termContext?.timeZoneId,
+      );
       const termLeadDays = dayDiff(segment.startDay, termDay);
       const chaoShenOrJieQi: QimenChaoShenState = segment.isIntercalary
         ? '超神'

--- a/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/jushu.ts
@@ -27,6 +27,8 @@
 import { SolarDay, SolarTerm, SolarTime } from 'tyme4ts';
 import { tiangan, jiazi, qimen } from '../../../../divination/divination-data';
 import { SIX_XUN_HEADS } from '../../../../ganzhi/data';
+import { DEFAULT_CHINA_TIMEZONE_HOURS } from '../../../../calendar/civil-time';
+import { TimeManager } from '../../../../calendar/timeManager';
 import { sanQiLiuYi } from './_constants';
 
 const { dizhi, diPanPalaces, palaceStars, palaceDoorMap, jieQiJuShuMap } = qimen;
@@ -145,11 +147,44 @@ interface ZhirunSegment {
   isIntercalary: boolean;
 }
 
+export interface QimenTermContext {
+  /** 真实瞬时点；采用历表节气先按中国标准时读取。 */
+  referenceDate: Date;
+  /** 将交节瞬时点换算为当地民用日期，以判断交节所在日与晚子时。 */
+  localOffsetMinutes: number;
+}
+
 /** 精确交节所在的奇门干支日；23 点后按晚子时换日。 */
-function getQimenDayForTerm(term: TymeSolarTerm): TymeSolarDay {
+function getQimenDayForTerm(term: TymeSolarTerm, localOffsetMinutes?: number): TymeSolarDay {
   const termTime = term.getJulianDay().getSolarTime();
-  const termDay = termTime.getSolarDay();
-  return termTime.getHour() >= 23 ? termDay.next(1) : termDay;
+  const localTermTime =
+    localOffsetMinutes === undefined
+      ? termTime
+      : (() => {
+          const chinaTime = termTime;
+          const termUtcDate = new Date(
+            Date.UTC(
+              chinaTime.getYear(),
+              chinaTime.getMonth() - 1,
+              chinaTime.getDay(),
+              chinaTime.getHour(),
+              chinaTime.getMinute(),
+              chinaTime.getSecond(),
+            ) -
+              DEFAULT_CHINA_TIMEZONE_HOURS * 60 * 60 * 1000,
+          );
+          const localParts = TimeManager.getWallClockParts(termUtcDate, localOffsetMinutes);
+          return SolarTime.fromYmdHms(
+            localParts.year,
+            localParts.month,
+            localParts.day,
+            localParts.hour,
+            localParts.minute,
+            localParts.second,
+          );
+        })();
+  const termDay = localTermTime.getSolarDay();
+  return localTermTime.getHour() >= 23 ? termDay.next(1) : termDay;
 }
 
 function isUpperYuanFuTou(day: TymeSolarDay): boolean {
@@ -163,13 +198,17 @@ function isUpperYuanFuTou(day: TymeSolarDay): boolean {
  * 上中下三元共十五日。节气交节日恰逢四符头之一即为正授；累计超神达到九日
  * （传统首尾兼算，公历日期差为八日）时，只能在芒种或大雪后重复本节三元。
  */
-function resolveZhirunSegment(today: TymeSolarDay, currentTerm: TymeSolarTerm): ZhirunSegment {
+function resolveZhirunSegment(
+  today: TymeSolarDay,
+  currentTerm: TymeSolarTerm,
+  localOffsetMinutes?: number,
+): ZhirunSegment {
   let anchorTerm = currentTerm;
   let anchorDay: TymeSolarDay | undefined;
 
   // 四个上元符头每十五日一遇，天然正授通常一年可见；十年上限用于防止历法异常。
   for (let i = 0; i < 240; i++) {
-    const candidateDay = getQimenDayForTerm(anchorTerm);
+    const candidateDay = getQimenDayForTerm(anchorTerm, localOffsetMinutes);
     if (!candidateDay.isAfter(today) && isUpperYuanFuTou(candidateDay)) {
       anchorDay = candidateDay;
       break;
@@ -191,7 +230,7 @@ function resolveZhirunSegment(today: TymeSolarDay, currentTerm: TymeSolarTerm): 
   for (let i = 0; i < segmentCount; i++) {
     const nextStartDay = segment.startDay.next(15);
     const nextTerm = segment.term.next(1);
-    const leadDays = dayDiff(nextStartDay, getQimenDayForTerm(nextTerm));
+    const leadDays = dayDiff(nextStartDay, getQimenDayForTerm(nextTerm, localOffsetMinutes));
     const shouldIntercalate =
       !segment.isIntercalary && ZHIRUN_TERMS.has(segment.term.getName()) && leadDays >= 8;
 
@@ -285,6 +324,7 @@ export function getQimenJuShu(
     ganzhi: { day: string };
   },
   juMethod: QimenJuMethod = 'chaibu',
+  termContext?: QimenTermContext,
 ): QimenJuShuResult {
   if (juMethod !== 'chaibu' && juMethod !== 'zhirun') {
     throw new Error(`未知的奇门定局方法：${String(juMethod)}。`);
@@ -303,7 +343,20 @@ export function getQimenJuShu(
       timeInfo.solar.second ?? 0,
     );
     const today = getQimenGanZhiDay(currentTime);
-    const term = currentTime.getTerm();
+    const termTime = termContext
+      ? (() => {
+          const chinaParts = TimeManager.getWallClockParts(termContext.referenceDate, 480);
+          return SolarTime.fromYmdHms(
+            chinaParts.year,
+            chinaParts.month,
+            chinaParts.day,
+            chinaParts.hour,
+            chinaParts.minute,
+            chinaParts.second,
+          );
+        })()
+      : currentTime;
+    const term = termTime.getTerm();
     if (!term) {
       throw new Error(
         `无法获取 ${timeInfo.solar.year}年${timeInfo.solar.month}月${timeInfo.solar.day}日 的节气信息。`,
@@ -315,11 +368,11 @@ export function getQimenJuShu(
       throw new Error(`找不到节气 "${jieQi}" 对应的局数规则。`);
     }
 
-    const jieQiDay = getQimenDayForTerm(term);
+    const jieQiDay = getQimenDayForTerm(term, termContext?.localOffsetMinutes);
     const yuanNames = ['上元', '中元', '下元'] as const;
 
     if (juMethod === 'zhirun') {
-      const segment = resolveZhirunSegment(today, term);
+      const segment = resolveZhirunSegment(today, term, termContext?.localOffsetMinutes);
       const activeJieQi = segment.term.getName();
       const activeRule = jieQiJuShuMap[activeJieQi as keyof typeof jieQiJuShuMap];
       if (!activeRule) {
@@ -330,7 +383,7 @@ export function getQimenJuShu(
       const yuanIndex = Math.floor(daysFromUpperFuTou / 5);
       const activeFuTouDay = segment.startDay.next(yuanIndex * 5);
       const activeFuTou = getDayGanZhi(activeFuTouDay);
-      const termDay = getQimenDayForTerm(segment.term);
+      const termDay = getQimenDayForTerm(segment.term, termContext?.localOffsetMinutes);
       const termLeadDays = dayDiff(segment.startDay, termDay);
       const chaoShenOrJieQi: QimenChaoShenState = segment.isIntercalary
         ? '超神'

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -10,9 +10,20 @@ import type {
   QimenLifetimeStage,
   QimenTopic,
 } from '../../../../types/divination';
-import { LunarUtil } from '../../../../calendar/lunar';
+import { DEFAULT_CHINA_TIMEZONE_HOURS } from '../../../../calendar/civil-time';
+import { getHistoricalTimezoneOffsetAt } from '../../../../calendar/historical-timezone';
+import { createUtcTimestamp } from '../../../../calendar/date-validation';
 import { generateQimen } from '../index';
 import { diPanPalaces } from './_constants';
+
+export interface QimenDynamicTimeContext {
+  /** 固定 UTC 偏移；存在 IANA 时区时由 timeZoneId 优先。 */
+  timezone?: number;
+  /** 目标年度沿用的 IANA 时区，按年度瞬时点重新读取历史偏移。 */
+  timeZoneId?: string;
+  /** 出生时间已经解析出的固定偏移，用于日期字符串带偏移但未单独传 timezone 的情况。 */
+  fallbackOffsetMinutes?: number;
+}
 
 const OPPOSITE_BRANCHES: Record<string, string> = {
   子: '午',
@@ -29,6 +40,27 @@ const OPPOSITE_BRANCHES: Record<string, string> = {
   亥: '巳',
 };
 
+function getIanaOffsetMinutesAt(date: Date, timeZoneId: string): number {
+  const offsetMinutes = getHistoricalTimezoneOffsetAt(date, timeZoneId) * 60;
+  if (!Number.isFinite(offsetMinutes) || offsetMinutes < -720 || offsetMinutes > 840) {
+    throw new Error(`IANA 时区 ${timeZoneId} 在目标时刻的偏移无效。`);
+  }
+  return offsetMinutes;
+}
+
+function getDynamicOffsetMinutes(
+  date: Date,
+  timeContext: QimenDynamicTimeContext | undefined,
+): number {
+  if (timeContext?.timeZoneId?.trim()) {
+    return getIanaOffsetMinutesAt(date, timeContext.timeZoneId.trim());
+  }
+  if (timeContext?.timezone !== undefined) {
+    return timeContext.timezone * 60;
+  }
+  return timeContext?.fallbackOffsetMinutes ?? DEFAULT_CHINA_TIMEZONE_HOURS * 60;
+}
+
 /**
  * 扫描指定时间范围内的流年动态事件簇
  */
@@ -38,6 +70,7 @@ export function scanLifetimeDynamicEvents(
   periodRange: { startDate: string; endDate: string },
   method: 'zhuanpan' | 'feipan' = 'zhuanpan',
   juMethod: 'chaibu' | 'zhirun' = 'chaibu',
+  timeContext?: QimenDynamicTimeContext,
 ): QimenEventCluster[] {
   const clusters: QimenEventCluster[] = [];
 
@@ -55,13 +88,23 @@ export function scanLifetimeDynamicEvents(
     baseChart.jiuGongGe.find((item) => item.gong === p)?.name || `${p}宫`;
 
   for (let y = startYear; y <= maxEndYear; y++) {
-    const midYearDate = new Date(Date.UTC(y, 5, 15, 12, 0, 0));
+    const midYearDate = new Date(createUtcTimestamp(y, 5, 15, 12, 0, 0));
     let flowYearGanZhi: string;
+    let yearQimen: QimenData;
     try {
-      const timeInfo = LunarUtil.getTimeInfo(midYearDate);
-      flowYearGanZhi = timeInfo.ganzhi.year;
-    } catch {
-      continue;
+      const targetOffsetMinutes = getDynamicOffsetMinutes(midYearDate, timeContext);
+      yearQimen = generateQimen(
+        midYearDate,
+        method,
+        'year',
+        juMethod,
+        targetOffsetMinutes,
+        timeContext?.timeZoneId,
+      );
+      flowYearGanZhi = yearQimen.ganzhi.year;
+    } catch (cause) {
+      const detail = cause instanceof Error ? cause.message : String(cause);
+      throw new Error(`${y}年动态年盘生成失败：${detail}`, { cause });
     }
 
     const flowYearBranch = flowYearGanZhi[1];
@@ -160,21 +203,16 @@ export function scanLifetimeDynamicEvents(
     }
 
     // 4. 年家奇门局合参
-    try {
-      const yearQimen = generateQimen(midYearDate, method, 'year', juMethod);
-      if (yearQimen.classicPatterns && yearQimen.classicPatterns.length > 0) {
-        for (const yp of yearQimen.classicPatterns) {
-          if (yp.palaces.includes(taiSuiPalaceNum)) {
-            if (yp.type === 'good') {
-              supportEvidence.push(`岁盘吉格「${yp.name}」叠合临宫：${yp.summary}`);
-            } else if (yp.type === 'bad') {
-              counterEvidence.push(`岁盘凶格「${yp.name}」叠合临宫：${yp.summary}`);
-            }
+    if (yearQimen.classicPatterns && yearQimen.classicPatterns.length > 0) {
+      for (const yp of yearQimen.classicPatterns) {
+        if (yp.palaces.includes(taiSuiPalaceNum)) {
+          if (yp.type === 'good') {
+            supportEvidence.push(`岁盘吉格「${yp.name}」叠合临宫：${yp.summary}`);
+          } else if (yp.type === 'bad') {
+            counterEvidence.push(`岁盘凶格「${yp.name}」叠合临宫：${yp.summary}`);
           }
         }
       }
-    } catch {
-      // 容错忽略岁盘额外计算错误
     }
 
     // 若未命中任何特定主题，默认归为事业与大势

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
@@ -10,6 +10,7 @@ import type {
   QimenStagePolicy,
   QimenTopicCandidate,
 } from '../../../../types/divination';
+import type { CivilDateTimeParts } from '../../../../calendar/civil-time';
 import { diPanPalaces } from './_constants';
 import { getDunJiaStem } from './jushu';
 
@@ -18,8 +19,8 @@ const COUNTER_CLOCKWISE_OUTER_PALACES = [1, 6, 7, 2, 9, 4, 3, 8];
 
 const YANG_STEMS = ['甲', '丙', '戊', '庚', '壬'];
 
-function addYearsToDate(date: Date, years: number): string {
-  const d = new Date(date.getTime());
+function addYearsToCivilDate(date: CivilDateTimeParts, years: number): string {
+  const d = new Date(Date.UTC(date.year, date.month - 1, date.day));
   d.setUTCFullYear(d.getUTCFullYear() + years);
   return d.toISOString().split('T')[0];
 }
@@ -83,14 +84,26 @@ function evaluatePalaceSupportAndConstraints(
   return { support, constraints };
 }
 
-function getAnchorBaseDate(birthDate: Date, anchorRule?: QimenStagePolicy['anchorRule']): Date {
+function getAnchorBaseDate(
+  birthDate: Date,
+  anchorRule: QimenStagePolicy['anchorRule'] | undefined,
+  birthCivilDate?: CivilDateTimeParts,
+): CivilDateTimeParts {
+  const baseDate = birthCivilDate ?? {
+    year: birthDate.getUTCFullYear(),
+    month: birthDate.getUTCMonth() + 1,
+    day: birthDate.getUTCDate(),
+    hour: 0,
+    minute: 0,
+    second: 0,
+  };
   if (anchorRule === 'lunarNewYear') {
-    return new Date(Date.UTC(birthDate.getUTCFullYear(), 0, 1));
+    return { ...baseDate, month: 1, day: 1 };
   }
   if (anchorRule === 'solarTermBoundary') {
-    return new Date(Date.UTC(birthDate.getUTCFullYear(), 1, 4));
+    return { ...baseDate, month: 2, day: 4 };
   }
-  return birthDate;
+  return baseDate;
 }
 
 /**
@@ -103,10 +116,11 @@ export function buildLifetimeStages(
   policy: QimenStagePolicy,
   birthDate: Date,
   gender?: 'male' | 'female',
+  birthCivilDate?: CivilDateTimeParts,
 ): QimenLifetimeStage[] {
   const model = policy.model ?? 'pillarFourLimits';
   const stages: QimenLifetimeStage[] = [];
-  const anchorBaseDate = getAnchorBaseDate(birthDate, policy.anchorRule);
+  const anchorBaseDate = getAnchorBaseDate(birthDate, policy.anchorRule, birthCivilDate);
   const ageOffset = policy.ageSystem === 'nominalAge' ? 1 : 0;
 
   const getPalaceName = (p: number) =>
@@ -162,8 +176,8 @@ export function buildLifetimeStages(
         title: '初限·早年根基',
         ageStart: 0 + ageOffset,
         ageEnd: 16 + ageOffset,
-        calStart: addYearsToDate(anchorBaseDate, 0),
-        calEnd: addYearsToDate(anchorBaseDate, 16),
+        calStart: addYearsToCivilDate(anchorBaseDate, 0),
+        calEnd: addYearsToCivilDate(anchorBaseDate, 16),
         gongs: yearPalaces,
         theme: '年柱主限：主家庭原生教养、长辈福荫护持、学识基础与先天命质形成。',
         markers: [`年干${yearStem}`, `年支${yearBranch}`],
@@ -173,8 +187,8 @@ export function buildLifetimeStages(
         title: '中前限·青年立业',
         ageStart: 17 + ageOffset,
         ageEnd: 32 + ageOffset,
-        calStart: addYearsToDate(anchorBaseDate, 17),
-        calEnd: addYearsToDate(anchorBaseDate, 32),
+        calStart: addYearsToCivilDate(anchorBaseDate, 17),
+        calEnd: addYearsToCivilDate(anchorBaseDate, 32),
         gongs: monthPalaces,
         theme: '月柱主限：走出家庭踏入社会、人际圈层开拓、事业基石奠定与青年自我认知。',
         markers: [`月干${monthStem}`, `月支${monthBranch}`],
@@ -184,8 +198,8 @@ export function buildLifetimeStages(
         title: '中后限·中年鼎盛',
         ageStart: 33 + ageOffset,
         ageEnd: 48 + ageOffset,
-        calStart: addYearsToDate(anchorBaseDate, 33),
-        calEnd: addYearsToDate(anchorBaseDate, 48),
+        calStart: addYearsToCivilDate(anchorBaseDate, 33),
+        calEnd: addYearsToCivilDate(anchorBaseDate, 48),
         gongs: dayPalaces,
         theme: '日柱主限：人生核心建树期，自身心力智慧完全展现，家庭与社会中流砥柱。',
         markers: [`日干${dayStem}`],
@@ -195,8 +209,8 @@ export function buildLifetimeStages(
         title: '末限·晚景安泰',
         ageStart: 49 + ageOffset,
         ageEnd: 80 + ageOffset,
-        calStart: addYearsToDate(anchorBaseDate, 49),
-        calEnd: addYearsToDate(anchorBaseDate, 80),
+        calStart: addYearsToCivilDate(anchorBaseDate, 49),
+        calEnd: addYearsToCivilDate(anchorBaseDate, 80),
         gongs: hourPalaces,
         theme: '时柱主限：事业收获定型、后辈晚生接班、生活闲适自洽与精神安泰归宿。',
         markers: [`时干${hourStem}`, `值使${baseChart.zhiShi}`],
@@ -257,8 +271,8 @@ export function buildLifetimeStages(
         title: `行限第${i + 1}步（${getPalaceName(gong)}）`,
         ageStart,
         ageEnd,
-        calendarStart: addYearsToDate(anchorBaseDate, i * yearsPerStage),
-        calendarEnd: addYearsToDate(anchorBaseDate, (i + 1) * yearsPerStage - 1),
+        calendarStart: addYearsToCivilDate(anchorBaseDate, i * yearsPerStage),
+        calendarEnd: addYearsToCivilDate(anchorBaseDate, (i + 1) * yearsPerStage - 1),
         dominantPalaces: [{ palace: gong, name: getPalaceName(gong) }],
         associatedMarkers: [`行限临${getPalaceName(gong)}`],
         stageTheme: `九宫巡行运限：当值${getPalaceName(gong)}，能量由该宫门星神干及奇仪克应主导。`,
@@ -296,8 +310,8 @@ export function buildLifetimeStages(
         title: yaoTitle,
         ageStart,
         ageEnd,
-        calendarStart: addYearsToDate(anchorBaseDate, (yao - 1) * 10),
-        calendarEnd: addYearsToDate(anchorBaseDate, yao === 8 ? 80 : yao * 10 - 1),
+        calendarStart: addYearsToCivilDate(anchorBaseDate, (yao - 1) * 10),
+        calendarEnd: addYearsToCivilDate(anchorBaseDate, yao === 8 ? 80 : yao * 10 - 1),
         dominantPalaces: [{ palace: curGong, name: getPalaceName(curGong) }],
         associatedMarkers: [
           yao % 2 === 1 ? `值符星${baseChart.zhiFu}` : `值使门${baseChart.zhiShi}`,

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-time.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-time.ts
@@ -19,8 +19,10 @@ import {
 } from '../../../../calendar/true-solar-time';
 
 export interface QimenNormalizedTimeResult {
-  /** 用于排盘计算的标准化 Date 对象 */
+  /** 日时计算坐标；真太阳时模式下表示校正后的当地钟表时间。 */
   normalizedDate: Date;
+  /** 出生真实瞬时点，用于节气与天文事件定位。 */
+  referenceDate: Date;
   /** 四柱计算基准日期（真太阳时模式下为经度修正后的时刻） */
   calculationParts: CivilDateTimeParts;
   /** 本次计算应使用的当地 UTC 偏移（分钟），与 normalizedDate 表示同一 civil 时刻 */
@@ -125,6 +127,7 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
   let crossesDate: boolean | undefined;
 
   let normalizedDate: Date;
+  let referenceDate: Date | undefined;
   let effectiveTimezone: number;
 
   if (timeStandard === 'trueSolar') {
@@ -146,13 +149,18 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
     isDstApplied = tstResult.chinaDst.applied;
     crossesDate = tstResult.crossesDate;
     effectiveTimezone = tstResult.timezone;
+    referenceDate = new Date(
+      resolveCivilTime(
+        { ...tstResult.standardTime, timezone: tstResult.timezone },
+        { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
+      ).utcTimestamp,
+    );
 
-    // 解析真太阳时修正后的标准 UTC 时间
+    // 太阳时钟表不再应用民用时区的跳时/回拨规则，沿用出生时已解析的偏移。
     const resolvedCivil = resolveCivilTime(
       {
         ...calculationParts,
         timezone: tstResult.timezone,
-        timeZoneId: tstResult.timeZoneId,
       },
       { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
     );
@@ -173,21 +181,20 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
   }
 
   // 4. 提取当令节气
-  let solarTermName = '立春';
-  try {
-    const termParts = getCivilDateTimeAtFixedOffset(normalizedDate, DEFAULT_CHINA_TIMEZONE_HOURS);
-    const st = SolarTime.fromYmdHms(
-      termParts.year,
-      termParts.month,
-      termParts.day,
-      termParts.hour,
-      termParts.minute,
-      termParts.second,
-    );
-    solarTermName = st.getTerm().getName();
-  } catch {
-    // 容错默认节气
-  }
+  const termParts = getCivilDateTimeAtFixedOffset(
+    referenceDate ?? normalizedDate,
+    DEFAULT_CHINA_TIMEZONE_HOURS,
+  );
+  const solarTermName = SolarTime.fromYmdHms(
+    termParts.year,
+    termParts.month,
+    termParts.day,
+    termParts.hour,
+    termParts.minute,
+    termParts.second,
+  )
+    .getTerm()
+    .getName();
 
   // 5. 默认阶段策略
   const stagePolicy: QimenStagePolicy = {
@@ -217,6 +224,7 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
 
   return {
     normalizedDate,
+    referenceDate: referenceDate ?? normalizedDate,
     calculationParts,
     timezoneOffsetMinutes: effectiveTimezone * 60,
     basis,

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-time.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-time.ts
@@ -8,6 +8,7 @@ import type { QimenLifetimeInput, QimenStagePolicy } from '../../../../types/div
 import {
   resolveCivilTime,
   DEFAULT_CHINA_TIMEZONE_HOURS,
+  getCivilDateTimeAtFixedOffset,
   type CivilDateTimeParts,
 } from '../../../../calendar/civil-time';
 import {
@@ -22,6 +23,8 @@ export interface QimenNormalizedTimeResult {
   normalizedDate: Date;
   /** 四柱计算基准日期（真太阳时模式下为经度修正后的时刻） */
   calculationParts: CivilDateTimeParts;
+  /** 本次计算应使用的当地 UTC 偏移（分钟），与 normalizedDate 表示同一 civil 时刻 */
+  timezoneOffsetMinutes: number;
   /** 依据元数据快照 */
   basis: {
     calendar: string;
@@ -172,13 +175,14 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
   // 4. 提取当令节气
   let solarTermName = '立春';
   try {
+    const termParts = getCivilDateTimeAtFixedOffset(normalizedDate, DEFAULT_CHINA_TIMEZONE_HOURS);
     const st = SolarTime.fromYmdHms(
-      calculationParts.year,
-      calculationParts.month,
-      calculationParts.day,
-      calculationParts.hour,
-      calculationParts.minute,
-      calculationParts.second,
+      termParts.year,
+      termParts.month,
+      termParts.day,
+      termParts.hour,
+      termParts.minute,
+      termParts.second,
     );
     solarTermName = st.getTerm().getName();
   } catch {
@@ -214,6 +218,7 @@ export function normalizeQimenLifetimeTime(input: QimenLifetimeInput): QimenNorm
   return {
     normalizedDate,
     calculationParts,
+    timezoneOffsetMinutes: effectiveTimezone * 60,
     basis,
   };
 }

--- a/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
@@ -21,6 +21,7 @@ import {
   type SolarTermEvidence,
   type SolarTermName,
 } from '../../../../calendar/solar-term-evidence';
+import { DEFAULT_CHINA_TIMEZONE_HOURS } from '../../../../calendar/civil-time';
 import {
   calculateMoonPhaseEvidence,
   type MoonPhaseEvidence,
@@ -140,17 +141,26 @@ export interface JieQiPhaseResult {
  * 下元（第 11-15 天）。此字段只描述节气内日期位置；正式定局三元由定局算法给出。
  *
  * @param date 真实瞬时点；民用年月日时分秒按 TimeManager 当前偏移读取
+ * @param explicitOffsetMinutes 可选的本次计算时区偏移；传入时不读取全局默认值
+ * @param termOffsetMinutes 节气采用历表的参考偏移；显式地点时区通常传中国标准时 480 分钟
  * @returns 节气内自然日阶段信息
  */
-export function getJieQiPhaseByDate(date: Date): JieQiPhaseResult {
-  const civilTime = TimeManager.getWallClockParts(date);
+export function getJieQiPhaseByDate(
+  date: Date,
+  explicitOffsetMinutes?: number,
+  termOffsetMinutes?: number,
+): JieQiPhaseResult {
+  const resolvedTermOffsetMinutes =
+    termOffsetMinutes ??
+    (explicitOffsetMinutes === undefined ? undefined : DEFAULT_CHINA_TIMEZONE_HOURS * 60);
+  const termTimeParts = TimeManager.getWallClockParts(date, resolvedTermOffsetMinutes);
   const solarTime = SolarTime.fromYmdHms(
-    civilTime.year,
-    civilTime.month,
-    civilTime.day,
-    civilTime.hour,
-    civilTime.minute,
-    civilTime.second,
+    termTimeParts.year,
+    termTimeParts.month,
+    termTimeParts.day,
+    termTimeParts.hour,
+    termTimeParts.minute,
+    termTimeParts.second,
   );
   const term = solarTime.getTerm();
   const jieQi = term.getName();
@@ -315,11 +325,11 @@ export function getLunarPhaseByIndex(index: number): LunarPhase {
  * @param date 真实瞬时点；公历日期按 TimeManager 当前偏移读取
  * @returns 月相
  */
-export function getLunarPhase(date: Date): LunarPhase {
+export function getLunarPhase(date: Date, explicitOffsetMinutes?: number): LunarPhase {
   if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
     throw new Error('月相日期必须是有效日期。');
   }
-  const civilTime = TimeManager.getWallClockParts(date);
+  const civilTime = TimeManager.getWallClockParts(date, explicitOffsetMinutes);
   const solarDay = SolarDay.fromYmd(civilTime.year, civilTime.month, civilTime.day);
   const phase = solarDay.getLunarDay().getPhase();
   return getLunarPhaseByIndex(phase.getIndex());
@@ -413,11 +423,19 @@ export function getDayOfficerInfo(dayOfficer: string) {
  * @param ganzhi 四柱干支
  * @param jieQi 节气名称
  * @param date 真实瞬时点；民用日期按 TimeManager 当前偏移读取，月相证据保留该瞬时点
+ * @param explicitOffsetMinutes 可选的本次计算时区偏移；传入时民用日期与月相使用同一 civil
+ * @param termOffsetMinutes 节气采用历表的参考偏移；显式地点时区通常传中国标准时 480 分钟
  * @returns 节令背景信息
  */
-export function buildSeasonality(ganzhi: BaseGanZhi, jieQi: string, date: Date): SeasonalityInfo {
+export function buildSeasonality(
+  ganzhi: BaseGanZhi,
+  jieQi: string,
+  date: Date,
+  explicitOffsetMinutes?: number,
+  termOffsetMinutes?: number,
+): SeasonalityInfo {
   // ── 1. 节气与三元阶段（优先以太阳历准确定位节气） ──
-  const jieQiPhase = getJieQiPhaseByDate(date);
+  const jieQiPhase = getJieQiPhaseByDate(date, explicitOffsetMinutes, termOffsetMinutes);
   // 使用参数传人的节气名作为兜底，优先以太阳历实际节气为准
   const actualJieQi = jieQiPhase.jieQi || jieQi;
   const seasonalElement = getSeasonalElement(actualJieQi);
@@ -428,7 +446,7 @@ export function buildSeasonality(ganzhi: BaseGanZhi, jieQi: string, date: Date):
   const { relation, description } = getDaySeasonRelation(dayStem, seasonalElement);
 
   // ── 3. 月相 ──
-  const civilTime = TimeManager.getWallClockParts(date);
+  const civilTime = TimeManager.getWallClockParts(date, explicitOffsetMinutes);
   const solarDay = SolarDay.fromYmd(civilTime.year, civilTime.month, civilTime.day);
   const tymePhase = solarDay.getLunarDay().getPhase();
   const phaseIndex = tymePhase.getIndex();

--- a/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/seasonality.ts
@@ -433,9 +433,11 @@ export function buildSeasonality(
   date: Date,
   explicitOffsetMinutes?: number,
   termOffsetMinutes?: number,
+  referenceDate?: Date,
 ): SeasonalityInfo {
   // ── 1. 节气与三元阶段（优先以太阳历准确定位节气） ──
-  const jieQiPhase = getJieQiPhaseByDate(date, explicitOffsetMinutes, termOffsetMinutes);
+  const actualInstant = referenceDate ?? date;
+  const jieQiPhase = getJieQiPhaseByDate(actualInstant, explicitOffsetMinutes, termOffsetMinutes);
   // 使用参数传人的节气名作为兜底，优先以太阳历实际节气为准
   const actualJieQi = jieQiPhase.jieQi || jieQi;
   const seasonalElement = getSeasonalElement(actualJieQi);
@@ -452,7 +454,7 @@ export function buildSeasonality(
   const phaseIndex = tymePhase.getIndex();
   const lunarPhase = getLunarPhaseByIndex(phaseIndex);
   const lunarPhaseDetail = tymePhase.getName();
-  const moonPhaseEvidence = calculateMoonPhaseEvidence(date.getTime());
+  const moonPhaseEvidence = calculateMoonPhaseEvidence(actualInstant.getTime());
   const lunarPhaseConsistency = lunarPhaseDetail === moonPhaseEvidence.eightPhaseName;
 
   // ── 4. 建除十二神 ──

--- a/packages/core/src/divination/algorithms/qimen/index.ts
+++ b/packages/core/src/divination/algorithms/qimen/index.ts
@@ -232,6 +232,7 @@ function mapStemRelations(
  * @param method     排盘方法，默认 'zhuanpan'（转盘法）
  * @param scope      排盘级别，默认 'hour'（时家奇门）
  * @param timezoneOffsetMinutes 本次计算的显式 UTC 偏移（分钟），省略时沿用 TimeManager 默认值
+ * @param timeZoneId 本次计算所用 IANA 时区；用于历史节气按真实瞬时点解析当地偏移
  * @returns 完整的奇门遁甲数据 QimenData
  *
  * @example
@@ -252,6 +253,7 @@ export function generateQimen(
   scope: QimenScope = 'hour',
   juMethod: QimenJuMethod = 'chaibu',
   timezoneOffsetMinutes?: number,
+  timeZoneId?: string,
 ): QimenData {
   assertQimenScope(scope);
   // ──────────────────────────────────────────────────────────────────────────
@@ -265,6 +267,7 @@ export function generateQimen(
       : {
           referenceDate: new Date(timestamp),
           localOffsetMinutes: timezoneOffsetMinutes,
+          timeZoneId,
         };
 
   // 根据 scope 确定"主动干支"（用于定局、寻符使、空亡、驿马）

--- a/packages/core/src/divination/algorithms/qimen/index.ts
+++ b/packages/core/src/divination/algorithms/qimen/index.ts
@@ -34,7 +34,7 @@ import {
   getZhiFuZhiShiByGanZhi,
   getDunJiaStem,
 } from './helpers/jushu';
-import type { QimenJuMethod, QimenJuShuResult } from './helpers/jushu';
+import type { QimenJuMethod, QimenJuShuResult, QimenTermContext } from './helpers/jushu';
 import { getMonthQimenJuShu, getYearQimenJuShu } from './helpers/jushu-extended';
 import { arrangeJiuGongGe, resolveZhiShiLandingPalace } from './helpers/layout';
 import { getQimenPatternTags, buildPatternDetails, buildPalaceInsights } from './helpers/patterns';
@@ -231,6 +231,7 @@ function mapStemRelations(
  * @param customDate 自定义时间（可选，默认当前时间）
  * @param method     排盘方法，默认 'zhuanpan'（转盘法）
  * @param scope      排盘级别，默认 'hour'（时家奇门）
+ * @param timezoneOffsetMinutes 本次计算的显式 UTC 偏移（分钟），省略时沿用 TimeManager 默认值
  * @returns 完整的奇门遁甲数据 QimenData
  *
  * @example
@@ -250,13 +251,21 @@ export function generateQimen(
   method: QimenMethod = 'zhuanpan',
   scope: QimenScope = 'hour',
   juMethod: QimenJuMethod = 'chaibu',
+  timezoneOffsetMinutes?: number,
 ): QimenData {
   assertQimenScope(scope);
   // ──────────────────────────────────────────────────────────────────────────
   // 步骤 1：获取统一占卜时间信息
   // ──────────────────────────────────────────────────────────────────────────
-  const { timeInfo, ganzhi, timestamp } = getDivinationTime(customDate);
+  const { timeInfo, ganzhi, timestamp } = getDivinationTime(customDate, timezoneOffsetMinutes);
   const { jieQi } = timeInfo;
+  const termContext: QimenTermContext | undefined =
+    timezoneOffsetMinutes === undefined
+      ? undefined
+      : {
+          referenceDate: new Date(timestamp),
+          localOffsetMinutes: timezoneOffsetMinutes,
+        };
 
   // 根据 scope 确定"主动干支"（用于定局、寻符使、空亡、驿马）
   const activeGanZhi = getActiveGanZhi(ganzhi, scope);
@@ -264,7 +273,7 @@ export function generateQimen(
   // ──────────────────────────────────────────────────────────────────────────
   // 步骤 2：定局数
   // ──────────────────────────────────────────────────────────────────────────
-  const jushuResult = getJushuForScope(scope, ganzhi, timeInfo, juMethod);
+  const jushuResult = getJushuForScope(scope, ganzhi, timeInfo, juMethod, termContext);
   const { isYangDun, juShu, yuan } = jushuResult;
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -368,6 +377,8 @@ export function generateQimen(
     ganzhi,
     jushuResult.actualJieQi || jieQi,
     new Date(timestamp),
+    timezoneOffsetMinutes,
+    timezoneOffsetMinutes === undefined ? undefined : 480,
   );
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -512,6 +523,7 @@ function getJushuForScope(
     jieQi: string;
   },
   juMethod: QimenJuMethod = 'chaibu',
+  termContext?: QimenTermContext,
 ): QimenJuShuResult {
   switch (scope) {
     case 'year': {
@@ -550,6 +562,7 @@ function getJushuForScope(
           },
         },
         juMethod,
+        termContext,
       );
     }
   }

--- a/packages/core/src/divination/algorithms/qimen/index.ts
+++ b/packages/core/src/divination/algorithms/qimen/index.ts
@@ -254,18 +254,23 @@ export function generateQimen(
   juMethod: QimenJuMethod = 'chaibu',
   timezoneOffsetMinutes?: number,
   timeZoneId?: string,
+  referenceDate?: Date,
 ): QimenData {
   assertQimenScope(scope);
   // ──────────────────────────────────────────────────────────────────────────
   // 步骤 1：获取统一占卜时间信息
   // ──────────────────────────────────────────────────────────────────────────
-  const { timeInfo, ganzhi, timestamp } = getDivinationTime(customDate, timezoneOffsetMinutes);
+  const { timeInfo, ganzhi, timestamp } = getDivinationTime(
+    customDate,
+    timezoneOffsetMinutes,
+    referenceDate,
+  );
   const { jieQi } = timeInfo;
   const termContext: QimenTermContext | undefined =
     timezoneOffsetMinutes === undefined
       ? undefined
       : {
-          referenceDate: new Date(timestamp),
+          referenceDate: referenceDate ?? new Date(timestamp),
           localOffsetMinutes: timezoneOffsetMinutes,
           timeZoneId,
         };
@@ -382,6 +387,7 @@ export function generateQimen(
     new Date(timestamp),
     timezoneOffsetMinutes,
     timezoneOffsetMinutes === undefined ? undefined : 480,
+    referenceDate,
   );
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/packages/core/src/divination/algorithms/qimen/lifetime.ts
+++ b/packages/core/src/divination/algorithms/qimen/lifetime.ts
@@ -32,7 +32,13 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
   const juMethod = input.juMethod ?? 'chaibu';
 
   // 2. P1: 生成本命基础局（体）
-  const baseChart = generateQimen(timeResult.normalizedDate, method, 'hour', juMethod);
+  const baseChart = generateQimen(
+    timeResult.normalizedDate,
+    method,
+    'hour',
+    juMethod,
+    timeResult.timezoneOffsetMinutes,
+  );
 
   // 3. P1: 提取个人标记与六亲主题宫（枢）
   const personalMarkers = extractPersonalMarkers(baseChart);
@@ -46,6 +52,7 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
     timeResult.basis.stagePolicy,
     timeResult.normalizedDate,
     input.gender,
+    timeResult.calculationParts,
   );
 
   // 5. P3: 动态事件扫描与事件聚类（用，仅在指定 periodRange 时触发）

--- a/packages/core/src/divination/algorithms/qimen/lifetime.ts
+++ b/packages/core/src/divination/algorithms/qimen/lifetime.ts
@@ -39,6 +39,7 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
     juMethod,
     timeResult.timezoneOffsetMinutes,
     input.timeZoneId,
+    timeResult.referenceDate,
   );
 
   // 3. P1: 提取个人标记与六亲主题宫（枢）

--- a/packages/core/src/divination/algorithms/qimen/lifetime.ts
+++ b/packages/core/src/divination/algorithms/qimen/lifetime.ts
@@ -38,6 +38,7 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
     'hour',
     juMethod,
     timeResult.timezoneOffsetMinutes,
+    input.timeZoneId,
   );
 
   // 3. P1: 提取个人标记与六亲主题宫（枢）
@@ -64,6 +65,11 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
       input.periodRange,
       method,
       juMethod,
+      {
+        timezone: input.timezone,
+        timeZoneId: input.timeZoneId,
+        fallbackOffsetMinutes: timeResult.timezoneOffsetMinutes,
+      },
     );
   }
 

--- a/tests/fixtures/qimen-lifetime-timezone-probe.ts
+++ b/tests/fixtures/qimen-lifetime-timezone-probe.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+import { getDivinationTime } from '../../packages/core/src/calendar/timeManager';
 import { calculateQimenLifetime } from '../../packages/core/src/divination/algorithms/qimen';
 
 const result = calculateQimenLifetime({
@@ -28,10 +30,13 @@ const summarizeClusters = (source: typeof result) =>
     counterEvidence: cluster.counterEvidence,
   }));
 
+const actualTime = getDivinationTime(new Date(result.baseChart.timestamp), 840);
+assert.deepEqual(result.baseChart.ganzhi, actualTime.ganzhi);
+
 process.stdout.write(
   JSON.stringify({
     timestamp: result.baseChart.timestamp,
-    solar: result.baseChart.timeInfo.solar,
+    solar: actualTime.timeInfo.solar,
     ganzhi: result.baseChart.ganzhi,
     seasonality: {
       currentJieQi: result.baseChart.seasonality?.currentJieQi,

--- a/tests/fixtures/qimen-lifetime-timezone-probe.ts
+++ b/tests/fixtures/qimen-lifetime-timezone-probe.ts
@@ -4,7 +4,29 @@ const result = calculateQimenLifetime({
   birthDateTime: '2024-01-02T00:30:00',
   timezone: 14,
   timeStandard: 'civil',
+  periodRange: {
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+  },
 });
+
+const ianaResult = calculateQimenLifetime({
+  birthDateTime: '2023-01-15T14:30:00',
+  timeZoneId: 'America/New_York',
+  timeStandard: 'civil',
+  periodRange: {
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+  },
+});
+
+const summarizeClusters = (source: typeof result) =>
+  source.eventClusters?.map((cluster) => ({
+    key: cluster.key,
+    stageIndex: cluster.stageIndex,
+    supportEvidence: cluster.supportEvidence,
+    counterEvidence: cluster.counterEvidence,
+  }));
 
 process.stdout.write(
   JSON.stringify({
@@ -18,5 +40,7 @@ process.stdout.write(
       dayOfficer: result.baseChart.seasonality?.dayOfficer,
     },
     stageStart: result.stages[0]?.calendarStart,
+    dynamicClusters: summarizeClusters(result),
+    ianaDynamicClusters: summarizeClusters(ianaResult),
   }),
 );

--- a/tests/fixtures/qimen-lifetime-timezone-probe.ts
+++ b/tests/fixtures/qimen-lifetime-timezone-probe.ts
@@ -1,0 +1,22 @@
+import { calculateQimenLifetime } from '../../packages/core/src/divination/algorithms/qimen';
+
+const result = calculateQimenLifetime({
+  birthDateTime: '2024-01-02T00:30:00',
+  timezone: 14,
+  timeStandard: 'civil',
+});
+
+process.stdout.write(
+  JSON.stringify({
+    timestamp: result.baseChart.timestamp,
+    solar: result.baseChart.timeInfo.solar,
+    ganzhi: result.baseChart.ganzhi,
+    seasonality: {
+      currentJieQi: result.baseChart.seasonality?.currentJieQi,
+      phase: result.baseChart.seasonality?.jieQiPhase.phase,
+      lunarPhase: result.baseChart.seasonality?.lunarPhase,
+      dayOfficer: result.baseChart.seasonality?.dayOfficer,
+    },
+    stageStart: result.stages[0]?.calendarStart,
+  }),
+);

--- a/tests/qimen-lifetime-timezone.test.ts
+++ b/tests/qimen-lifetime-timezone.test.ts
@@ -14,6 +14,18 @@ interface TimezoneProbe {
     minute: number;
   };
   stageStart: string;
+  dynamicClusters: Array<{
+    key: string;
+    stageIndex: number;
+    supportEvidence: string[];
+    counterEvidence: string[];
+  }>;
+  ianaDynamicClusters: Array<{
+    key: string;
+    stageIndex: number;
+    supportEvidence: string[];
+    counterEvidence: string[];
+  }>;
 }
 
 function runProbe(timeZone: string) {
@@ -46,4 +58,12 @@ test('奇门终身局显式出生时区不受宿主时区影响', () => {
     minute: 30,
   });
   assert.equal(baseline.stageStart, '2024-01-02');
+  assert.ok(
+    baseline.dynamicClusters.some((cluster) => cluster.key.startsWith('cluster:2024:')),
+    '动态年盘应保留年度事件簇',
+  );
+  assert.ok(
+    baseline.ianaDynamicClusters.some((cluster) => cluster.key.startsWith('cluster:2024:')),
+    'IANA 时区动态年盘应保留年度事件簇',
+  );
 });

--- a/tests/qimen-lifetime-timezone.test.ts
+++ b/tests/qimen-lifetime-timezone.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface TimezoneProbe {
+  timestamp: number;
+  solar: {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+  };
+  stageStart: string;
+}
+
+function runProbe(timeZone: string) {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(testDir, '..');
+  const tsxCli = resolve(root, 'node_modules/tsx/dist/cli.mjs');
+  const tsconfig = resolve(root, 'tsconfig.app.json');
+  const probe = resolve(testDir, 'fixtures/qimen-lifetime-timezone-probe.ts');
+  const result = spawnSync(process.execPath, [tsxCli, '--tsconfig', tsconfig, probe], {
+    cwd: root,
+    env: { ...process.env, TZ: timeZone },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, `${timeZone}\n${result.stderr}`);
+  return JSON.parse(result.stdout.trim()) as TimezoneProbe;
+}
+
+test('奇门终身局显式出生时区不受宿主时区影响', () => {
+  const baseline = runProbe('UTC');
+  for (const timeZone of ['Asia/Shanghai', 'America/New_York', 'Pacific/Apia']) {
+    assert.deepEqual(runProbe(timeZone), baseline, timeZone);
+  }
+
+  assert.equal(baseline.timestamp, Date.parse('2024-01-01T10:30:00.000Z'));
+  assert.deepEqual(baseline.solar, {
+    year: 2024,
+    month: 1,
+    day: 2,
+    hour: 0,
+    minute: 30,
+  });
+  assert.equal(baseline.stageStart, '2024-01-02');
+});

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -53,6 +53,153 @@ test('奇门终身局 P0：时间标准化与真太阳时校正', () => {
   }, /启用真太阳时必须提供出生地经度/);
 });
 
+test('奇门终身局应沿用固定非东八区的 civil 与真实瞬时点', () => {
+  const input = {
+    birthDateTime: '1990-05-15T14:30:00',
+    timezone: -5,
+    timeStandard: 'civil' as const,
+  };
+  const normalized = normalizeQimenLifetimeTime(input);
+  const lifetime = calculateQimenLifetime(input);
+
+  assert.equal(normalized.timezoneOffsetMinutes, -300);
+  assert.equal(normalized.normalizedDate.toISOString(), '1990-05-15T19:30:00.000Z');
+  assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
+  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+    year: 1990,
+    month: 5,
+    day: 15,
+    hour: 14,
+    minute: 30,
+  });
+  assert.equal(lifetime.stages[0].calendarStart, '1990-05-15');
+});
+
+test('奇门终身局 IANA 夏令时应让基础盘保持当地 civil', () => {
+  const input = {
+    birthDateTime: '2024-05-15T14:30:00',
+    timeZoneId: 'America/New_York',
+    timeStandard: 'civil' as const,
+  };
+  const normalized = normalizeQimenLifetimeTime(input);
+  const lifetime = calculateQimenLifetime(input);
+
+  assert.equal(normalized.timezoneOffsetMinutes, -240);
+  assert.equal(normalized.normalizedDate.toISOString(), '2024-05-15T18:30:00.000Z');
+  assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
+  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+    year: 2024,
+    month: 5,
+    day: 15,
+    hour: 14,
+    minute: 30,
+  });
+  assert.match(lifetime.basis.timeZoneUsed, /America\/New_York \(UTC-4\)/);
+});
+
+test('奇门终身局真太阳时应沿用非东八区修正后的 civil', () => {
+  const input = {
+    birthDateTime: '2024-05-15T14:30:00',
+    timezone: -5,
+    timeStandard: 'trueSolar' as const,
+    location: { longitude: -74 },
+  };
+  const normalized = normalizeQimenLifetimeTime(input);
+  const lifetime = calculateQimenLifetime(input);
+  const solar = lifetime.baseChart.timeInfo.solar;
+
+  assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
+  assert.deepEqual(solar, {
+    year: normalized.calculationParts.year,
+    month: normalized.calculationParts.month,
+    day: normalized.calculationParts.day,
+    hour: normalized.calculationParts.hour,
+    minute: normalized.calculationParts.minute,
+  });
+});
+
+test('奇门终身局 UTC+14 当地午夜应保留出生日期并用于阶段日历', () => {
+  const input = {
+    birthDateTime: '2024-01-02T00:30:00',
+    timezone: 14,
+    timeStandard: 'civil' as const,
+  };
+  const normalized = normalizeQimenLifetimeTime(input);
+  const lifetime = calculateQimenLifetime(input);
+
+  assert.equal(normalized.normalizedDate.toISOString(), '2024-01-01T10:30:00.000Z');
+  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+    year: 2024,
+    month: 1,
+    day: 2,
+    hour: 0,
+    minute: 30,
+  });
+  assert.equal(lifetime.stages[0].calendarStart, '2024-01-02');
+});
+
+test('奇门终身局非东八区应按真实瞬时点切换立春而保留当地日时', () => {
+  const nyBefore = calculateQimenLifetime({
+    birthDateTime: '2024-02-04T03:27:00',
+    timezone: -5,
+    timeStandard: 'civil',
+  });
+  const nyAfter = calculateQimenLifetime({
+    birthDateTime: '2024-02-04T03:27:15',
+    timezone: -5,
+    timeStandard: 'civil',
+  });
+  assert.equal(nyBefore.baseChart.timeInfo.solarTerm, '大寒');
+  assert.equal(nyAfter.baseChart.timeInfo.solarTerm, '立春');
+  assert.deepEqual(nyBefore.baseChart.timeInfo.solar, {
+    year: 2024,
+    month: 2,
+    day: 4,
+    hour: 3,
+    minute: 27,
+  });
+  assert.deepEqual(nyAfter.baseChart.timeInfo.solar, nyBefore.baseChart.timeInfo.solar);
+  assert.deepEqual(
+    [nyBefore.baseChart.ganzhi.year, nyBefore.baseChart.ganzhi.month],
+    ['癸卯', '乙丑'],
+  );
+  assert.deepEqual(
+    [nyAfter.baseChart.ganzhi.year, nyAfter.baseChart.ganzhi.month],
+    ['甲辰', '丙寅'],
+  );
+  assert.equal(nyBefore.baseChart.seasonality?.currentJieQi, '大寒');
+  assert.equal(nyAfter.baseChart.seasonality?.currentJieQi, '立春');
+
+  const apiaBefore = calculateQimenLifetime({
+    birthDateTime: '2024-02-04T22:27:00',
+    timezone: 14,
+    timeStandard: 'civil',
+  });
+  const apiaAfter = calculateQimenLifetime({
+    birthDateTime: '2024-02-04T22:27:15',
+    timezone: 14,
+    timeStandard: 'civil',
+  });
+  assert.equal(apiaBefore.baseChart.timeInfo.solarTerm, '大寒');
+  assert.equal(apiaAfter.baseChart.timeInfo.solarTerm, '立春');
+  assert.deepEqual(apiaBefore.baseChart.timeInfo.solar, {
+    year: 2024,
+    month: 2,
+    day: 4,
+    hour: 22,
+    minute: 27,
+  });
+  assert.deepEqual(apiaAfter.baseChart.timeInfo.solar, apiaBefore.baseChart.timeInfo.solar);
+  assert.deepEqual(
+    [apiaBefore.baseChart.ganzhi.year, apiaBefore.baseChart.ganzhi.month],
+    ['癸卯', '乙丑'],
+  );
+  assert.deepEqual(
+    [apiaAfter.baseChart.ganzhi.year, apiaAfter.baseChart.ganzhi.month],
+    ['甲辰', '丙寅'],
+  );
+});
+
 test('奇门终身局 P1：个人标记与六亲主题宫提取', () => {
   const lifetime = calculateQimenLifetime({
     birthDateTime: '2024-06-15T14:30:00+08:00', // 芒种阳六局庚戌日癸未时

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -7,8 +7,57 @@ import {
   extractPersonalMarkers,
   buildTopicCandidates,
   buildLifetimeStages,
+  generateQimen,
   scanLifetimeDynamicEvents,
 } from '../packages/core/src/divination/algorithms/qimen';
+import { diPanPalaces } from '../packages/core/src/divination/algorithms/qimen/helpers/_constants';
+
+function annualPatternFacts(
+  chart: ReturnType<typeof generateQimen>,
+  taiSuiPalace: number,
+): string[] {
+  return (chart.classicPatterns ?? [])
+    .filter(
+      (pattern) =>
+        pattern.palaces.includes(taiSuiPalace) &&
+        (pattern.type === 'good' || pattern.type === 'bad'),
+    )
+    .map((pattern) => `${pattern.type}:${pattern.name}`)
+    .sort();
+}
+
+function clusterPatternFacts(cluster: {
+  supportEvidence: string[];
+  counterEvidence: string[];
+}): string[] {
+  return [
+    ...cluster.supportEvidence.flatMap((fact) => {
+      const match = fact.match(/岁盘吉格「([^」]+)」/);
+      return match ? [`good:${match[1]}`] : [];
+    }),
+    ...cluster.counterEvidence.flatMap((fact) => {
+      const match = fact.match(/岁盘凶格「([^」]+)」/);
+      return match ? [`bad:${match[1]}`] : [];
+    }),
+  ].sort();
+}
+
+function findTimezoneSensitiveAnnualYear(targetOffsetMinutes: number): number {
+  for (let year = 2024; year <= 2050; year += 1) {
+    const date = new Date(Date.UTC(year, 5, 15, 12, 0, 0));
+    const defaultChart = generateQimen(date, 'zhuanpan', 'year', 'chaibu', 480);
+    const targetChart = generateQimen(date, 'zhuanpan', 'year', 'chaibu', targetOffsetMinutes);
+    const taiSuiPalace = diPanPalaces[targetChart.ganzhi.year[1]];
+    if (
+      taiSuiPalace &&
+      JSON.stringify(annualPatternFacts(defaultChart, taiSuiPalace)) !==
+        JSON.stringify(annualPatternFacts(targetChart, taiSuiPalace))
+    ) {
+      return year;
+    }
+  }
+  throw new Error(`未找到 UTC${targetOffsetMinutes / 60} 对年盘经典格局产生差异的年度样本`);
+}
 
 test('奇门终身局 P0：时间标准化与真太阳时校正', () => {
   // 1. 公历常规出生时间（北京时间）
@@ -308,6 +357,98 @@ test('奇门终身局 P3：动态周期扫描与事件聚类（含年月日关�
     assert.ok(ec.triggerFact.length > 0);
     assert.ok(ec.verificationQuestions.length > 0);
   }
+});
+
+test('奇门终身局动态年盘失败应保留年份与原始原因', () => {
+  const base = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00',
+    timezone: 8,
+    timeStandard: 'civil',
+  });
+  const periodRange = {
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+  };
+
+  const invalidTimezoneError = assert.throws(() => {
+    scanLifetimeDynamicEvents(base.baseChart, base.stages, periodRange, 'zhuanpan', 'chaibu', {
+      timeZoneId: 'Invalid/Unknown',
+    });
+  }) as Error & { cause?: Error };
+  assert.match(invalidTimezoneError.message, /2024年动态年盘生成失败/u);
+  const invalidTimezoneCause = invalidTimezoneError.cause;
+  assert.ok(invalidTimezoneCause instanceof Error);
+  assert.match(invalidTimezoneCause.message, /无法识别 IANA 时区/u);
+
+  const generationError = assert.throws(() => {
+    scanLifetimeDynamicEvents(base.baseChart, base.stages, periodRange, 'zhuanpan', 'chaibu', {
+      fallbackOffsetMinutes: Number.NaN,
+    });
+  }) as Error & { cause?: Error };
+  assert.match(generationError.message, /2024年动态年盘生成失败/u);
+  const generationCause = generationError.cause;
+  assert.ok(generationCause instanceof Error);
+  assert.match(generationCause.message, /时区偏移分钟数/u);
+});
+
+test('奇门终身局动态年盘应采用固定 UTC 偏移而非默认东八区', () => {
+  const targetOffsetMinutes = 14 * 60;
+  const year = findTimezoneSensitiveAnnualYear(targetOffsetMinutes);
+  const result = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00',
+    timezone: 14,
+    timeStandard: 'civil',
+    periodRange: {
+      startDate: `${year}-01-01`,
+      endDate: `${year}-12-31`,
+    },
+  });
+  const annualCluster = result.eventClusters?.find(
+    (cluster) =>
+      cluster.key.startsWith(`cluster:${year}:`) &&
+      !cluster.key.includes(':month-clash:') &&
+      !cluster.key.includes(':day-nodal'),
+  );
+  assert.ok(annualCluster, `应存在${year}年年度事件簇`);
+
+  const date = new Date(Date.UTC(year, 5, 15, 12, 0, 0));
+  const expectedChart = generateQimen(date, 'zhuanpan', 'year', 'chaibu', targetOffsetMinutes);
+  const taiSuiPalace = diPanPalaces[expectedChart.ganzhi.year[1]];
+  assert.ok(taiSuiPalace);
+  assert.deepEqual(
+    clusterPatternFacts(annualCluster),
+    annualPatternFacts(expectedChart, taiSuiPalace),
+  );
+});
+
+test('奇门终身局动态年盘应按目标年度读取 IANA 夏令时偏移', () => {
+  const targetOffsetMinutes = -4 * 60;
+  const year = findTimezoneSensitiveAnnualYear(targetOffsetMinutes);
+  const result = calculateQimenLifetime({
+    birthDateTime: '2023-01-15T14:30:00',
+    timeZoneId: 'America/New_York',
+    timeStandard: 'civil',
+    periodRange: {
+      startDate: `${year}-01-01`,
+      endDate: `${year}-12-31`,
+    },
+  });
+  const annualCluster = result.eventClusters?.find(
+    (cluster) =>
+      cluster.key.startsWith(`cluster:${year}:`) &&
+      !cluster.key.includes(':month-clash:') &&
+      !cluster.key.includes(':day-nodal'),
+  );
+  assert.ok(annualCluster, `应存在${year}年年度事件簇`);
+
+  const date = new Date(Date.UTC(year, 5, 15, 12, 0, 0));
+  const expectedChart = generateQimen(date, 'zhuanpan', 'year', 'chaibu', targetOffsetMinutes);
+  const taiSuiPalace = diPanPalaces[expectedChart.ganzhi.year[1]];
+  assert.ok(taiSuiPalace);
+  assert.deepEqual(
+    clusterPatternFacts(annualCluster),
+    annualPatternFacts(expectedChart, taiSuiPalace),
+  );
 });
 
 test('奇门终身局 P4：自包含提示词规范、多流派依据与合规红线核验', () => {

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -10,6 +10,14 @@ import {
   generateQimen,
   scanLifetimeDynamicEvents,
 } from '../packages/core/src/divination/algorithms/qimen';
+import { getDivinationTime } from '../packages/core/src/calendar/timeManager';
+
+function verifiedChartSolar(chart: ReturnType<typeof generateQimen>, offset: number) {
+  const expected = getDivinationTime(new Date(chart.timestamp), offset);
+  assert.deepEqual(chart.ganzhi, expected.ganzhi);
+  return expected.timeInfo.solar;
+}
+
 import { diPanPalaces } from '../packages/core/src/divination/algorithms/qimen/helpers/_constants';
 
 function annualPatternFacts(
@@ -114,7 +122,7 @@ test('奇门终身局应沿用固定非东八区的 civil 与真实瞬时点', (
   assert.equal(normalized.timezoneOffsetMinutes, -300);
   assert.equal(normalized.normalizedDate.toISOString(), '1990-05-15T19:30:00.000Z');
   assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
-  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+  assert.deepEqual(verifiedChartSolar(lifetime.baseChart, normalized.timezoneOffsetMinutes), {
     year: 1990,
     month: 5,
     day: 15,
@@ -136,7 +144,7 @@ test('奇门终身局 IANA 夏令时应让基础盘保持当地 civil', () => {
   assert.equal(normalized.timezoneOffsetMinutes, -240);
   assert.equal(normalized.normalizedDate.toISOString(), '2024-05-15T18:30:00.000Z');
   assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
-  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+  assert.deepEqual(verifiedChartSolar(lifetime.baseChart, normalized.timezoneOffsetMinutes), {
     year: 2024,
     month: 5,
     day: 15,
@@ -155,7 +163,7 @@ test('奇门终身局真太阳时应沿用非东八区修正后的 civil', () =>
   };
   const normalized = normalizeQimenLifetimeTime(input);
   const lifetime = calculateQimenLifetime(input);
-  const solar = lifetime.baseChart.timeInfo.solar;
+  const solar = verifiedChartSolar(lifetime.baseChart, normalized.timezoneOffsetMinutes);
 
   assert.equal(lifetime.baseChart.timestamp, normalized.normalizedDate.getTime());
   assert.deepEqual(solar, {
@@ -177,7 +185,7 @@ test('奇门终身局 UTC+14 当地午夜应保留出生日期并用于阶段日
   const lifetime = calculateQimenLifetime(input);
 
   assert.equal(normalized.normalizedDate.toISOString(), '2024-01-01T10:30:00.000Z');
-  assert.deepEqual(lifetime.baseChart.timeInfo.solar, {
+  assert.deepEqual(verifiedChartSolar(lifetime.baseChart, normalized.timezoneOffsetMinutes), {
     year: 2024,
     month: 1,
     day: 2,
@@ -200,14 +208,17 @@ test('奇门终身局非东八区应按真实瞬时点切换立春而保留当�
   });
   assert.equal(nyBefore.baseChart.timeInfo.solarTerm, '大寒');
   assert.equal(nyAfter.baseChart.timeInfo.solarTerm, '立春');
-  assert.deepEqual(nyBefore.baseChart.timeInfo.solar, {
+  assert.deepEqual(verifiedChartSolar(nyBefore.baseChart, -300), {
     year: 2024,
     month: 2,
     day: 4,
     hour: 3,
     minute: 27,
   });
-  assert.deepEqual(nyAfter.baseChart.timeInfo.solar, nyBefore.baseChart.timeInfo.solar);
+  assert.deepEqual(
+    verifiedChartSolar(nyAfter.baseChart, -300),
+    verifiedChartSolar(nyBefore.baseChart, -300),
+  );
   assert.deepEqual(
     [nyBefore.baseChart.ganzhi.year, nyBefore.baseChart.ganzhi.month],
     ['癸卯', '乙丑'],
@@ -231,14 +242,17 @@ test('奇门终身局非东八区应按真实瞬时点切换立春而保留当�
   });
   assert.equal(apiaBefore.baseChart.timeInfo.solarTerm, '大寒');
   assert.equal(apiaAfter.baseChart.timeInfo.solarTerm, '立春');
-  assert.deepEqual(apiaBefore.baseChart.timeInfo.solar, {
+  assert.deepEqual(verifiedChartSolar(apiaBefore.baseChart, 840), {
     year: 2024,
     month: 2,
     day: 4,
     hour: 22,
     minute: 27,
   });
-  assert.deepEqual(apiaAfter.baseChart.timeInfo.solar, apiaBefore.baseChart.timeInfo.solar);
+  assert.deepEqual(
+    verifiedChartSolar(apiaAfter.baseChart, 840),
+    verifiedChartSolar(apiaBefore.baseChart, 840),
+  );
   assert.deepEqual(
     [apiaBefore.baseChart.ganzhi.year, apiaBefore.baseChart.ganzhi.month],
     ['癸卯', '乙丑'],
@@ -370,25 +384,29 @@ test('奇门终身局动态年盘失败应保留年份与原始原因', () => {
     endDate: '2024-12-31',
   };
 
-  const invalidTimezoneError = assert.throws(() => {
-    scanLifetimeDynamicEvents(base.baseChart, base.stages, periodRange, 'zhuanpan', 'chaibu', {
-      timeZoneId: 'Invalid/Unknown',
-    });
-  }) as Error & { cause?: Error };
-  assert.match(invalidTimezoneError.message, /2024年动态年盘生成失败/u);
-  const invalidTimezoneCause = invalidTimezoneError.cause;
-  assert.ok(invalidTimezoneCause instanceof Error);
-  assert.match(invalidTimezoneCause.message, /无法识别 IANA 时区/u);
-
-  const generationError = assert.throws(() => {
-    scanLifetimeDynamicEvents(base.baseChart, base.stages, periodRange, 'zhuanpan', 'chaibu', {
-      fallbackOffsetMinutes: Number.NaN,
-    });
-  }) as Error & { cause?: Error };
-  assert.match(generationError.message, /2024年动态年盘生成失败/u);
-  const generationCause = generationError.cause;
-  assert.ok(generationCause instanceof Error);
-  assert.match(generationCause.message, /时区偏移分钟数/u);
+  for (const [context, causePattern] of [
+    [{ timeZoneId: 'Invalid/Unknown' }, /无法识别 IANA 时区/u],
+    [{ fallbackOffsetMinutes: Number.NaN }, /时区偏移分钟数/u],
+  ] as const) {
+    assert.throws(
+      () =>
+        scanLifetimeDynamicEvents(
+          base.baseChart,
+          base.stages,
+          periodRange,
+          'zhuanpan',
+          'chaibu',
+          context,
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /2024年动态年盘生成失败/u);
+        assert.ok(error.cause instanceof Error);
+        assert.match(error.cause.message, causePattern);
+        return true;
+      },
+    );
+  }
 });
 
 test('奇门终身局动态年盘应采用固定 UTC 偏移而非默认东八区', () => {

--- a/tests/qimen-true-solar-term.test.ts
+++ b/tests/qimen-true-solar-term.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  calculateQimenLifetime,
+  normalizeQimenLifetimeTime,
+} from '../packages/core/src/divination/algorithms/qimen';
+import { getDivinationTime } from '../packages/core/src/calendar/timeManager';
+
+test('太阳时钟表落入民用跳时缺口时保持原出生瞬时点', () => {
+  const input = {
+    birthDateTime: '2024-03-10T04:00:00',
+    timeZoneId: 'America/New_York',
+    timeStandard: 'trueSolar' as const,
+    location: { longitude: -74 },
+  };
+  const normalized = normalizeQimenLifetimeTime(input);
+  assert.equal(normalized.referenceDate.toISOString(), '2024-03-10T08:00:00.000Z');
+  assert.equal(normalized.calculationParts.hour, 2);
+  assert.equal(normalized.timezoneOffsetMinutes, -240);
+  const result = calculateQimenLifetime(input);
+  assert.equal(result.baseChart.ganzhi.hour.at(-1), '丑');
+});
+
+test('历史夏令时两种明确入口保留相同真实出生瞬时点', () => {
+  const birth = {
+    birthDateTime: '1990-05-15T12:00:00',
+    timeStandard: 'trueSolar' as const,
+    location: { longitude: 116.4 },
+  };
+  const fixed = normalizeQimenLifetimeTime({ ...birth, timezone: 8, applyChinaDst: true });
+  const iana = normalizeQimenLifetimeTime({ ...birth, timeZoneId: 'Asia/Shanghai' });
+  assert.equal(fixed.referenceDate.toISOString(), '1990-05-15T03:00:00.000Z');
+  assert.equal(iana.referenceDate.toISOString(), fixed.referenceDate.toISOString());
+});
+
+for (const sample of [
+  {
+    birthDateTime: '2024-02-04T16:30:00',
+    timezone: 8,
+    longitude: 116.4,
+    term: '立春',
+    year: '甲辰',
+    month: '丙寅',
+  },
+  {
+    birthDateTime: '2024-02-04T16:20:00',
+    timezone: 8,
+    longitude: 135,
+    term: '大寒',
+    year: '癸卯',
+    month: '乙丑',
+  },
+  {
+    birthDateTime: '2024-02-04T03:30:00',
+    timezone: -5,
+    longitude: -74,
+    term: '立春',
+    year: '甲辰',
+    month: '丙寅',
+  },
+]) {
+  test(`真太阳时修正跨交节仍按真实瞬时点定年月：${sample.birthDateTime} UTC${sample.timezone}`, () => {
+    const input = {
+      birthDateTime: sample.birthDateTime,
+      timezone: sample.timezone,
+      location: { longitude: sample.longitude },
+    };
+    const civil = calculateQimenLifetime({ ...input, timeStandard: 'civil' });
+    const normalizedCivil = normalizeQimenLifetimeTime({ ...input, timeStandard: 'civil' });
+    const normalizedSolar = normalizeQimenLifetimeTime({ ...input, timeStandard: 'trueSolar' });
+    const solar = calculateQimenLifetime({ ...input, timeStandard: 'trueSolar' });
+    assert.equal(normalizedSolar.referenceDate.getTime(), normalizedCivil.normalizedDate.getTime());
+    assert.notEqual(
+      normalizedSolar.normalizedDate.getTime(),
+      normalizedSolar.referenceDate.getTime(),
+    );
+    assert.equal(solar.basis.solarTerm, sample.term);
+    assert.equal(solar.baseChart.timeInfo.solarTerm, sample.term);
+    assert.equal(solar.baseChart.seasonality?.currentJieQi, sample.term);
+    assert.equal(solar.baseChart.ganzhi.year, sample.year);
+    assert.equal(solar.baseChart.ganzhi.month, sample.month);
+    assert.equal(solar.baseChart.ganzhi.year, civil.baseChart.ganzhi.year);
+    const corrected = getDivinationTime(
+      normalizedSolar.normalizedDate,
+      normalizedSolar.timezoneOffsetMinutes,
+    );
+    assert.equal(solar.baseChart.ganzhi.day, corrected.ganzhi.day);
+    assert.equal(solar.baseChart.ganzhi.hour, corrected.ganzhi.hour);
+  });
+}


### PR DESCRIPTION
奇门终身局在非东八区、历史夏令时和真太阳时跨节气附近，可能把当地钟表时间或真太阳时当作实际交节瞬间，造成年月干支、局数和年度动态不一致。

本次按出生地时区解析民用时间，按真实瞬间定位节气与年月，按校正后的当地时刻计算日时；历史节气及各年动态分别解析当年的时区偏移。真太阳时校正落入夏令时跳时区间时也可正确排盘，年度生成失败会明确返回错误。

验证：1805 项单元测试、146 项公开接口测试通过；新增回归覆盖立春前后、固定时差、纽约夏令时、中国历史夏令时、低年份和不同宿主时区。65 项 MCP 测试、类型检查、ESLint、格式检查与生产构建全部通过。

兼容性：既有调用参数保持兼容；修正边界案例的计算结果。未发布 npm 或 Android，未合并正式分支。