### PR TITLE
压缩星盘行运提示词中的重复相位

### DIFF
--- a/packages/core/src/divination/astrolabe-scope.ts
+++ b/packages/core/src/divination/astrolabe-scope.ts
@@ -1758,9 +1758,14 @@ function buildTransitEvidence(
     .slice(0, 6)
     .map(formatTransitLine);
   const lead = headline.length ? headline : transitLines.slice(0, 6);
-  return [`主要行运相位：${lead.join('；')}。`, `取样相位明细：${transitLines.join('；')}。`].join(
-    '\n',
-  );
+  const leadSet = new Set(lead);
+  const remaining = transitLines.filter((line) => !leadSet.has(line));
+  return [
+    `主要行运相位：${lead.join('；')}。`,
+    remaining.length ? `其余取样相位：${remaining.join('；')}。` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function formatAdvancedScopeFacts(params: {

--- a/tests/astrolabe-scope.test.ts
+++ b/tests/astrolabe-scope.test.ts
@@ -122,6 +122,17 @@ test('星盘流年分析对象会生成行运证据和展示文本', () => {
   assert.doesNotMatch(context.promptText, /宫主星落宫/);
   assert.match(context.promptText, /行运取样：2028-07-01 12:00（UTC\+8）/);
   assert.match(context.promptText, /主要行运相位：/);
+  const sampledAspects = context.promptText
+    .split('\n')
+    .filter((line) => /^(主要行运相位|其余取样相位|取样相位明细)：/.test(line))
+    .flatMap((line) =>
+      line
+        .slice(line.indexOf('：') + 1)
+        .replace(/。$/, '')
+        .split('；'),
+    );
+  assert.ok(sampledAspects.length > 6, '固定流年样本应保留重点以外的取样相位');
+  assert.equal(new Set(sampledAspects).size, sampledAspects.length, '每条取样相位只列示一次');
   assert.match(context.promptText, /行运落宫：/);
   assert.match(context.promptText, /周期关键星象（2028-01-01 00:00至2029-01-01 00:00，共\d+项）。/);
   assert.match(context.promptText, /周期主轴：/);


### PR DESCRIPTION
星盘提示词先列主要行运相位，随后完整列表又重复这些记录，增加长度而没有补充信息。现将后续列表改为其余取样相位，每条记录保留一次，主要相位的优先顺序不变。

真实全年星盘样本回归检查相位记录完整且不重复；与经文补全共同通过1806项单元测试及类型检查。提示词回归、65项MCP测试、ESLint、格式检查与生产构建全部通过。
