### PR TITLE
完善长资料分阶段解读与后台运限资料恢复

### DIFF
--- a/packages/core/src/prompt/ziwei.ts
+++ b/packages/core/src/prompt/ziwei.ts
@@ -1,6 +1,11 @@
 import type { AnalysisPayloadV1, PalaceFact, ScopeType, StarFact } from '../types/analysis';
 import type { ZiweiRuntime } from '../ziwei/runtime';
-import { formatZiweiFortuneTimeline, type ZiweiFortuneTimeline } from '../ziwei/fortune-timeline';
+import {
+  formatZiweiFortuneTimeline,
+  formatZiweiFortuneTimelinePhase,
+  type ZiweiFortuneTimeline,
+  type ZiweiFortuneTimelinePhaseSelection,
+} from '../ziwei/fortune-timeline';
 import { analyzeZiweiCompatibility, getBodyPalaceAxisSummary } from '../ziwei/iztro/index';
 import { formatBaziForPrompt, type BaziChartResult } from '../bazi/index';
 import { formatPromptCurrentTime } from './current-time';
@@ -284,7 +289,7 @@ export function getZiweiPromptCalculationScopes(scope: ZiweiPromptScope): ScopeT
   return scope === 'full' ? SCOPE_ORDER : [scope];
 }
 
-export function formatZiweiTargetLowerScopeFacts(runtime: ZiweiRuntime) {
+export function formatZiweiTargetLowerScopeFacts(runtime: Pick<ZiweiRuntime, 'payloadByScope'>) {
   const scopes: ScopeType[] = ['monthly', 'daily', 'hourly'];
   const lines = scopes.flatMap((scope) => {
     const payload = runtime.payloadByScope[scope];
@@ -321,6 +326,12 @@ export function formatZiweiTargetLowerScopeFacts(runtime: ZiweiRuntime) {
   });
   return lines.length ? `目标日期下层资料：\n${lines.join('\n')}` : '';
 }
+
+export {
+  formatZiweiFortuneTimelinePhase,
+  type ZiweiFortuneTimeline,
+  type ZiweiFortuneTimelinePhaseSelection,
+};
 
 export function formatZiweiFullScopeText(runtime: ZiweiRuntime) {
   if (runtime.fortuneTimeline) {

--- a/packages/core/src/ziwei/fortune-timeline.ts
+++ b/packages/core/src/ziwei/fortune-timeline.ts
@@ -82,6 +82,13 @@ export type ZiweiFortuneTimeline = {
   periods: ZiweiFortunePeriod[];
 };
 
+/** 完整运限资料中的一个连续阶段；年份索引保持原时间线顺序。 */
+export type ZiweiFortuneTimelinePhaseSelection = {
+  periodIndex: number;
+  startYearIndex: number;
+  endYearIndex: number;
+};
+
 const MUTAGEN_LABELS = ['禄', '权', '科', '忌'] as const;
 const FLOW_MONTH_BRANCHES = [
   '寅',
@@ -1011,6 +1018,63 @@ export function formatZiweiFortuneTimeline(timeline: ZiweiFortuneTimeline) {
     }
   }
   return lines.join('\n');
+}
+
+/**
+ * 将已有完整时间线按大限/流年边界格式化为一个自包含阶段。
+ * 阶段只裁剪结构化 periods/years，不裁剪已经格式化的字符串。
+ */
+export function formatZiweiFortuneTimelinePhase(
+  timeline: ZiweiFortuneTimeline,
+  selections: readonly ZiweiFortuneTimelinePhaseSelection[],
+  phaseNumber: number,
+  phaseCount: number,
+) {
+  if (!selections.length) throw new Error('紫微阶段至少需要一段运限资料。');
+  if (!Number.isInteger(phaseNumber) || phaseNumber < 1 || phaseNumber > phaseCount) {
+    throw new Error('紫微阶段编号无效。');
+  }
+  const periods = selections.map((selection) => {
+    const source = timeline.periods[selection.periodIndex];
+    if (!source) throw new Error(`紫微阶段引用不存在的大限：${selection.periodIndex}。`);
+    if (
+      !Number.isInteger(selection.startYearIndex) ||
+      !Number.isInteger(selection.endYearIndex) ||
+      selection.startYearIndex < 0 ||
+      selection.endYearIndex < selection.startYearIndex ||
+      selection.endYearIndex >= source.years.length
+    ) {
+      throw new Error(`紫微阶段引用无效的流年范围：${selection.periodIndex}。`);
+    }
+    return {
+      ...source,
+      years: source.years.slice(selection.startYearIndex, selection.endYearIndex + 1),
+    };
+  });
+  const phaseTimeline: ZiweiFortuneTimeline = { ...timeline, periods };
+  const firstPeriod = periods[0]!;
+  const firstYear = firstPeriod.years[0]!;
+  const lastPeriod = periods.at(-1)!;
+  const lastYear = lastPeriod.years.at(-1)!;
+  const selectionText = selections
+    .map((selection) => {
+      const period = timeline.periods[selection.periodIndex]!;
+      const first = period.years[selection.startYearIndex]!;
+      const last = period.years[selection.endYearIndex]!;
+      return `${period.label}：${first.age}岁至${last.age}岁（${first.dateStr}至${last.endDateStr ?? last.dateStr}）`;
+    })
+    .join('；');
+  const timelineText =
+    timeline.scope === 'all'
+      ? formatCompactTimeline(phaseTimeline)
+      : formatZiweiFortuneTimeline(phaseTimeline);
+  return [
+    `紫微完整运限阶段 ${phaseNumber}/${phaseCount}`,
+    `本阶段覆盖：${selectionText}`,
+    `本阶段事实日期：${firstYear.dateStr} 至 ${lastYear.endDateStr ?? lastYear.dateStr}`,
+    `完整资料全局覆盖：${timeline.actualStartDateStr} 至 ${timeline.actualEndDateStr}`,
+    timelineText,
+  ].join('\n');
 }
 
 export function findZiweiFortunePeriod(timeline: ZiweiFortuneTimeline, nominalAge: number) {

--- a/src/components/AiChatPanel.tsx
+++ b/src/components/AiChatPanel.tsx
@@ -15,12 +15,15 @@ import {
 import type { AiChatPromptMode, AiChatSession } from '@/lib/ai/chat-history';
 import type { AiRequestConfig } from '@/lib/ai/settings';
 import type { ReadingSubjectSnapshot } from '@/lib/ai/reading-subject';
+import type { ReadingMemorySeed } from '@/lib/ai/reading-workflow';
 import { registerDismissLayer } from '@/lib/dismiss-layer';
 import { WorkspaceButton } from './workspace/WorkspaceUI';
 
 interface AiChatPanelProps {
   /** AI 上下文提示（排盘数据 + 设置摘要，不含用户问题） */
   contextPrompt: string;
+  /** 工作流首条提示；完整运限资料由 readingResourceSeed 发送，避免原文重复进入每个阶段。 */
+  workflowPrompt?: string;
   /** 用于在 contextPrompt 变化时重置对话的 key */
   resetKey?: string;
   /** 问题灵感弹窗 */
@@ -48,6 +51,14 @@ interface AiChatPanelProps {
   readingSubject?: ReadingSubjectSnapshot;
   /** 当前页面锁定的占卜术式，随历史会话保存与恢复 */
   readingMethod?: string;
+  /** 当前页面可复用的结构化盘面资源，仅接受与 readingSubject 匹配的种子。 */
+  readingResourceSeed?: ReadingMemorySeed;
+  /** 当前工作流必须等完整结构化资料就绪后才能发送。 */
+  readingResourceRequired?: boolean;
+  /** 完整结构化资料生成失败时的可重试提示。 */
+  readingResourceError?: string;
+  /** 重新生成失败的完整结构化资料。 */
+  onRetryReadingResources?: () => void;
 }
 
 const PLACEHOLDER = '输入你想询问的问题…';
@@ -116,6 +127,7 @@ function ChatMessageItem({ turn }: { turn: ChatTurn }) {
 
 function AiChatPanelImpl({
   contextPrompt,
+  workflowPrompt,
   resetKey,
   onOpenInspiration,
   externalInput,
@@ -130,6 +142,10 @@ function AiChatPanelImpl({
   inputResetKey,
   readingSubject,
   readingMethod,
+  readingResourceSeed,
+  readingResourceRequired = false,
+  readingResourceError,
+  onRetryReadingResources,
 }: AiChatPanelProps) {
   const {
     turns,
@@ -146,7 +162,7 @@ function AiChatPanelImpl({
     canRetry,
     reset,
     cancel,
-  } = useAiChat(aiConfig, readingSubject, readingMethod);
+  } = useAiChat(aiConfig, readingSubject, readingMethod, readingResourceSeed);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const shouldAutoScrollRef = useRef(true);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -156,7 +172,7 @@ function AiChatPanelImpl({
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [historySaveError, setHistorySaveError] = useState('');
   const isBusy = status === 'loading' || status === 'streaming';
-  const isContextReady = contextPrompt.trim().length > 0;
+  const isStructuredWorkflow = Boolean(workflowPrompt?.trim());
   const storageKey = useMemo(
     () => getAiChatStorageKey(historyKey || `${resetKey || ''}\n${contextPrompt}`),
     [historyKey, resetKey, contextPrompt],
@@ -165,12 +181,25 @@ function AiChatPanelImpl({
     () => historySessions.find((session) => session.id === activeSessionId),
     [historySessions, activeSessionId],
   );
+  const isLegacySession = Boolean(activeSession && !activeSession.readingResourceKey);
+  const requiresStructuredSeed =
+    !isLegacySession && (readingResourceRequired || isStructuredWorkflow);
+  const isContextReady =
+    contextPrompt.trim().length > 0 &&
+    (!requiresStructuredSeed || (isStructuredWorkflow && Boolean(readingResourceSeed)));
+  const isReadingResourceBlocked =
+    error.includes('历史会话所需的完整盘面资料') || error.includes('历史会话缺少锁定主体资料');
   const directSendIdRef = useRef('');
   const autoStartKeyRef = useRef<string | undefined>(undefined);
   const autoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const historySessionsRef = useRef<AiChatSession[]>([]);
   const activeSessionIdRef = useRef('');
   const inputResetKeyRef = useRef(inputResetKey);
+  const readingResourceSeedRef = useRef(readingResourceSeed);
+
+  useEffect(() => {
+    readingResourceSeedRef.current = readingResourceSeed;
+  }, [readingResourceSeed]);
 
   const applyHistoryState = useCallback(
     (sessions: AiChatSession[], nextActiveSessionId: string, persist = true) => {
@@ -196,6 +225,7 @@ function AiChatPanelImpl({
       initialQuestion?: string;
       promptMode: AiChatPromptMode;
     }) => {
+      if (readingResourceRequired && !readingResourceSeed) return;
       const now = new Date().toISOString();
       const session: AiChatSession = {
         id: createAiChatSessionId(),
@@ -203,6 +233,7 @@ function AiChatPanelImpl({
         initialQuestion: options.initialQuestion?.trim() ?? '',
         initialPrompt: options.prompt,
         readingSubject,
+        ...(readingResourceSeed?.key ? { readingResourceKey: readingResourceSeed.key } : {}),
         readingMethod,
         completionStatus: 'pending',
         promptMode: options.promptMode,
@@ -216,9 +247,17 @@ function AiChatPanelImpl({
       setIsHistoryOpen(false);
       reset();
       setInputValue('');
-      analyze(options.prompt);
+      analyze(options.prompt, readingResourceSeed);
     },
-    [analyze, applyHistoryState, readingMethod, readingSubject, reset],
+    [
+      analyze,
+      applyHistoryState,
+      readingMethod,
+      readingResourceRequired,
+      readingResourceSeed,
+      readingSubject,
+      reset,
+    ],
   );
 
   // 当上下文变化时，恢复上次使用的会话，并自动兼容旧版单条历史。
@@ -241,6 +280,8 @@ function AiChatPanelImpl({
         activeSession.readingSubject,
         activeSession.completionStatus,
         activeSession.readingMethod,
+        readingResourceSeedRef.current,
+        activeSession.readingResourceKey,
       );
       autoStartKeyRef.current = key;
     } else {
@@ -310,12 +351,12 @@ function AiChatPanelImpl({
     const text = directSend.text.trim();
     if (!text || !isContextReady) return;
     startNewSession({
-      prompt: contextPrompt + '\n\n' + text,
+      prompt: (workflowPrompt || contextPrompt) + '\n\n' + text,
       titleSource: text,
       initialQuestion: text,
       promptMode: 'context-question',
     });
-  }, [directSend, isContextReady, contextPrompt, startNewSession]);
+  }, [directSend, isContextReady, contextPrompt, startNewSession, workflowPrompt]);
 
   // 自动发送首轮（占卜页：session.prompt 已含完整问题，无需用户输入）
   useEffect(() => {
@@ -392,7 +433,7 @@ function AiChatPanelImpl({
 
     if (!hasStarted) {
       startNewSession({
-        prompt: contextPrompt + '\n\n' + text,
+        prompt: (workflowPrompt || contextPrompt) + '\n\n' + text,
         titleSource: text,
         initialQuestion: text,
         promptMode: 'context-question',
@@ -401,7 +442,16 @@ function AiChatPanelImpl({
       // 追问
       ask(text);
     }
-  }, [inputValue, isBusy, isContextReady, hasStarted, contextPrompt, startNewSession, ask]);
+  }, [
+    inputValue,
+    isBusy,
+    isContextReady,
+    hasStarted,
+    contextPrompt,
+    workflowPrompt,
+    startNewSession,
+    ask,
+  ]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -442,6 +492,8 @@ function AiChatPanelImpl({
       session.readingSubject,
       session.completionStatus,
       session.readingMethod,
+      readingResourceSeed,
+      session.readingResourceKey,
     );
     setInputValue('');
     setIsHistoryOpen(false);
@@ -466,6 +518,8 @@ function AiChatPanelImpl({
         nextActiveSession.readingSubject,
         nextActiveSession.completionStatus,
         nextActiveSession.readingMethod,
+        readingResourceSeed,
+        nextActiveSession.readingResourceKey,
       );
     } else {
       reset();
@@ -481,15 +535,19 @@ function AiChatPanelImpl({
         <div>
           <h2>{workspaceMode ? '解答' : 'AI 解析'}</h2>
           <p>
-            {!isContextReady
-              ? '正在生成排盘数据，请稍候…'
-              : status === 'error'
-                ? '本次回复失败，你的问题已保留，可直接重新生成。'
-                : status === 'cancelled'
-                  ? '本次回复已停止，已生成内容保留，可重新生成。'
-                  : hasStarted
-                    ? historySaveError || '可以继续追问，历史对话会自动保存。'
-                    : '在下方输入问题开始 AI 解析。'}
+            {readingResourceError
+              ? '完整盘面资料生成失败，请重试。'
+              : error && !canRetry
+                ? '完整盘面资料正在恢复，请稍候。'
+                : !isContextReady
+                  ? '正在生成排盘数据，请稍候…'
+                  : status === 'error'
+                    ? '本次回复失败，你的问题已保留，可直接重新生成。'
+                    : status === 'cancelled'
+                      ? '本次回复已停止，已生成内容保留，可重新生成。'
+                      : hasStarted
+                        ? historySaveError || '可以继续追问，历史对话会自动保存。'
+                        : '在下方输入问题开始 AI 解析。'}
           </p>
         </div>
         <div className="ai-chat-head-actions">
@@ -641,12 +699,34 @@ function AiChatPanelImpl({
                 {notice}
               </p>
             ))}
+            {readingResourceError ? (
+              <div className="ai-chat-error-notice" role="alert" aria-live="assertive">
+                <div className="ai-chat-error-content">
+                  <strong>完整资料生成失败</strong>
+                  <span>{readingResourceError}</span>
+                  <small>已保留成功生成的资料，重试只补生成失败的部分。</small>
+                </div>
+                {onRetryReadingResources ? (
+                  <button
+                    type="button"
+                    className="ai-chat-retry-btn"
+                    onClick={onRetryReadingResources}
+                  >
+                    重新生成资料
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
             {error ? (
               <div className="ai-chat-error-notice" role="alert" aria-live="assertive">
                 <div className="ai-chat-error-content">
-                  <strong>AI 回复失败</strong>
+                  <strong>{isReadingResourceBlocked ? '完整资料尚未就绪' : 'AI 回复失败'}</strong>
                   <span>{error}</span>
-                  <small>你的问题已保留，不需要重新输入。</small>
+                  <small>
+                    {isReadingResourceBlocked
+                      ? '资料准备完成后可以继续当前会话。'
+                      : '你的问题已保留，不需要重新输入。'}
+                  </small>
                 </div>
                 {canRetry ? (
                   <button type="button" className="ai-chat-retry-btn" onClick={handleRetry}>
@@ -655,7 +735,7 @@ function AiChatPanelImpl({
                 ) : null}
               </div>
             ) : null}
-            {status === 'cancelled' ? (
+            {status === 'cancelled' && !error ? (
               <div className="ai-chat-error-notice" role="status" aria-live="polite">
                 <div className="ai-chat-error-content">
                   <strong>AI 回复已停止</strong>

--- a/src/hooks/useAiChat.ts
+++ b/src/hooks/useAiChat.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { streamAiChat, type ChatMessage } from '@/lib/ai/stream-client';
 import type { AiRequestConfig } from '@/lib/ai/settings';
-import { runReadingWorkflow, type ReadingMemory } from '@/lib/ai/reading-workflow';
+import {
+  runReadingWorkflow,
+  type ReadingMemory,
+  type ReadingMemorySeed,
+} from '@/lib/ai/reading-workflow';
 import { executeReadingAction } from '@/lib/ai/reading-resources';
 import type { ReadingSubjectSnapshot } from '@/lib/ai/reading-subject';
 
@@ -27,7 +31,7 @@ export interface UseAiChat {
   /** 是否已开始解析（至少有过一次 analyze 调用） */
   hasStarted: boolean;
   /** 用提示词开始首次解析 */
-  analyze: (prompt: string) => void;
+  analyze: (prompt: string, resourceSeed?: ReadingMemorySeed) => void;
   /** 发送追问消息 */
   ask: (question: string) => void;
   /** 恢复已保存的对话 */
@@ -37,6 +41,8 @@ export interface UseAiChat {
     readingSubject?: ReadingSubjectSnapshot,
     completionStatus?: AiChatCompletionStatus,
     readingMethod?: string,
+    resourceSeed?: ReadingMemorySeed,
+    resourceKey?: string,
   ) => void;
   /** 重新发送上一次失败的请求 */
   retry: () => void;
@@ -55,10 +61,69 @@ export interface RestoredAiChatState {
   canRetry: boolean;
 }
 
+export interface ReadingResourceRequirement {
+  subjectId: string;
+  key: string;
+}
+
+export function isReadingResourceSeedCompatible(
+  seed: ReadingMemorySeed | undefined,
+  subjectId: string | undefined,
+  resourceKey: string | undefined,
+) {
+  return Boolean(
+    seed && subjectId && resourceKey && seed.subjectId === subjectId && seed.key === resourceKey,
+  );
+}
+
+export function resolveReadingResourceSeed(
+  requirement: ReadingResourceRequirement | undefined,
+  seed: ReadingMemorySeed | undefined,
+): ReadingMemory | null {
+  if (
+    !seed ||
+    !requirement ||
+    !isReadingResourceSeedCompatible(seed, requirement.subjectId, requirement.key)
+  )
+    return null;
+  return { resources: [...seed.resources] };
+}
+
+const READING_RESOURCE_RESTORE_ERROR =
+  '本次历史会话所需的完整盘面资料正在恢复，资料就绪后才能继续。';
+const READING_RESOURCE_MISMATCH_ERROR =
+  '本次历史会话所需的完整盘面资料与当前主体或运限范围不匹配，请切换回原范围后继续。';
+const READING_RESOURCE_SUBJECT_ERROR =
+  '本次历史会话缺少锁定主体资料，无法安全恢复完整盘面，请新建会话后继续。';
+
+export function getReadingResourceRestoreError(
+  seed: ReadingMemorySeed | undefined,
+  requirement?: ReadingResourceRequirement,
+) {
+  if (requirement && !requirement.subjectId) return READING_RESOURCE_SUBJECT_ERROR;
+  return seed ? READING_RESOURCE_MISMATCH_ERROR : READING_RESOURCE_RESTORE_ERROR;
+}
+
+function createReadingMemory(
+  seed: ReadingMemorySeed | undefined,
+  subjectId?: string,
+  resourceKey?: string,
+): ReadingMemory {
+  if (
+    !seed ||
+    !subjectId ||
+    seed.subjectId !== subjectId ||
+    (resourceKey !== undefined && seed.key !== resourceKey)
+  )
+    return { resources: [] };
+  return { resources: [...seed.resources] };
+}
+
 export function useAiChat(
   aiConfig?: AiRequestConfig,
   readingSubject?: ReadingSubjectSnapshot,
   readingMethod?: string,
+  readingSeed?: ReadingMemorySeed,
 ): UseAiChat {
   const [turns, setTurns] = useState<ChatTurn[]>([]);
   const [streamingContent, setStreamingContent] = useState('');
@@ -68,6 +133,11 @@ export function useAiChat(
   const [notices, setNotices] = useState<string[]>([]);
   const noticesRef = useRef<string[]>([]);
   const readingMemoryRef = useRef<ReadingMemory>({ resources: [] });
+  const readingSeedRef = useRef<ReadingMemorySeed | undefined>(readingSeed);
+  const readingResourceRequirementRef = useRef<ReadingResourceRequirement | undefined>(undefined);
+  const pendingRestoredStateRef = useRef<
+    Pick<RestoredAiChatState, 'error' | 'canRetry'> | undefined
+  >(undefined);
   const [hasStarted, setHasStarted] = useState(false);
   const [canRetry, setCanRetry] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -79,6 +149,26 @@ export function useAiChat(
   const readingSubjectLockedRef = useRef(false);
   const readingMethodRef = useRef<string | undefined>(readingMethod);
   const readingMethodLockedRef = useRef(false);
+
+  useEffect(() => {
+    readingSeedRef.current = readingSeed;
+    const requirement = readingResourceRequirementRef.current;
+    const memory = resolveReadingResourceSeed(requirement, readingSeed);
+    if (!memory) {
+      if (requirement) {
+        setError(getReadingResourceRestoreError(readingSeed, requirement));
+        setCanRetry(false);
+      }
+      return;
+    }
+
+    readingMemoryRef.current = memory;
+    readingResourceRequirementRef.current = undefined;
+    const restoredState = pendingRestoredStateRef.current;
+    pendingRestoredStateRef.current = undefined;
+    setError(restoredState?.error ?? '');
+    setCanRetry(restoredState?.canRetry ?? false);
+  }, [readingSeed]);
 
   useEffect(() => {
     if (!readingSubjectLockedRef.current) readingSubjectRef.current = readingSubject;
@@ -107,7 +197,9 @@ export function useAiChat(
     streamingRef.current = '';
     turnsRef.current = [];
     initialPromptRef.current = '';
-    readingMemoryRef.current = { resources: [] };
+    readingMemoryRef.current = createReadingMemory(readingSeedRef.current, readingSubject?.id);
+    readingResourceRequirementRef.current = undefined;
+    pendingRestoredStateRef.current = undefined;
     readingSubjectLockedRef.current = false;
     readingSubjectRef.current = readingSubject;
     readingMethodLockedRef.current = false;
@@ -130,13 +222,26 @@ export function useAiChat(
       restoredSubject?: ReadingSubjectSnapshot,
       completionStatus?: AiChatCompletionStatus,
       restoredReadingMethod?: string,
+      resourceSeed?: ReadingMemorySeed,
+      resourceKey?: string,
     ) => {
       abortRef.current?.abort();
       abortRef.current = null;
       streamingRef.current = '';
       turnsRef.current = nextTurns;
       initialPromptRef.current = initialPrompt;
-      readingMemoryRef.current = { resources: [] };
+      const resourceRequirement = resourceKey
+        ? { subjectId: restoredSubject?.id ?? '', key: resourceKey }
+        : undefined;
+      const restoredMemory = resolveReadingResourceSeed(
+        resourceRequirement,
+        resourceSeed ?? readingSeedRef.current,
+      );
+      readingMemoryRef.current = resourceKey
+        ? (restoredMemory ?? { resources: [] })
+        : createReadingMemory(undefined, restoredSubject?.id);
+      readingResourceRequirementRef.current =
+        resourceKey && !restoredMemory ? resourceRequirement : undefined;
       readingSubjectLockedRef.current = true;
       readingSubjectRef.current = restoredSubject;
       readingMethodLockedRef.current = true;
@@ -147,10 +252,20 @@ export function useAiChat(
       setTurns(nextTurns);
       setStreamingContent('');
       const restoredState = resolveRestoredAiChatState(nextTurns, initialPrompt, completionStatus);
+      pendingRestoredStateRef.current = readingResourceRequirementRef.current
+        ? { error: restoredState.error, canRetry: restoredState.canRetry }
+        : undefined;
       setStatus(restoredState.status);
-      setError(restoredState.error);
+      setError(
+        readingResourceRequirementRef.current
+          ? getReadingResourceRestoreError(
+              resourceSeed ?? readingSeedRef.current,
+              readingResourceRequirementRef.current,
+            )
+          : restoredState.error,
+      );
       setHasStarted(restoredState.hasStarted);
-      setCanRetry(restoredState.canRetry);
+      setCanRetry(readingResourceRequirementRef.current ? false : restoredState.canRetry);
     },
     [readingMethod],
   );
@@ -269,14 +384,19 @@ export function useAiChat(
   );
 
   const analyze = useCallback(
-    (prompt: string) => {
+    (prompt: string, resourceSeed?: ReadingMemorySeed) => {
       if (!prompt.trim()) return;
       readingSubjectLockedRef.current = false;
       readingSubjectRef.current = readingSubject;
       readingMethodLockedRef.current = false;
       readingMethodRef.current = readingMethod;
       initialPromptRef.current = prompt;
-      readingMemoryRef.current = { resources: [] };
+      readingResourceRequirementRef.current = undefined;
+      pendingRestoredStateRef.current = undefined;
+      readingMemoryRef.current = createReadingMemory(
+        resourceSeed ?? readingSeedRef.current,
+        readingSubject?.id,
+      );
       turnsRef.current = [];
       setTurns([]);
       setHasStarted(true);
@@ -289,6 +409,16 @@ export function useAiChat(
     (question: string) => {
       const trimmed = question.trim();
       if (!trimmed) return;
+      if (readingResourceRequirementRef.current) {
+        setError(
+          getReadingResourceRestoreError(
+            readingSeedRef.current,
+            readingResourceRequirementRef.current,
+          ),
+        );
+        setCanRetry(false);
+        return;
+      }
 
       // 从 ref 读取最新的 turns，避免在 state updater 内部产生副作用
       const nextTurns = [...turnsRef.current, { role: 'user' as const, content: trimmed }];
@@ -300,6 +430,16 @@ export function useAiChat(
   );
 
   const retry = useCallback(() => {
+    if (readingResourceRequirementRef.current) {
+      setError(
+        getReadingResourceRestoreError(
+          readingSeedRef.current,
+          readingResourceRequirementRef.current,
+        ),
+      );
+      setCanRetry(false);
+      return;
+    }
     if (!lastRequestRef.current.length) return;
     const nextTurns = removeIncompleteChatTurns(turnsRef.current);
     if (nextTurns.length !== turnsRef.current.length) {

--- a/src/lib/ai/chat-history.ts
+++ b/src/lib/ai/chat-history.ts
@@ -11,6 +11,7 @@ export interface AiChatSession {
   initialQuestion: string;
   initialPrompt?: string;
   readingSubject?: ReadingSubjectSnapshot;
+  readingResourceKey?: string;
   readingMethod?: string;
   completionStatus?: AiChatCompletionStatus;
   promptMode: AiChatPromptMode;
@@ -97,6 +98,9 @@ function normalizeSession(value: unknown): AiChatSession | null {
     initialQuestion: typeof value.initialQuestion === 'string' ? value.initialQuestion : '',
     ...(typeof value.initialPrompt === 'string' ? { initialPrompt: value.initialPrompt } : {}),
     ...(readingSubject ? { readingSubject } : {}),
+    ...(typeof value.readingResourceKey === 'string' && value.readingResourceKey.trim()
+      ? { readingResourceKey: value.readingResourceKey.trim() }
+      : {}),
     ...(readingMethod ? { readingMethod } : {}),
     ...(completionStatus ? { completionStatus } : {}),
     promptMode,

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -429,11 +429,10 @@ function formatZiweiPhaseFacts(
 function buildZiweiPhaseAddition(
   guide: string,
   currentTimeContext: string,
-  question: string,
   facts: string,
   supplementalText: string,
 ) {
-  return `${guide}${currentTimeContext}\n\n【本轮问题】${question}\n\n【紫微完整资料阶段】\n${facts}${
+  return `${guide}${currentTimeContext}\n\n【紫微完整资料阶段】\n${facts}${
     supplementalText ? `\n\n【其他已取得资料】\n${supplementalText}` : ''
   }\n\n【阶段解读】依据本阶段盘面分析，保留阶段编号、日期与运限边界，给出本阶段结论及其适用条件。`;
 }
@@ -445,7 +444,6 @@ function buildZiweiPhasePlan(
   resourceTitle: string,
   guide: string,
   currentTimeContext: string,
-  question: string,
   supplementalText: string,
 ): ZiweiPhase[] {
   const timeline = result.fortuneTimeline;
@@ -457,7 +455,7 @@ function buildZiweiPhasePlan(
     try {
       fitReadingMessages(
         messages,
-        buildZiweiPhaseAddition(guide, currentTimeContext, question, facts, supplementalText),
+        buildZiweiPhaseAddition(guide, currentTimeContext, facts, supplementalText),
       );
       return true;
     } catch (error) {
@@ -515,17 +513,29 @@ function buildZiweiPhasePlan(
     }
   }
 
-  const phases = drafts.map((draft, index) => ({
+  const packedDrafts: ZiweiPhaseDraft[] = [];
+  for (const draft of drafts) {
+    const previous = packedDrafts.at(-1);
+    const combined = previous
+      ? {
+          selection: [...previous.selection, ...draft.selection],
+          includeTargetLower: previous.includeTargetLower || draft.includeTargetLower,
+        }
+      : undefined;
+    if (combined && fits(combined)) packedDrafts[packedDrafts.length - 1] = combined;
+    else packedDrafts.push(draft);
+  }
+  const phases = packedDrafts.map((draft, index) => ({
     ...draft,
     resourceKey,
     subjectTitle: resourceTitle,
-    summaryLabel: `主体：${resourceTitle}｜阶段${index + 1}/${drafts.length}`,
-    facts: formatZiweiPhaseFacts(result, draft, index + 1, drafts.length, resourceTitle),
+    summaryLabel: `主体：${resourceTitle}｜阶段${index + 1}/${packedDrafts.length}`,
+    facts: formatZiweiPhaseFacts(result, draft, index + 1, packedDrafts.length, resourceTitle),
   }));
   for (const phase of phases) {
     fitReadingMessages(
       messages,
-      buildZiweiPhaseAddition(guide, currentTimeContext, question, phase.facts, supplementalText),
+      buildZiweiPhaseAddition(guide, currentTimeContext, phase.facts, supplementalText),
     );
   }
   return phases;
@@ -534,7 +544,6 @@ function buildZiweiPhasePlan(
 function buildPhaseSummaryAddition(
   guide: string,
   currentTimeContext: string,
-  question: string,
   entries: readonly PhaseAnswer[],
   phaseCount: number,
   intermediate: boolean,
@@ -543,11 +552,11 @@ function buildPhaseSummaryAddition(
   const facts = entries
     .map((entry) => `【${entry.labels.join('；')}分析】\n${entry.answer}`)
     .join('\n\n');
-  return `${guide}${currentTimeContext}\n\n【本轮问题】${question}\n\n【阶段覆盖核对】已纳入阶段：${covered
+  return `${guide}${currentTimeContext}\n\n【阶段覆盖核对】已纳入阶段：${covered
     .map((index) => `${index + 1}/${phaseCount}`)
     .join('、')}；阶段资料必须全部参与当前${intermediate ? '归并' : '汇总'}。\n\n${
     intermediate
-      ? '【阶段归并】请保留每个阶段编号、日期和事实边界，归并阶段分析，不补写未列事实。'
+      ? '【阶段归并】请保留每个阶段编号、日期和事实边界，依据各阶段已列事实归并分析。'
       : '【最终解读】请综合已完成的全部阶段分析回答本轮问题；结论必须能追溯到阶段编号和日期范围。'
   }\n\n${facts}`;
 }
@@ -584,7 +593,6 @@ function packPhaseAnswers(
   entries: readonly PhaseAnswer[],
   guide: string,
   currentTimeContext: string,
-  question: string,
   phaseCount: number,
 ) {
   const groups: PhaseAnswer[][] = [];
@@ -594,14 +602,7 @@ function packPhaseAnswers(
     try {
       fitReadingMessages(
         messages,
-        buildPhaseSummaryAddition(
-          guide,
-          currentTimeContext,
-          question,
-          candidate,
-          phaseCount,
-          false,
-        ),
+        buildPhaseSummaryAddition(guide, currentTimeContext, candidate, phaseCount, false),
       );
       current = candidate;
     } catch (error) {
@@ -625,7 +626,6 @@ async function collectZiweiPhaseSummary(
   deps: ReadingDependencies,
   guide: string,
   currentTimeContext: string,
-  question: string,
   supplementalText: string,
 ) {
   const entries: PhaseAnswer[] = Array.from({ length: phases.length }, (_, index) => ({
@@ -649,7 +649,7 @@ async function collectZiweiPhaseSummary(
     }
     const prepared = fitReadingMessages(
       messages,
-      buildZiweiPhaseAddition(guide, currentTimeContext, question, phase.facts, supplementalText),
+      buildZiweiPhaseAddition(guide, currentTimeContext, phase.facts, supplementalText),
     );
     options.onProgress({
       stage: 'writing',
@@ -702,7 +702,6 @@ async function collectZiweiPhaseSummary(
       currentEntries,
       guide,
       currentTimeContext,
-      question,
       phases.length,
     );
     if (groups.length === 1) {
@@ -710,7 +709,6 @@ async function collectZiweiPhaseSummary(
       const addition = buildPhaseSummaryAddition(
         guide,
         currentTimeContext,
-        question,
         groups[0]!,
         phases.length,
         false,
@@ -724,7 +722,7 @@ async function collectZiweiPhaseSummary(
       assertPhaseIndices(group, phases.length);
       const prepared = fitReadingMessages(
         messages,
-        buildPhaseSummaryAddition(guide, currentTimeContext, question, group, phases.length, true),
+        buildPhaseSummaryAddition(guide, currentTimeContext, group, phases.length, true),
       );
       const answer = await collectResponse(prepared, options, deps.stream);
       requirePhaseAnswer(
@@ -765,7 +763,6 @@ async function runZiweiPhasedReading(
       resource.title,
       guide,
       currentTimeContext,
-      question,
       supplementalText,
     ),
   );
@@ -827,7 +824,6 @@ async function runZiweiPhasedReading(
     deps,
     guide,
     currentTimeContext,
-    question,
     supplementalText,
   );
   if (finalMessages.length < messages.length)

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -4,6 +4,14 @@ import type { ChatMessage, StreamOptions } from './stream-client';
 import { verifyReadingAnswer } from './reading-verification';
 import type { ReadingSubjectSnapshot } from './reading-subject';
 import { FRONTEND_DEFAULT_TIME_ZONE_ID } from '@/lib/time-policy';
+import {
+  formatZiweiFortuneTimelinePhase,
+  formatZiweiPayloadForPrompt,
+  formatZiweiTargetLowerScopeFacts,
+  type SerializableZiweiResult,
+  type ZiweiFortuneTimeline,
+  type ZiweiFortuneTimelinePhaseSelection,
+} from '@core/prompt';
 
 export type ReadingTarget = 'primary' | 'partner';
 
@@ -25,7 +33,27 @@ export type ReadingResource = {
   sourceIds?: string[];
   structured?: Record<string, unknown>;
 };
-export type ReadingMemory = { resources: ReadingResource[]; schemas?: ReadingResource[] };
+type ZiweiPhaseStatus = 'pending' | 'succeeded' | 'failed' | 'cancelled';
+type ZiweiPhaseMemory = {
+  resourceKey: string;
+  resourceText: string;
+  structuredText: string;
+  subjectId: string;
+  question: string;
+  phases: Array<{
+    index: number;
+    resourceKey: string;
+    subjectTitle: string;
+    facts: string;
+    status: ZiweiPhaseStatus;
+    answer?: string;
+  }>;
+};
+export type ReadingMemory = {
+  resources: ReadingResource[];
+  schemas?: ReadingResource[];
+  ziweiPhaseReading?: ZiweiPhaseMemory;
+};
 export type { ReadingSubjectSnapshot } from './reading-subject';
 export type ReadingProgress = {
   stage: 'preparing' | 'consulting' | 'calculating' | 'checking' | 'writing';
@@ -297,6 +325,530 @@ function collectResponse(
   });
 }
 
+type ZiweiPhaseDraft = {
+  selection: ZiweiFortuneTimelinePhaseSelection[];
+  includeTargetLower: boolean;
+};
+
+type ZiweiPhase = ZiweiPhaseDraft & {
+  resourceKey: string;
+  subjectTitle: string;
+  summaryLabel: string;
+  facts: string;
+};
+
+type PhaseAnswer = {
+  indices: number[];
+  labels: string[];
+  answer: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getZiweiFullResult(resource: ReadingResource): SerializableZiweiResult | undefined {
+  const structured = resource.structured;
+  if (!structured || structured.fortuneTimeline === undefined) return undefined;
+  const timeline = structured.fortuneTimeline;
+  const payloadByScope = structured.payloadByScope;
+  if (
+    !isRecord(timeline) ||
+    timeline.scope !== 'all' ||
+    !Array.isArray(timeline.periods) ||
+    !timeline.periods.length ||
+    !isRecord(payloadByScope) ||
+    ['origin', 'decadal', 'yearly', 'monthly', 'daily', 'hourly'].some(
+      (scope) => !isRecord(payloadByScope[scope]),
+    )
+  )
+    return undefined;
+  if (
+    timeline.periods.some(
+      (period: unknown) =>
+        !isRecord(period) || !Array.isArray(period.years) || !period.years.length,
+    )
+  )
+    return undefined;
+  return structured as unknown as SerializableZiweiResult;
+}
+
+function getZiweiTargetYearIndex(timeline: ZiweiFortuneTimeline) {
+  const periodIndex = timeline.selectedPeriodIndex;
+  const period = timeline.periods[periodIndex];
+  if (!period) throw new Error('紫微完整运限资料缺少目标大限。');
+  const yearIndex = period.years.findIndex(
+    (year) =>
+      year.age === timeline.targetAge &&
+      year.dateStr <= timeline.targetDateStr &&
+      (year.endDateStr ?? year.dateStr) >= timeline.targetDateStr,
+  );
+  if (yearIndex < 0) throw new Error('紫微完整运限资料缺少目标流年。');
+  return { periodIndex, yearIndex };
+}
+
+function formatZiweiPhaseFacts(
+  result: SerializableZiweiResult,
+  draft: ZiweiPhaseDraft,
+  phaseNumber: number,
+  phaseCount: number,
+  resourceTitle: string,
+) {
+  const timeline = result.fortuneTimeline;
+  if (!timeline) throw new Error('紫微完整资料缺少运限时间线。');
+  const origin = result.payloadByScope.origin;
+  if (!origin) throw new Error('紫微完整资料缺少本命资料。');
+  const algorithmText =
+    (origin.calculation_config?.algorithm ?? result.calculationConfig.algorithm) === 'zhongzhou'
+      ? '安星口径：中州派安星法'
+      : '安星口径：传统通行安星法';
+  const originText = formatZiweiPayloadForPrompt(origin, { includeBasicInfo: true });
+  const timelineText = formatZiweiFortuneTimelinePhase(
+    timeline,
+    draft.selection,
+    phaseNumber,
+    phaseCount,
+  );
+  const lowerText = draft.includeTargetLower ? formatZiweiTargetLowerScopeFacts(result) : '';
+  return [
+    `主体：${resourceTitle}`,
+    algorithmText,
+    `本命资料：\n${originText}`,
+    timelineText,
+    lowerText,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function buildZiweiPhaseAddition(
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+  facts: string,
+  supplementalText: string,
+) {
+  return `${guide}${currentTimeContext}\n\n【本轮问题】${question}\n\n【紫微完整资料阶段】\n${facts}${
+    supplementalText ? `\n\n【其他已取得资料】\n${supplementalText}` : ''
+  }\n\n【阶段解读】依据本阶段盘面分析，保留阶段编号、日期与运限边界，给出本阶段结论及其适用条件。`;
+}
+
+function buildZiweiPhasePlan(
+  messages: ChatMessage[],
+  result: SerializableZiweiResult,
+  resourceKey: string,
+  resourceTitle: string,
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+  supplementalText: string,
+): ZiweiPhase[] {
+  const timeline = result.fortuneTimeline;
+  if (!timeline) throw new Error('紫微完整资料缺少运限时间线。');
+  const target = getZiweiTargetYearIndex(timeline);
+  const drafts: ZiweiPhaseDraft[] = [];
+  const fits = (draft: ZiweiPhaseDraft) => {
+    const facts = formatZiweiPhaseFacts(result, draft, 9999, 9999, resourceTitle);
+    try {
+      fitReadingMessages(
+        messages,
+        buildZiweiPhaseAddition(guide, currentTimeContext, question, facts, supplementalText),
+      );
+      return true;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('解读容量')) return false;
+      throw error;
+    }
+  };
+
+  for (let periodIndex = 0; periodIndex < timeline.periods.length; periodIndex += 1) {
+    const period = timeline.periods[periodIndex]!;
+    const wholePeriod: ZiweiPhaseDraft = {
+      selection: [
+        {
+          periodIndex,
+          startYearIndex: 0,
+          endYearIndex: period.years.length - 1,
+        },
+      ],
+      includeTargetLower: periodIndex === target.periodIndex,
+    };
+    if (fits(wholePeriod)) {
+      drafts.push(wholePeriod);
+      continue;
+    }
+
+    let startYearIndex = 0;
+    while (startYearIndex < period.years.length) {
+      let endYearIndex = -1;
+      for (
+        let candidateEnd = startYearIndex;
+        candidateEnd < period.years.length;
+        candidateEnd += 1
+      ) {
+        const candidate: ZiweiPhaseDraft = {
+          selection: [{ periodIndex, startYearIndex, endYearIndex: candidateEnd }],
+          includeTargetLower:
+            periodIndex === target.periodIndex &&
+            target.yearIndex >= startYearIndex &&
+            target.yearIndex <= candidateEnd,
+        };
+        if (!fits(candidate)) break;
+        endYearIndex = candidateEnd;
+      }
+      if (endYearIndex < startYearIndex) {
+        throw new Error(`紫微完整资料的第${periodIndex + 1}个大限仍超出单阶段容量。`);
+      }
+      drafts.push({
+        selection: [{ periodIndex, startYearIndex, endYearIndex }],
+        includeTargetLower:
+          periodIndex === target.periodIndex &&
+          target.yearIndex >= startYearIndex &&
+          target.yearIndex <= endYearIndex,
+      });
+      startYearIndex = endYearIndex + 1;
+    }
+  }
+
+  const phases = drafts.map((draft, index) => ({
+    ...draft,
+    resourceKey,
+    subjectTitle: resourceTitle,
+    summaryLabel: `主体：${resourceTitle}｜阶段${index + 1}/${drafts.length}`,
+    facts: formatZiweiPhaseFacts(result, draft, index + 1, drafts.length, resourceTitle),
+  }));
+  for (const phase of phases) {
+    fitReadingMessages(
+      messages,
+      buildZiweiPhaseAddition(guide, currentTimeContext, question, phase.facts, supplementalText),
+    );
+  }
+  return phases;
+}
+
+function buildPhaseSummaryAddition(
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+  entries: readonly PhaseAnswer[],
+  phaseCount: number,
+  intermediate: boolean,
+) {
+  const covered = [...new Set(entries.flatMap((entry) => entry.indices))].sort((a, b) => a - b);
+  const facts = entries
+    .map((entry) => `【${entry.labels.join('；')}分析】\n${entry.answer}`)
+    .join('\n\n');
+  return `${guide}${currentTimeContext}\n\n【本轮问题】${question}\n\n【阶段覆盖核对】已纳入阶段：${covered
+    .map((index) => `${index + 1}/${phaseCount}`)
+    .join('、')}；阶段资料必须全部参与当前${intermediate ? '归并' : '汇总'}。\n\n${
+    intermediate
+      ? '【阶段归并】请保留每个阶段编号、日期和事实边界，归并阶段分析，不补写未列事实。'
+      : '【最终解读】请综合已完成的全部阶段分析回答本轮问题；结论必须能追溯到阶段编号和日期范围。'
+  }\n\n${facts}`;
+}
+
+function assertPhaseCoverage(entries: readonly PhaseAnswer[], phaseCount: number) {
+  for (const entry of entries) {
+    if (!entry.answer.trim()) {
+      throw new Error(
+        `紫微阶段${entry.indices.map((index) => `${index + 1}/${phaseCount}`).join('、')}返回空结果，请重试。`,
+      );
+    }
+  }
+  const covered = new Set(entries.flatMap((entry) => entry.indices));
+  for (let index = 0; index < phaseCount; index += 1) {
+    if (!covered.has(index)) throw new Error(`紫微阶段${index + 1}/${phaseCount}未参与汇总。`);
+  }
+}
+
+function requirePhaseAnswer(answer: string, label: string) {
+  if (!answer.trim()) throw new Error(`${label}返回空结果，请重试。`);
+  return answer;
+}
+
+function assertPhaseIndices(entries: readonly PhaseAnswer[], phaseCount: number) {
+  for (const index of entries.flatMap((entry) => entry.indices)) {
+    if (!Number.isInteger(index) || index < 0 || index >= phaseCount) {
+      throw new Error(`紫微阶段编号${index + 1}超出当前阶段范围。`);
+    }
+  }
+}
+
+function packPhaseAnswers(
+  messages: ChatMessage[],
+  entries: readonly PhaseAnswer[],
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+  phaseCount: number,
+) {
+  const groups: PhaseAnswer[][] = [];
+  let current: PhaseAnswer[] = [];
+  for (const entry of entries) {
+    const candidate = [...current, entry];
+    try {
+      fitReadingMessages(
+        messages,
+        buildPhaseSummaryAddition(
+          guide,
+          currentTimeContext,
+          question,
+          candidate,
+          phaseCount,
+          false,
+        ),
+      );
+      current = candidate;
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('解读容量')) throw error;
+      if (!current.length)
+        throw new Error(`紫微阶段${entry.indices[0]! + 1}/${phaseCount}的分析结果超出汇总容量。`);
+      groups.push(current);
+      current = [entry];
+    }
+  }
+  if (current.length) groups.push(current);
+  return groups;
+}
+
+async function collectZiweiPhaseSummary(
+  messages: ChatMessage[],
+  phases: readonly ZiweiPhase[],
+  options: ReadingOptions,
+  deps: ReadingDependencies,
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+  supplementalText: string,
+) {
+  let entries: PhaseAnswer[] = Array.from({ length: phases.length }, (_, index) => ({
+    indices: [index],
+    labels: [phases[index]!.summaryLabel],
+    answer: '',
+  }));
+  const cached = options.memory.ziweiPhaseReading;
+  for (let index = 0; index < phases.length; index += 1) {
+    const phase = phases[index]!;
+    const record = cached?.phases[index];
+    if (
+      record?.status === 'succeeded' &&
+      record.resourceKey === phase.resourceKey &&
+      record.subjectTitle === phase.subjectTitle &&
+      record.facts === phase.facts &&
+      record.answer?.trim()
+    ) {
+      entries[index]!.answer = record.answer;
+      continue;
+    }
+    const prepared = fitReadingMessages(
+      messages,
+      buildZiweiPhaseAddition(guide, currentTimeContext, question, phase.facts, supplementalText),
+    );
+    options.onProgress({
+      stage: 'writing',
+      text: `正在分析${phase.subjectTitle} ${phase.summaryLabel.split('｜').at(-1)}`,
+    });
+    if (cached) {
+      cached.phases[index] = {
+        index,
+        resourceKey: phase.resourceKey,
+        subjectTitle: phase.subjectTitle,
+        facts: phase.facts,
+        status: 'pending',
+      };
+    }
+    try {
+      const answer = requirePhaseAnswer(
+        await collectResponse(prepared, options, deps.stream),
+        `紫微阶段${index + 1}/${phases.length}`,
+      );
+      entries[index]!.answer = answer;
+      if (cached)
+        cached.phases[index] = {
+          index,
+          resourceKey: phase.resourceKey,
+          subjectTitle: phase.subjectTitle,
+          facts: phase.facts,
+          status: 'succeeded',
+          answer,
+        };
+    } catch (error) {
+      if (cached) {
+        cached.phases[index] = {
+          index,
+          resourceKey: phase.resourceKey,
+          subjectTitle: phase.subjectTitle,
+          facts: phase.facts,
+          status: options.signal?.aborted ? 'cancelled' : 'failed',
+        };
+      }
+      throw error;
+    }
+  }
+  assertPhaseCoverage(entries, phases.length);
+
+  let currentEntries = entries;
+  let reductionRound = 0;
+  while (true) {
+    const groups = packPhaseAnswers(
+      messages,
+      currentEntries,
+      guide,
+      currentTimeContext,
+      question,
+      phases.length,
+    );
+    if (groups.length === 1) {
+      assertPhaseCoverage(groups[0]!, phases.length);
+      const addition = buildPhaseSummaryAddition(
+        guide,
+        currentTimeContext,
+        question,
+        groups[0]!,
+        phases.length,
+        false,
+      );
+      return fitReadingMessages(messages, addition);
+    }
+    reductionRound += 1;
+    if (reductionRound > 8) throw new Error('紫微阶段汇总超过可控归并层数，请重试。');
+    const nextEntries: PhaseAnswer[] = [];
+    for (const group of groups) {
+      assertPhaseIndices(group, phases.length);
+      const prepared = fitReadingMessages(
+        messages,
+        buildPhaseSummaryAddition(guide, currentTimeContext, question, group, phases.length, true),
+      );
+      const answer = await collectResponse(prepared, options, deps.stream);
+      requirePhaseAnswer(
+        answer,
+        `紫微阶段归并（${group.map((entry) => entry.indices.map((index) => index + 1).join('、')).join('、')}）`,
+      );
+      nextEntries.push({
+        indices: [...new Set(group.flatMap((entry) => entry.indices))].sort((a, b) => a - b),
+        labels: [...new Set(group.flatMap((entry) => entry.labels))],
+        answer,
+      });
+    }
+    assertPhaseCoverage(nextEntries, phases.length);
+    currentEntries = nextEntries;
+  }
+}
+
+async function runZiweiPhasedReading(
+  messages: ChatMessage[],
+  options: ReadingOptions,
+  deps: ReadingDependencies,
+  fullResources: readonly {
+    resource: ReadingResource;
+    result: SerializableZiweiResult;
+  }[],
+  supplementalResources: ReadingResource[],
+  guide: string,
+  currentTimeContext: string,
+  question: string,
+) {
+  if (!fullResources.length) throw new Error('紫微完整资料缺少主体。');
+  const supplementalText = formatReadingResources(supplementalResources);
+  const phases = fullResources.flatMap(({ resource, result }) =>
+    buildZiweiPhasePlan(
+      messages,
+      result,
+      resource.key,
+      resource.title,
+      guide,
+      currentTimeContext,
+      question,
+      supplementalText,
+    ),
+  );
+  const resourceKey = fullResources
+    .map(({ resource }) => `${resource.key}:${resource.title}`)
+    .join('\u0000');
+  const resourceText = [
+    ...fullResources.map(({ resource }) => `${resource.title}\n${resource.text}`),
+    supplementalText,
+  ].join('\u0000');
+  const structuredText = fullResources
+    .map(({ resource }) => JSON.stringify(resource.structured) ?? '')
+    .join('\u0000');
+  const previous = options.memory.ziweiPhaseReading;
+  const reusable =
+    previous?.resourceKey === resourceKey &&
+    previous.resourceText === resourceText &&
+    previous.structuredText === structuredText &&
+    previous.subjectId === (options.subject?.id ?? '') &&
+    previous.question === question &&
+    previous.phases.length === phases.length;
+  const phaseMemory: ZiweiPhaseMemory = reusable
+    ? previous!
+    : {
+        resourceKey,
+        resourceText,
+        structuredText,
+        subjectId: options.subject?.id ?? '',
+        question,
+        phases: phases.map((phase, index) => ({
+          index,
+          resourceKey: phase.resourceKey,
+          subjectTitle: phase.subjectTitle,
+          facts: phase.facts,
+          status: 'pending',
+        })),
+      };
+  if (reusable) {
+    phaseMemory.phases = phases.map((phase, index) => {
+      const old = previous!.phases[index];
+      return old?.resourceKey === phase.resourceKey &&
+        old.subjectTitle === phase.subjectTitle &&
+        old.facts === phase.facts
+        ? old
+        : {
+            index,
+            resourceKey: phase.resourceKey,
+            subjectTitle: phase.subjectTitle,
+            facts: phase.facts,
+            status: 'pending' as const,
+          };
+    });
+  }
+  options.memory.ziweiPhaseReading = phaseMemory;
+  const finalMessages = await collectZiweiPhaseSummary(
+    messages,
+    phases,
+    options,
+    deps,
+    guide,
+    currentTimeContext,
+    question,
+    supplementalText,
+  );
+  if (finalMessages.length < messages.length)
+    options.onNotice('对话较长，本轮保留原始盘面与最近的问答。');
+  options.onProgress({ stage: 'writing', text: '正在综合全部紫微阶段解读' });
+  let answer = '';
+  await deps.stream(finalMessages, {
+    ...options,
+    onChunk: (chunk) => {
+      answer += chunk;
+      options.onChunk(chunk);
+    },
+    onDone: () => {
+      if (!answer.trim()) {
+        options.onError('紫微最终汇总返回空结果，请重试。');
+        return;
+      }
+      options.onProgress({ stage: 'checking', text: '正在核对关键事实' });
+      for (const issue of verifyReadingAnswer(messages[0]!.content, answer, [
+        ...fullResources.map(({ resource }) => resource),
+        ...supplementalResources,
+      ]))
+        options.onNotice(`回答中有一处需要核对：${issue}`);
+      options.onDone();
+    },
+  });
+}
+
 export async function runReadingWorkflow(
   messages: ChatMessage[],
   options: ReadingOptions,
@@ -338,9 +890,10 @@ export async function runReadingWorkflow(
   const seen = new Set([...resources, ...schemaResources].map((item) => item.key));
   const notes: string[] = [];
   let calls = 0;
+  const hasStoredFullZiwei = resources.some((resource) => Boolean(getZiweiFullResult(resource)));
   options.onProgress({ stage: 'preparing', text: '正在梳理问题与盘面' });
   try {
-    for (let round = 0; round < (isSimpleFollowup ? 0 : 2); round += 1) {
+    for (let round = 0; round < (isSimpleFollowup || hasStoredFullZiwei ? 0 : 2); round += 1) {
       let needsRefinement = false;
       guard();
       const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
@@ -462,6 +1015,27 @@ export async function runReadingWorkflow(
       return `${guide}${currentTimeContext}${material ? `\n\n【补充资料】\n${material}` : ''}${status}\n\n【本轮解读】\n${isSimpleFollowup ? '请结合当前盘面、已有补充资料和上一轮解读直接回答用户的追问，保持原盘主体与计算口径，说明判断依据和适用条件。' : '请完整回答用户最近的问题，将已知盘面与查得传统条文结合具体情境推导。'}先说明主要判断，再展开支持依据、变化条件与关键时段。对影响当前结论的缺项，具体说明所需资料，同时完成已知部分。`;
     };
     const finalSelection = selectResourcesForMessages(messages, finalResources, buildFinalAddition);
+    const ziweiFullResources = finalResources.flatMap((resource) => {
+      const result = getZiweiFullResult(resource);
+      return result ? [{ resource, result }] : [];
+    });
+    const ziweiFullResourceSet = new Set(ziweiFullResources.map(({ resource }) => resource));
+    const omittedZiweiFullResources = finalSelection.omitted.filter((resource) =>
+      ziweiFullResourceSet.has(resource),
+    );
+    if (omittedZiweiFullResources.length && ziweiFullResources.length) {
+      await runZiweiPhasedReading(
+        messages,
+        options,
+        deps,
+        ziweiFullResources,
+        finalResources.filter((resource) => !ziweiFullResourceSet.has(resource)),
+        guide,
+        currentTimeContext,
+        latestUserQuestion,
+      );
+      return;
+    }
     const finalStatusNotes = getFinalStatusNotes(finalSelection.omitted);
     if (finalSelection.omitted.length) {
       options.onNotice(

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -607,7 +607,9 @@ function packPhaseAnswers(
     } catch (error) {
       if (!(error instanceof Error) || !error.message.includes('解读容量')) throw error;
       if (!current.length)
-        throw new Error(`紫微阶段${entry.indices[0]! + 1}/${phaseCount}的分析结果超出汇总容量。`);
+        throw new Error(`紫微阶段${entry.indices[0]! + 1}/${phaseCount}的分析结果超出汇总容量。`, {
+          cause: error,
+        });
       groups.push(current);
       current = [entry];
     }
@@ -626,7 +628,7 @@ async function collectZiweiPhaseSummary(
   question: string,
   supplementalText: string,
 ) {
-  let entries: PhaseAnswer[] = Array.from({ length: phases.length }, (_, index) => ({
+  const entries: PhaseAnswer[] = Array.from({ length: phases.length }, (_, index) => ({
     indices: [index],
     labels: [phases[index]!.summaryLabel],
     answer: '',

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -11,7 +11,7 @@ import {
   type SerializableZiweiResult,
   type ZiweiFortuneTimeline,
   type ZiweiFortuneTimelinePhaseSelection,
-} from '@core/prompt';
+} from 'mingyu-core/prompt';
 
 export type ReadingTarget = 'primary' | 'partner';
 

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -54,6 +54,11 @@ export type ReadingMemory = {
   schemas?: ReadingResource[];
   ziweiPhaseReading?: ZiweiPhaseMemory;
 };
+export type ReadingMemorySeed = {
+  subjectId: string;
+  key: string;
+  resources: ReadingResource[];
+};
 export type { ReadingSubjectSnapshot } from './reading-subject';
 export type ReadingProgress = {
   stage: 'preparing' | 'consulting' | 'calculating' | 'checking' | 'writing';

--- a/src/pages/ResultPage/hooks/useZiweiCalculations.ts
+++ b/src/pages/ResultPage/hooks/useZiweiCalculations.ts
@@ -1,9 +1,10 @@
 import { useWorkerRequest } from '@/hooks/useWorkerRequest';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { buildZiweiChartInput } from '@/lib/full-chart-engine/ziwei';
 import { getDefaultHoroscopeContext } from 'mingyu-core/ziwei';
 import type { AnalysisPayloadV1, ScopeType } from '@/types/analysis';
 import type { ChartInput } from '@/types/chart';
+import type { ReadingResource } from '@/lib/ai/reading-workflow';
 import type { QueryInputState } from '@/lib/query-state';
 import type { ZiweiPayloadByScopeState, ZiweiRuntimeState } from '../ResultPage.types';
 import {
@@ -12,8 +13,10 @@ import {
   getCachedZiweiRuntime,
   getZiweiDisplayKey,
   getZiweiInputKey,
+  getZiweiReadingResourceKey,
   loadZiweiDisplayPayload,
   loadZiweiPromptScopePayloads,
+  loadZiweiReadingResource,
   loadZiweiPayload,
   loadZiweiRuntime,
   stabilizeZiweiChartInput,
@@ -35,6 +38,10 @@ export interface ZiweiCalculations {
   currentZiweiPayload: AnalysisPayloadV1 | null;
   promptZiweiScopePayloads: Partial<Record<ScopeType, AnalysisPayloadV1>> | null;
   partnerZiweiPayload: AnalysisPayloadV1 | null;
+  ziweiReadingResources: ReadingResource[];
+  ziweiReadingResourcesReady: boolean;
+  ziweiReadingResourceError: string;
+  reloadZiweiReadingResources: () => void;
 }
 
 export function useZiweiCalculations(
@@ -47,6 +54,7 @@ export function useZiweiCalculations(
   },
   isZiweiTabMounted: boolean,
   isPromptTabMounted: boolean,
+  isInstantResult = false,
 ): ZiweiCalculations {
   const primaryZiweiInput = useMemo(() => {
     try {
@@ -323,6 +331,132 @@ export function useZiweiCalculations(
     promptState.ziweiScope !== 'full' &&
     Boolean(promptState.ziweiScopeDate);
   const promptHourIndex = useMemo(() => getDefaultHoroscopeContext().hourIndex, []);
+  const readingResourceRequest = useMemo(() => {
+    if (
+      isInstantResult ||
+      !isPromptTabMounted ||
+      promptState.ziweiScope !== 'full' ||
+      (promptState.promptSource !== 'ziwei' && promptState.promptSource !== 'bazi-ziwei') ||
+      (promptState.promptSource === 'bazi-ziwei' && inputState.analysisMode !== 'single') ||
+      !primaryZiweiInput ||
+      !primaryZiweiInputKey
+    ) {
+      return null;
+    }
+
+    const dateStr = promptState.ziweiScopeDate || getDefaultHoroscopeContext().dateStr;
+    const items: Array<{
+      role: 'primary' | 'partner';
+      input: ChartInput;
+      inputKey: string;
+      subjectTitle: string;
+    }> = [
+      {
+        role: 'primary' as const,
+        input: primaryZiweiInput,
+        inputKey: primaryZiweiInputKey,
+        subjectTitle: primaryZiweiInput.name || '第一主体',
+      },
+    ];
+    if (inputState.analysisMode === 'compatibility') {
+      if (!partnerZiweiInput || !partnerZiweiInputKey) return null;
+      items.push({
+        role: 'partner' as const,
+        input: partnerZiweiInput,
+        inputKey: partnerZiweiInputKey,
+        subjectTitle: partnerZiweiInput.name || '第二主体',
+      });
+    }
+    return {
+      dateStr,
+      hourIndex: promptHourIndex,
+      items,
+      key: items
+        .map(({ role, inputKey }) =>
+          getZiweiReadingResourceKey(inputKey, dateStr, promptHourIndex, role),
+        )
+        .join('\u0000'),
+    };
+  }, [
+    inputState.analysisMode,
+    isInstantResult,
+    isPromptTabMounted,
+    partnerZiweiInput,
+    partnerZiweiInputKey,
+    primaryZiweiInput,
+    primaryZiweiInputKey,
+    promptHourIndex,
+    promptState.promptSource,
+    promptState.ziweiScope,
+    promptState.ziweiScopeDate,
+  ]);
+  const [ziweiReadingResources, setZiweiReadingResources] = useState<ReadingResource[]>([]);
+  const [ziweiReadingResourceKey, setZiweiReadingResourceKey] = useState('');
+  const [ziweiReadingResourceError, setZiweiReadingResourceError] = useState('');
+  const [ziweiReadingResourceRetry, setZiweiReadingResourceRetry] = useState(0);
+  const readingResourceRequestKeyRef = useRef('');
+  const reloadZiweiReadingResources = useCallback(() => {
+    setZiweiReadingResourceRetry((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!readingResourceRequest) {
+      readingResourceRequestKeyRef.current = '';
+      setZiweiReadingResources([]);
+      setZiweiReadingResourceKey('');
+      setZiweiReadingResourceError('');
+      return;
+    }
+
+    let active = true;
+    const isSameRequest = readingResourceRequestKeyRef.current === readingResourceRequest.key;
+    readingResourceRequestKeyRef.current = readingResourceRequest.key;
+    if (!isSameRequest) {
+      setZiweiReadingResources([]);
+      setZiweiReadingResourceKey('');
+    }
+    setZiweiReadingResourceError('');
+    void Promise.all(
+      readingResourceRequest.items.map(async (item) => {
+        try {
+          return {
+            resource: await loadZiweiReadingResource(
+              item.input,
+              item.inputKey,
+              readingResourceRequest.dateStr,
+              readingResourceRequest.hourIndex,
+              item.role,
+              item.subjectTitle,
+            ),
+          };
+        } catch {
+          return { resource: null };
+        }
+      }),
+    ).then((results) => {
+      if (!active) return;
+      const resources = results
+        .map(({ resource }) => resource)
+        .filter((resource): resource is ReadingResource => Boolean(resource));
+      setZiweiReadingResources(resources);
+      const hasFailure = resources.length !== results.length;
+      setZiweiReadingResourceKey(hasFailure ? '' : readingResourceRequest.key);
+      setZiweiReadingResourceError(hasFailure ? '完整紫微资料生成失败，请重新生成资料。' : '');
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [readingResourceRequest, ziweiReadingResourceRetry]);
+
+  const currentZiweiReadingResources =
+    readingResourceRequest?.key === ziweiReadingResourceKey ? ziweiReadingResources : [];
+  const ziweiReadingResourcesReady = Boolean(
+    readingResourceRequest &&
+    readingResourceRequest.key === ziweiReadingResourceKey &&
+    currentZiweiReadingResources.length === readingResourceRequest.items.length,
+  );
+
   const fortuneRequest = useMemo(() => {
     if (
       !shouldLoadZiweiPromptPayload ||
@@ -551,5 +685,9 @@ export function useZiweiCalculations(
         : null
       : activeZiweiPayloadByScope,
     partnerZiweiPayload,
+    ziweiReadingResources: currentZiweiReadingResources,
+    ziweiReadingResourcesReady,
+    ziweiReadingResourceError,
+    reloadZiweiReadingResources,
   };
 }

--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -85,6 +85,7 @@ import { usePromptShortcuts } from './hooks/usePromptShortcuts';
 import { AiChatPanel } from '@/components/AiChatPanel';
 import { getChartChatHistoryContext } from '@/lib/ai/chat-history';
 import { buildReadingSubject } from '@/lib/ai/reading-subject';
+import type { ReadingMemorySeed } from '@/lib/ai/reading-workflow';
 import {
   ResultAssistantFab,
   ResultAssistantHeader,
@@ -531,7 +532,17 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
     ziweiFortuneText,
     currentZiweiPayload,
     partnerZiweiPayload,
-  } = useZiweiCalculations(inputState, promptState, mountedTabs.ziwei, mountedTabs.prompt);
+    ziweiReadingResources,
+    ziweiReadingResourcesReady,
+    ziweiReadingResourceError,
+    reloadZiweiReadingResources,
+  } = useZiweiCalculations(
+    inputState,
+    promptState,
+    mountedTabs.ziwei,
+    mountedTabs.prompt,
+    isInstantResult,
+  );
   const updatePromptState = useCallback(
     (next: Partial<QueryPromptState>) => {
       const merged = {
@@ -1264,7 +1275,7 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
       }),
     [activeBaziShortcutMode],
   );
-  function computeZiweiPromptText(question: string): string {
+  function computeZiweiPromptText(question: string, includeFullScope = true): string {
     if (!showAssistantPane) return '';
     if (isInstantResult) {
       return currentZiweiPayload
@@ -1310,18 +1321,20 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
       },
     );
     const scopedPrompt =
-      promptState.ziweiScope === 'full' && activeZiweiPayloadByScope
-        ? (() => {
-            const fullScopeText = formatZiweiFullScopeText(activeZiweiPayloadByScope);
-            return fullScopeText
-              ? basePrompt.replace('【问题】', `【完整运限资料】\n${fullScopeText}\n\n【问题】`)
-              : basePrompt;
-          })()
+      promptState.ziweiScope === 'full'
+        ? includeFullScope && activeZiweiPayloadByScope
+          ? (() => {
+              const fullScopeText = formatZiweiFullScopeText(activeZiweiPayloadByScope);
+              return fullScopeText
+                ? basePrompt.replace('【问题】', `【完整运限资料】\n${fullScopeText}\n\n【问题】`)
+                : basePrompt;
+            })()
+          : basePrompt
         : supportingText
           ? basePrompt.replace('【问题】', `【上层运限资料】\n${supportingText}\n\n【问题】`)
           : basePrompt;
     return applyZiweiPromptSelection(
-      [scopedPrompt, ziweiFortuneText].filter(Boolean).join('\n\n'),
+      [scopedPrompt, includeFullScope ? ziweiFortuneText : ''].filter(Boolean).join('\n\n'),
       promptState.ziweiTopicId,
       promptState.ziweiSubtopicId,
       toPromptScope(promptState.ziweiScope),
@@ -1380,6 +1393,39 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
     showAssistantPane,
   ]);
 
+  const phaseEnhancedZiweiPromptPack = useMemo(() => {
+    if (
+      isInstantResult ||
+      !showAssistantPane ||
+      promptState.promptSource !== 'bazi-ziwei' ||
+      !currentZiweiPayload
+    ) {
+      return '';
+    }
+
+    const ziweiTopic = resolveZiweiTopicByBaziShortcutMode(
+      promptState.baziTopicId || promptState.ziweiTopicId || activeBaziShortcutMode,
+    );
+    return [
+      buildEnhancedZiweiPromptPack(currentZiweiPayload, ziweiTopic),
+      formatZiweiSupportingScopeText(
+        promptZiweiScopePayloads,
+        currentZiweiPayload.active_scope.scope,
+      ),
+    ]
+      .filter(Boolean)
+      .join('\n\n');
+  }, [
+    activeBaziShortcutMode,
+    promptState.baziTopicId,
+    promptState.promptSource,
+    promptState.ziweiTopicId,
+    currentZiweiPayload,
+    promptZiweiScopePayloads,
+    isInstantResult,
+    showAssistantPane,
+  ]);
+
   const enhancedBaziPromptPack = useMemo(() => {
     if (
       isInstantResult ||
@@ -1406,7 +1452,11 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
     showAssistantPane,
   ]);
 
-  function computeEnhancedPromptText(question: string, finalQuestion: string): string {
+  function computeEnhancedPromptText(
+    question: string,
+    finalQuestion: string,
+    includeFullScope = true,
+  ): string {
     if (!showAssistantPane || inputState.analysisMode !== 'single') return '';
     if (isInstantResult) {
       return baziResult && currentZiweiPayload
@@ -1418,20 +1468,23 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
           )
         : '';
     }
-    if (!baziResult || !enhancedZiweiPromptPack || !enhancedBaziPromptPack) return '';
+    const ziweiPromptPack = includeFullScope
+      ? enhancedZiweiPromptPack
+      : phaseEnhancedZiweiPromptPack;
+    if (!baziResult || !ziweiPromptPack || !enhancedBaziPromptPack) return '';
 
     return buildBaziZiweiEnhancedPrompt({
       baziResult,
       baziText: enhancedBaziPromptPack,
       ziweiText:
-        promptState.ziweiScope === 'full' && activeZiweiPayloadByScope
+        includeFullScope && promptState.ziweiScope === 'full' && activeZiweiPayloadByScope
           ? [
-              enhancedZiweiPromptPack,
+              ziweiPromptPack,
               `【完整运限资料】\n${formatZiweiFullScopeText(activeZiweiPayloadByScope)}`,
             ]
               .filter(Boolean)
               .join('\n\n')
-          : enhancedZiweiPromptPack,
+          : ziweiPromptPack,
       question: finalQuestion || question,
       questionScopeLabel: activeBaziQuestionScopeLabel,
       baziFortuneSummary:
@@ -1915,6 +1968,66 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
 
     return previewActivePromptText;
   }, [previewActivePromptText, showAssistantPane]);
+
+  const readingResourceSeed = useMemo<ReadingMemorySeed | undefined>(() => {
+    if (!readingSubject.id || !ziweiReadingResourcesReady) return undefined;
+    return {
+      subjectId: readingSubject.id,
+      key: ziweiReadingResources.map((resource) => resource.key).join('\u0000'),
+      resources: ziweiReadingResources,
+    };
+  }, [readingSubject.id, ziweiReadingResources, ziweiReadingResourcesReady]);
+
+  const workflowPrompt = useMemo(() => {
+    if (
+      isInstantResult ||
+      promptState.ziweiScope !== 'full' ||
+      (promptState.promptSource === 'bazi-ziwei' && inputState.analysisMode !== 'single')
+    )
+      return '';
+    if (promptState.promptSource === 'ziwei') {
+      return computeZiweiPromptText(effectiveZiweiQuickQuestion, false);
+    }
+    if (promptState.promptSource === 'bazi-ziwei') {
+      return computeEnhancedPromptText(effectiveBaziQuickQuestion, finalBaziQuestion, false);
+    }
+    return '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    promptState.promptSource,
+    effectiveZiweiQuickQuestion,
+    effectiveBaziQuickQuestion,
+    finalBaziQuestion,
+    promptState.ziweiScope,
+    promptState.ziweiTopic,
+    promptState.ziweiTopicId,
+    promptState.ziweiSubtopicId,
+    promptState.baziTopicId,
+    promptState.baziSubtopicId,
+    activeZiweiPayloadByScope,
+    activeZiweiShortcutMode,
+    activeBaziShortcutMode,
+    promptZiweiScopePayloads,
+    currentZiweiPayload,
+    partnerZiweiPayload,
+    ziweiRuntime,
+    partnerZiweiRuntime,
+    baziResult,
+    enhancedZiweiPromptPack,
+    phaseEnhancedZiweiPromptPack,
+    enhancedBaziPromptPack,
+    baziFortuneContext,
+    activeBaziQuestionScopeLabel,
+    ziweiScopeSummaryText,
+    inputState.analysisMode,
+    isInstantResult,
+    showAssistantPane,
+  ]);
+  const readingResourceRequired =
+    !isInstantResult &&
+    promptState.ziweiScope === 'full' &&
+    (promptState.promptSource === 'ziwei' ||
+      (promptState.promptSource === 'bazi-ziwei' && inputState.analysisMode === 'single'));
 
   const [inspirationText, setInspirationText] = useState('');
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -2456,7 +2569,12 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
               <div className="workspace-ai-layout is-answer-workbench">
                 <AiChatPanel
                   contextPrompt={aiContextPrompt}
+                  workflowPrompt={workflowPrompt || undefined}
                   readingSubject={readingSubject}
+                  readingResourceSeed={workflowPrompt.trim() ? readingResourceSeed : undefined}
+                  readingResourceRequired={readingResourceRequired}
+                  readingResourceError={ziweiReadingResourceError || undefined}
+                  onRetryReadingResources={reloadZiweiReadingResources}
                   historyKey={getChartChatHistoryContext(aiContextPrompt)}
                   resetKey={`${promptState.promptSource}-${promptState.baziFortuneScope}-${promptState.ziweiScope}`}
                   externalInput={inspirationText}

--- a/src/pages/ResultPage/utils/createPayloadWorker.ts
+++ b/src/pages/ResultPage/utils/createPayloadWorker.ts
@@ -1,6 +1,14 @@
 import { attachWorkerSafety } from '@/hooks/useWorkerRequest';
 import type { AnalysisPayloadV1, ScopeType } from '@/types/analysis';
 import type { ChartInput } from '@/types/chart';
+import type { buildSerializableZiweiResult } from 'mingyu-core/ziwei';
+
+type ZiweiReadingResourceContent = {
+  text: string;
+  usable: true;
+  kind: 'evidence';
+  structured: ReturnType<typeof buildSerializableZiweiResult>;
+};
 
 export function createPayloadWorker(
   input: ChartInput,
@@ -36,6 +44,53 @@ export function createPayloadWorker(
   };
 
   worker.postMessage({ id: requestId, input });
+
+  return () => {
+    disarm();
+    worker.terminate();
+  };
+}
+
+export function createReadingResourceWorker(
+  input: ChartInput,
+  dateStr: string,
+  hourIndex: number,
+  requestId: string,
+  onSuccess: (resource: ZiweiReadingResourceContent) => void,
+  onError: (message: string) => void,
+): () => void {
+  const worker = new Worker(new URL('../../../workers/ziwei-payload.worker.ts', import.meta.url), {
+    type: 'module',
+  });
+  const disarm = attachWorkerSafety(worker, { onError });
+  worker.onmessage = (
+    event: MessageEvent<{
+      id: string;
+      kind?: 'payload' | 'reading-resource';
+      ok: boolean;
+      resource?: ZiweiReadingResourceContent;
+      error?: string;
+    }>,
+  ) => {
+    if (event.data.id !== requestId) return;
+    disarm();
+
+    if (event.data.kind === 'reading-resource' && event.data.ok && event.data.resource) {
+      onSuccess(event.data.resource);
+    } else {
+      onError(event.data.error || '紫微完整运限资料生成失败。');
+    }
+
+    worker.terminate();
+  };
+
+  worker.postMessage({
+    id: requestId,
+    kind: 'reading-resource',
+    input,
+    dateStr,
+    hourIndex,
+  });
 
   return () => {
     disarm();

--- a/src/pages/ResultPage/utils/createPayloadWorker.ts
+++ b/src/pages/ResultPage/utils/createPayloadWorker.ts
@@ -1,14 +1,9 @@
 import { attachWorkerSafety } from '@/hooks/useWorkerRequest';
 import type { AnalysisPayloadV1, ScopeType } from '@/types/analysis';
 import type { ChartInput } from '@/types/chart';
-import type { buildSerializableZiweiResult } from 'mingyu-core/ziwei';
+import type { ReadingResource } from '@/lib/ai/reading-workflow';
 
-type ZiweiReadingResourceContent = {
-  text: string;
-  usable: true;
-  kind: 'evidence';
-  structured: ReturnType<typeof buildSerializableZiweiResult>;
-};
+export type ZiweiReadingResourceContent = Omit<ReadingResource, 'key' | 'title'>;
 
 export function createPayloadWorker(
   input: ChartInput,

--- a/src/pages/ResultPage/utils/ziweiCalculationCache.ts
+++ b/src/pages/ResultPage/utils/ziweiCalculationCache.ts
@@ -3,9 +3,10 @@ import { createBoundedMemoryCache } from '@/lib/bounded-memory-cache';
 import { createSecureId } from '@/lib/secure-id';
 import type { AnalysisPayloadV1, ScopeType } from '@/types/analysis';
 import type { ChartInput } from '@/types/chart';
+import type { ReadingResource } from '@/lib/ai/reading-workflow';
 import type { ZiweiPayloadByScopeState, ZiweiRuntimeState } from '../ResultPage.types';
 import { createDisplayWorker } from './createDisplayWorker';
-import { createPayloadWorker } from './createPayloadWorker';
+import { createPayloadWorker, createReadingResourceWorker } from './createPayloadWorker';
 
 type ZiweiRuntime = NonNullable<ZiweiRuntimeState>;
 type ZiweiPayloadByScope = NonNullable<ZiweiPayloadByScopeState>;
@@ -14,9 +15,14 @@ const chartInputCache = createBoundedMemoryCache<ChartInput>(12);
 const runtimeCache = createBoundedMemoryCache<ZiweiRuntime>(8);
 const payloadCache = createBoundedMemoryCache<ZiweiPayloadByScope>(8);
 const displayPayloadCache = createBoundedMemoryCache<AnalysisPayloadV1>(24);
+type ZiweiReadingResourceContent = Omit<ReadingResource, 'key' | 'title'>;
+const readingContentCache = createBoundedMemoryCache<ZiweiReadingResourceContent>(8);
+const readingResourceCache = createBoundedMemoryCache<ZiweiReadingResourceContent>(16);
 const pendingRuntime = new Map<string, Promise<ZiweiRuntime>>();
 const pendingPayload = new Map<string, Promise<ZiweiPayloadByScope>>();
 const pendingDisplayPayload = new Map<string, Promise<AnalysisPayloadV1>>();
+const pendingReadingContent = new Map<string, Promise<ZiweiReadingResourceContent>>();
+const pendingReadingResource = new Map<string, Promise<ZiweiReadingResourceContent>>();
 
 export function getZiweiInputKey(input: ChartInput): string {
   return JSON.stringify(input);
@@ -54,6 +60,90 @@ export function loadZiweiRuntime(input: ChartInput, inputKey: string): Promise<Z
     .finally(() => pendingRuntime.delete(inputKey));
   pendingRuntime.set(inputKey, request);
   return request;
+}
+
+function getZiweiReadingRuntimeKey(inputKey: string, dateStr: string, hourIndex: number) {
+  return `${inputKey}\u0000${dateStr}\u0000${hourIndex}`;
+}
+
+export function getZiweiReadingResourceKey(
+  inputKey: string,
+  dateStr: string,
+  hourIndex: number,
+  role: 'primary' | 'partner',
+) {
+  return `ziwei-reading-full\u0000${role}\u0000${getZiweiReadingRuntimeKey(inputKey, dateStr, hourIndex)}`;
+}
+
+function loadZiweiReadingContent(
+  input: ChartInput,
+  inputKey: string,
+  dateStr: string,
+  hourIndex: number,
+): Promise<ZiweiReadingResourceContent> {
+  const runtimeKey = getZiweiReadingRuntimeKey(inputKey, dateStr, hourIndex);
+  const cached = readingContentCache.get(runtimeKey);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = pendingReadingContent.get(runtimeKey);
+  if (pending) return pending;
+
+  const request = new Promise<ZiweiReadingResourceContent>((resolve, reject) => {
+    createReadingResourceWorker(
+      input,
+      dateStr,
+      hourIndex,
+      `${createSecureId()}-reading-resource`,
+      resolve,
+      (message) => reject(new Error(message)),
+    );
+  })
+    .then((content) => {
+      readingContentCache.set(runtimeKey, content);
+      return content;
+    })
+    .finally(() => pendingReadingContent.delete(runtimeKey));
+  pendingReadingContent.set(runtimeKey, request);
+  return request;
+}
+
+export function loadZiweiReadingResource(
+  input: ChartInput,
+  inputKey: string,
+  dateStr: string,
+  hourIndex: number,
+  role: 'primary' | 'partner',
+  subjectTitle: string,
+): Promise<ReadingResource> {
+  const resourceKey = getZiweiReadingResourceKey(inputKey, dateStr, hourIndex, role);
+  const cached = readingResourceCache.get(resourceKey);
+  if (cached)
+    return Promise.resolve({
+      key: resourceKey,
+      title: `${subjectTitle}紫微完整运限资料`,
+      ...cached,
+    });
+
+  const pending = pendingReadingResource.get(resourceKey);
+  if (pending)
+    return pending.then((content) => ({
+      key: resourceKey,
+      title: `${subjectTitle}紫微完整运限资料`,
+      ...content,
+    }));
+
+  const request = loadZiweiReadingContent(input, inputKey, dateStr, hourIndex)
+    .then((content) => {
+      readingResourceCache.set(resourceKey, content);
+      return content;
+    })
+    .finally(() => pendingReadingResource.delete(resourceKey));
+  pendingReadingResource.set(resourceKey, request);
+  return request.then((content) => ({
+    key: resourceKey,
+    title: `${subjectTitle}紫微完整运限资料`,
+    ...content,
+  }));
 }
 
 export function loadZiweiPayload(

--- a/src/workers/ziwei-payload.worker.ts
+++ b/src/workers/ziwei-payload.worker.ts
@@ -6,12 +6,7 @@ import { buildSerializableZiweiResult } from 'mingyu-core/ziwei';
 import { formatPublicZiweiFullScopeText } from 'mingyu-core/prompt/public-api';
 import type { ChartInput } from '@/types/chart';
 
-type ZiweiReadingResourceContent = {
-  text: string;
-  usable: true;
-  kind: 'evidence';
-  structured: ReturnType<typeof buildSerializableZiweiResult>;
-};
+import type { ZiweiReadingResourceContent } from '@/pages/ResultPage/utils/createPayloadWorker';
 
 type ZiweiPayloadWorkerRequest =
   | {
@@ -48,27 +43,28 @@ type ZiweiPayloadWorkerResponse =
     };
 
 self.onmessage = async (event: MessageEvent<ZiweiPayloadWorkerRequest>) => {
+  const request = event.data;
   try {
     const response: ZiweiPayloadWorkerResponse =
-      event.data.kind === 'reading-resource'
+      request.kind === 'reading-resource'
         ? {
-            id: event.data.id,
+            id: request.id,
             kind: 'reading-resource',
             ok: true,
             resource: await (async (): Promise<ZiweiReadingResourceContent> => {
               const runtime = await calculatePublicZiweiChartForScopes(
-                event.data.input,
+                request.input,
                 ['decadal', 'yearly', 'monthly', 'daily', 'hourly'],
                 {
                   skipAnalysis: true,
                   horoscopeContext: {
-                    dateStr: event.data.dateStr,
-                    hourIndex: event.data.hourIndex,
+                    dateStr: request.dateStr,
+                    hourIndex: request.hourIndex,
                   },
                   fortuneRange: {
                     scope: 'all',
-                    dateStr: event.data.dateStr,
-                    hourIndex: event.data.hourIndex,
+                    dateStr: request.dateStr,
+                    hourIndex: request.hourIndex,
                   },
                 },
               );
@@ -76,21 +72,21 @@ self.onmessage = async (event: MessageEvent<ZiweiPayloadWorkerRequest>) => {
                 text: formatPublicZiweiFullScopeText(runtime),
                 usable: true,
                 kind: 'evidence',
-                structured: buildSerializableZiweiResult(runtime),
+                structured: { ...buildSerializableZiweiResult(runtime) },
               };
             })(),
           }
         : {
-            id: event.data.id,
+            id: request.id,
             kind: 'payload',
             ok: true,
-            payloadByScope: await calculateZiweiPayloadByScope(event.data.input),
+            payloadByScope: await calculateZiweiPayloadByScope(request.input),
           };
     self.postMessage(response);
   } catch (error) {
     const response: ZiweiPayloadWorkerResponse = {
-      id: event.data.id,
-      kind: event.data.kind === 'reading-resource' ? 'reading-resource' : 'payload',
+      id: request.id,
+      kind: request.kind === 'reading-resource' ? 'reading-resource' : 'payload',
       ok: false,
       error: error instanceof Error ? error.message : '紫微排盘失败。',
     };

--- a/src/workers/ziwei-payload.worker.ts
+++ b/src/workers/ziwei-payload.worker.ts
@@ -1,35 +1,96 @@
-import { calculateZiweiPayloadByScope } from '@/lib/full-chart-engine/ziwei';
+import {
+  calculatePublicZiweiChartForScopes,
+  calculateZiweiPayloadByScope,
+} from '@/lib/full-chart-engine/ziwei';
+import { buildSerializableZiweiResult } from 'mingyu-core/ziwei';
+import { formatPublicZiweiFullScopeText } from 'mingyu-core/prompt/public-api';
 import type { ChartInput } from '@/types/chart';
 
-type ZiweiPayloadWorkerRequest = {
-  id: string;
-  input: ChartInput;
+type ZiweiReadingResourceContent = {
+  text: string;
+  usable: true;
+  kind: 'evidence';
+  structured: ReturnType<typeof buildSerializableZiweiResult>;
 };
+
+type ZiweiPayloadWorkerRequest =
+  | {
+      id: string;
+      input: ChartInput;
+      kind?: 'payload';
+    }
+  | {
+      id: string;
+      input: ChartInput;
+      kind: 'reading-resource';
+      dateStr: string;
+      hourIndex: number;
+    };
 
 type ZiweiPayloadWorkerResponse =
   | {
       id: string;
+      kind: 'payload';
       ok: true;
       payloadByScope: Awaited<ReturnType<typeof calculateZiweiPayloadByScope>>;
     }
   | {
       id: string;
+      kind: 'reading-resource';
+      ok: true;
+      resource: ZiweiReadingResourceContent;
+    }
+  | {
+      id: string;
+      kind: 'payload' | 'reading-resource';
       ok: false;
       error: string;
     };
 
 self.onmessage = async (event: MessageEvent<ZiweiPayloadWorkerRequest>) => {
   try {
-    const payloadByScope = await calculateZiweiPayloadByScope(event.data.input);
-    const response: ZiweiPayloadWorkerResponse = {
-      id: event.data.id,
-      ok: true,
-      payloadByScope,
-    };
+    const response: ZiweiPayloadWorkerResponse =
+      event.data.kind === 'reading-resource'
+        ? {
+            id: event.data.id,
+            kind: 'reading-resource',
+            ok: true,
+            resource: await (async (): Promise<ZiweiReadingResourceContent> => {
+              const runtime = await calculatePublicZiweiChartForScopes(
+                event.data.input,
+                ['decadal', 'yearly', 'monthly', 'daily', 'hourly'],
+                {
+                  skipAnalysis: true,
+                  horoscopeContext: {
+                    dateStr: event.data.dateStr,
+                    hourIndex: event.data.hourIndex,
+                  },
+                  fortuneRange: {
+                    scope: 'all',
+                    dateStr: event.data.dateStr,
+                    hourIndex: event.data.hourIndex,
+                  },
+                },
+              );
+              return {
+                text: formatPublicZiweiFullScopeText(runtime),
+                usable: true,
+                kind: 'evidence',
+                structured: buildSerializableZiweiResult(runtime),
+              };
+            })(),
+          }
+        : {
+            id: event.data.id,
+            kind: 'payload',
+            ok: true,
+            payloadByScope: await calculateZiweiPayloadByScope(event.data.input),
+          };
     self.postMessage(response);
   } catch (error) {
     const response: ZiweiPayloadWorkerResponse = {
       id: event.data.id,
+      kind: event.data.kind === 'reading-resource' ? 'reading-resource' : 'payload',
       ok: false,
       error: error instanceof Error ? error.message : '紫微排盘失败。',
     };

--- a/tests/ai-chat-history.test.ts
+++ b/tests/ai-chat-history.test.ts
@@ -123,3 +123,32 @@ test('AI 历史应保留未完成回答标记和原主体快照', () => {
   assert.equal(state.sessions[0]?.turns[1]?.incomplete, true);
   assert.equal(state.sessions[0]?.readingSubject?.id, 'subject-old');
 });
+
+test('AI 历史应保留结构化资料指纹以隔离不同命盘', () => {
+  const state = normalizeAiChatHistory({
+    version: 2,
+    sessions: [
+      {
+        id: 'structured',
+        title: '完整紫微资料',
+        initialQuestion: '问事业',
+        initialPrompt: '阶段入口',
+        readingResourceKey: 'ziwei-reading-full-primary-old',
+        readingSubject: {
+          id: 'subject-old',
+          source: 'ziwei',
+          lockedInputs: { ziwei: { year: 1990 } },
+          allowedMethods: ['ziwei'],
+          range: { ziweiScope: 'full' },
+        },
+        promptMode: 'context-question',
+        turns: [],
+        createdAt: '2026-07-13T08:00:00.000Z',
+        updatedAt: '2026-07-13T08:01:00.000Z',
+      },
+    ],
+    activeSessionId: 'structured',
+  });
+
+  assert.equal(state.sessions[0]?.readingResourceKey, 'ziwei-reading-full-primary-old');
+});

--- a/tests/ai-chat-lifecycle.test.ts
+++ b/tests/ai-chat-lifecycle.test.ts
@@ -3,9 +3,13 @@ import assert from 'node:assert/strict';
 import { getAiChatCompletionStatus } from '@/lib/ai/chat-history';
 import {
   buildAiChatRequest,
+  getReadingResourceRestoreError,
+  isReadingResourceSeedCompatible,
   removeIncompleteChatTurns,
+  resolveReadingResourceSeed,
   resolveRestoredAiChatState,
 } from '@/hooks/useAiChat';
+import type { ReadingMemorySeed } from '@/lib/ai/reading-workflow';
 
 test('重试和追问的消息应过滤未完成回答但保留原问题', () => {
   const turns = [
@@ -130,4 +134,46 @@ test('无新增消息时显式未完成状态仍按保存状态恢复', () => {
     'cancelled',
   );
   assert.equal(resolveRestoredAiChatState(turns, '原始盘面提示词', 'error').status, 'error');
+});
+
+test('历史完整资料应等待异步种子且拒绝不同范围或主体的种子', () => {
+  const requirement = { subjectId: 'subject-old', key: 'ziwei-full-range-a' };
+  const delayedSeed: ReadingMemorySeed = {
+    subjectId: 'subject-old',
+    key: 'ziwei-full-range-a',
+    resources: [
+      {
+        key: 'ziwei-full-range-a',
+        title: '旧主体紫微完整运限资料',
+        text: '完整盘面资料',
+        usable: true,
+      },
+    ],
+  };
+
+  assert.equal(resolveReadingResourceSeed(requirement, undefined), null);
+  assert.equal(
+    isReadingResourceSeedCompatible(
+      { ...delayedSeed, key: 'ziwei-full-range-b' },
+      requirement.subjectId,
+      requirement.key,
+    ),
+    false,
+  );
+  assert.equal(
+    isReadingResourceSeedCompatible(
+      { ...delayedSeed, subjectId: 'subject-current' },
+      requirement.subjectId,
+      requirement.key,
+    ),
+    false,
+  );
+  assert.deepEqual(
+    resolveReadingResourceSeed(requirement, delayedSeed)?.resources,
+    delayedSeed.resources,
+  );
+  assert.match(
+    getReadingResourceRestoreError(undefined, { subjectId: '', key: requirement.key }),
+    /缺少锁定主体资料/,
+  );
 });

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -20,6 +20,7 @@ import {
   buildZiweiChartInput,
   calculatePublicZiweiChartForScopes,
 } from 'mingyu-core/ziwei';
+import { formatPublicZiweiFullScopeText } from 'mingyu-core/prompt/public-api';
 
 function harness(responses: string[]) {
   const sent: Parameters<ReadingDependencies['stream']>[0][] = [];
@@ -184,6 +185,7 @@ async function makeCanonicalZiweiFullResource(
   gender: 'male' | 'female',
   birth: { year: string; month: string; day: string },
   key: string,
+  oversized = true,
 ) {
   const input = buildZiweiChartInput({
     name,
@@ -206,7 +208,9 @@ async function makeCanonicalZiweiFullResource(
   return {
     key,
     title: `${name}紫微完整运限资料`,
-    text: `${name}原始完整资料`.repeat(16_000),
+    text: oversized
+      ? `${name}原始完整资料`.repeat(16_000)
+      : formatPublicZiweiFullScopeText(runtime),
     usable: true,
     structured: buildSerializableZiweiResult(runtime),
   } satisfies ReadingResource;
@@ -600,6 +604,28 @@ test('紫微完整结构化资料未超限时零额外阶段调用', async () =>
   assert.equal(h.sent.length, 1);
   assert.equal(h.options.memory.ziweiPhaseReading, undefined);
   assert.match(h.sent[0]![0]!.content, /紫微完整资料/);
+});
+
+test('真实完整紫微规范正文未超限时进入最终stream', async () => {
+  const h = harness(['最终解读']);
+  const resource = await makeCanonicalZiweiFullResource(
+    '真实主体',
+    'female',
+    { year: '1992', month: '8', day: '21' },
+    'ziwei-full-real-text',
+    false,
+  );
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream: h.stream,
+    execute: async () => {
+      throw new Error('未预期的补算');
+    },
+  });
+  assert.equal(h.sent.length, 1);
+  assert.match(h.sent[0]![0]!.content, /完整紫微运限资料/);
+  assert.match(h.sent[0]![0]!.content, /真实主体紫微完整运限资料/);
 });
 
 test('紫微结构化时间线超限时按完整阶段事实逐段解读并汇总', async () => {

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -630,7 +630,7 @@ test('真实完整紫微规范正文未超限时进入最终stream', async () =>
 
 test('紫微结构化时间线超限时按完整阶段事实逐段解读并汇总', async () => {
   const h = harness(['第一阶段判断', '第二阶段判断', '全部阶段汇总']);
-  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const resource = makeZiweiFullResource(2, 1500, '完整原始资料'.repeat(16000));
   h.options.memory.resources = [resource];
   h.options.subject = ziweiSubject;
   await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
@@ -639,7 +639,7 @@ test('紫微结构化时间线超限时按完整阶段事实逐段解读并汇�
       throw new Error('未预期的补算');
     },
   });
-  assert.equal(h.sent.length, 3);
+  assert.equal(h.sent.length, 3, JSON.stringify(h.errors));
   assert.match(h.sent[0]![0]!.content, /阶段 1\/2/);
   assert.match(h.sent[0]![0]!.content, /主体：紫微完整运限资料/);
   assert.match(h.sent[0]![0]!.content, /安星口径：传统通行安星法/);
@@ -654,8 +654,23 @@ test('紫微结构化时间线超限时按完整阶段事实逐段解读并汇�
   );
 });
 
+test('紫微单年事实仍超容量时保留原始资料并明确失败', async () => {
+  const h = harness([]);
+  const resource = makeZiweiFullResource(1, 4000, '完整原始资料'.repeat(16000));
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream: h.stream,
+    execute: async () => resource,
+  });
+  assert.equal(h.sent.length, 0);
+  assert.deepEqual(h.errors, ['紫微完整资料的第1个大限仍超出单阶段容量。']);
+  assert.equal(h.options.memory.resources[0], resource);
+  assert.equal(h.done(), 0);
+});
+
 test('紫微阶段空回答标记失败并可重试', async () => {
-  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const resource = makeZiweiFullResource(2, 1500, '完整原始资料'.repeat(16000));
   const first = harness([]);
   first.options.memory.resources = [resource];
   first.options.subject = ziweiSubject;
@@ -688,7 +703,7 @@ test('紫微阶段空回答标记失败并可重试', async () => {
 });
 
 test('紫微阶段归并空回答不形成全覆盖', async () => {
-  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const resource = makeZiweiFullResource(2, 1500, '完整原始资料'.repeat(16000));
   const h = harness([]);
   h.options.memory.resources = [resource];
   h.options.subject = ziweiSubject;
@@ -754,12 +769,12 @@ test('两份真实完整紫微盘超限时按主体分别分阶段并综合', as
 
 test('紫微双主体中途失败后重试只补失败主体阶段', async () => {
   const primary = {
-    ...makeZiweiFullResource(2, 4000, '第一主体完整资料'.repeat(16_000)),
+    ...makeZiweiFullResource(2, 1500, '第一主体完整资料'.repeat(16_000)),
     key: 'ziwei-full-primary',
     title: '甲主体紫微完整运限资料',
   };
   const partner = {
-    ...makeZiweiFullResource(2, 4000, '第二主体完整资料'.repeat(16_000)),
+    ...makeZiweiFullResource(2, 1500, '第二主体完整资料'.repeat(16_000)),
     key: 'ziwei-full-partner',
     title: '乙主体紫微完整运限资料',
   };
@@ -805,7 +820,7 @@ test('紫微双主体中途失败后重试只补失败主体阶段', async () =>
 
 test('紫微阶段失败后同问题重试只补失败阶段并保留成功阶段', async () => {
   const h = harness([]);
-  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const resource = makeZiweiFullResource(2, 1500, '完整原始资料'.repeat(16000));
   h.options.memory.resources = [resource];
   h.options.subject = ziweiSubject;
   const sent: ChatMessage[][] = [];
@@ -841,7 +856,7 @@ test('紫微阶段失败后同问题重试只补失败阶段并保留成功阶�
 
 test('紫微阶段取消后换问题不会复用旧摘要', async () => {
   const h = harness([]);
-  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const resource = makeZiweiFullResource(2, 1500, '完整原始资料'.repeat(16000));
   h.options.memory.resources = [resource];
   h.options.subject = ziweiSubject;
   const controller = new AbortController();

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -9,10 +9,17 @@ import {
   type ReadingMemory,
   type ReadingOptions,
   type ReadingDependencies,
+  type ReadingResource,
 } from '../src/lib/ai/reading-workflow';
 import { executeReadingAction, lookupReadingClassics } from '../src/lib/ai/reading-resources';
 import type { ReadingSubjectSnapshot } from '../src/lib/ai/reading-subject';
+import type { ChatMessage } from '../src/lib/ai/stream-client';
 import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import {
+  buildSerializableZiweiResult,
+  buildZiweiChartInput,
+  calculatePublicZiweiChartForScopes,
+} from 'mingyu-core/ziwei';
 
 function harness(responses: string[]) {
   const sent: Parameters<ReadingDependencies['stream']>[0][] = [];
@@ -57,6 +64,160 @@ const baziSubject: ReadingSubjectSnapshot = {
   },
   allowedMethods: ['bazi'],
   range: { baziFortuneScope: 'year' },
+};
+
+function makeZiweiLayer(seed: string, starCount = 1) {
+  return {
+    name: `流年${seed}`,
+    heavenlyStem: '甲',
+    earthlyBranch: '子',
+    palaceNames: ['命宫'],
+    palaceTargets: ['命宫'],
+    mutagen: [''],
+    stars: [Array.from({ length: starCount }, (_, index) => `星曜${seed}-${index}`)],
+    yearlyDecStars: { jiangqian12: [], suiqian12: [] },
+  };
+}
+
+function makeZiweiFullResource(yearCount = 2, starCount = 1, text = '紫微完整资料') {
+  const years = Array.from({ length: yearCount }, (_, index) => ({
+    age: index + 1,
+    year: 2000 + index,
+    dateStr: `${2000 + index}-01-01`,
+    endDateStr: `${2000 + index}-12-31`,
+    label: `流年${2000 + index}`,
+    ganZhi: '甲子',
+    layer: makeZiweiLayer(String(2000 + index), starCount),
+  }));
+  const payload = {
+    basic_info: {
+      gender: '男',
+      solar_date: '1999-01-01',
+      lunar_date: '己卯年腊月十五',
+      birth_time_label: '子时',
+      zodiac: '兔',
+      soul_palace_branch: '子',
+      body_palace_branch: '午',
+      soul: '贪狼',
+      body: '天相',
+      hidden_palaces: { body_palace_name: '身宫' },
+      four_pillars: {
+        year_pillar: '己卯',
+        month_pillar: '丙子',
+        day_pillar: '甲子',
+        hour_pillar: '甲子',
+      },
+    },
+    active_scope: {
+      scope: 'origin',
+      label: '本命',
+      solar_date: '1999-01-01',
+      lunar_date: '己卯年腊月十五',
+      nominal_age: 1,
+      palace_name: '命宫',
+      mutagen_map: [],
+    },
+    palaces: [],
+    evidence_pool: [],
+  };
+  const timeline = {
+    scope: 'all',
+    targetDateStr: '2000-06-01',
+    targetHourIndex: 0,
+    targetAge: 1,
+    targetYear: 2000,
+    actualStartDateStr: '2000-01-01',
+    actualEndDateStr: `${1999 + yearCount}-12-31`,
+    selectedPeriodIndex: 0,
+    periods: [
+      {
+        kind: 'decadal' as const,
+        label: '第一大限',
+        startAge: 1,
+        endAge: yearCount,
+        dateStr: '2000-01-01',
+        endDateStr: `${1999 + yearCount}-12-31`,
+        source: 'iztro-horoscope' as const,
+        years,
+        layer: makeZiweiLayer('大限'),
+      },
+    ],
+  };
+  const payloadByScope = Object.fromEntries(
+    ['origin', 'decadal', 'yearly', 'monthly', 'daily', 'hourly'].map((scope) => [
+      scope,
+      {
+        ...payload,
+        active_scope: {
+          ...payload.active_scope,
+          scope,
+          label: scope,
+        },
+      },
+    ]),
+  );
+  const structured = {
+    basicInfo: payload.basic_info,
+    calculationConfig: { algorithm: 'default' },
+    scopeNames: ['origin', 'decadal', 'yearly', 'monthly', 'daily', 'hourly'],
+    payloadByScope,
+    fortuneTimeline: timeline,
+    fourMutagens: {},
+    birthMutagens: {},
+    gongList: [],
+    命宫: '子',
+    身宫: '身宫',
+    五行局: '水二局',
+    四化: {},
+  };
+  return {
+    key: 'ziwei-full',
+    title: '紫微完整运限资料',
+    text,
+    usable: true,
+    structured,
+  } satisfies ReadingResource;
+}
+
+async function makeCanonicalZiweiFullResource(
+  name: string,
+  gender: 'male' | 'female',
+  birth: { year: string; month: string; day: string },
+  key: string,
+) {
+  const input = buildZiweiChartInput({
+    name,
+    gender,
+    dateType: 'solar',
+    ...birth,
+    timeIndex: 4,
+    isLeapMonth: false,
+    algorithm: 'default',
+  });
+  const runtime = await calculatePublicZiweiChartForScopes(
+    input,
+    ['decadal', 'yearly', 'monthly', 'daily', 'hourly'],
+    {
+      skipAnalysis: true,
+      horoscopeContext: { dateStr: '2026-08-06', hourIndex: 4 },
+      fortuneRange: { scope: 'all', dateStr: '2026-08-06', hourIndex: 4 },
+    },
+  );
+  return {
+    key,
+    title: `${name}紫微完整运限资料`,
+    text: `${name}原始完整资料`.repeat(16_000),
+    usable: true,
+    structured: buildSerializableZiweiResult(runtime),
+  } satisfies ReadingResource;
+}
+
+const ziweiSubject: ReadingSubjectSnapshot = {
+  id: 'subject-ziwei-test',
+  source: 'ziwei',
+  lockedInputs: { ziwei: { name: '测试者', gender: 'male' } },
+  allowedMethods: ['ziwei'],
+  range: { ziweiScope: 'full', ziweiScopeDate: '2000-06-01', scopeHourIndex: 0 },
 };
 
 test('解读加载分术式路线并与可下载 Skill 同源', () => {
@@ -423,6 +584,269 @@ test('真实超出最终上下文时不静默丢弃成功资料并明确覆盖�
   assert.match(h.sent.at(-1)![0].content, /待后续补足/);
   assert.ok(h.notices.some((text) => text.includes('未纳入本轮判断')));
   assert.doesNotMatch(h.sent.at(-1)![0].content, /第二阶段完整事实/);
+});
+
+test('紫微完整结构化资料未超限时零额外阶段调用', async () => {
+  const h = harness(['最终解读']);
+  const resource = makeZiweiFullResource(2, 1);
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream: h.stream,
+    execute: async () => {
+      throw new Error('未预期的补算');
+    },
+  });
+  assert.equal(h.sent.length, 1);
+  assert.equal(h.options.memory.ziweiPhaseReading, undefined);
+  assert.match(h.sent[0]![0]!.content, /紫微完整资料/);
+});
+
+test('紫微结构化时间线超限时按完整阶段事实逐段解读并汇总', async () => {
+  const h = harness(['第一阶段判断', '第二阶段判断', '全部阶段汇总']);
+  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream: h.stream,
+    execute: async () => {
+      throw new Error('未预期的补算');
+    },
+  });
+  assert.equal(h.sent.length, 3);
+  assert.match(h.sent[0]![0]!.content, /阶段 1\/2/);
+  assert.match(h.sent[0]![0]!.content, /主体：紫微完整运限资料/);
+  assert.match(h.sent[0]![0]!.content, /安星口径：传统通行安星法/);
+  assert.match(h.sent[0]![0]!.content, /流年2000/);
+  assert.match(h.sent[1]![0]!.content, /阶段 2\/2/);
+  assert.match(h.sent[1]![0]!.content, /流年2001/);
+  assert.match(h.sent[2]![0]!.content, /1\/2、2\/2/);
+  assert.equal(h.options.memory.resources[0], resource);
+  assert.equal(
+    h.options.memory.ziweiPhaseReading?.phases.every((item) => item.status === 'succeeded'),
+    true,
+  );
+});
+
+test('紫微阶段空回答标记失败并可重试', async () => {
+  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const first = harness([]);
+  first.options.memory.resources = [resource];
+  first.options.subject = ziweiSubject;
+  let calls = 0;
+  const emptyStream: ReadingDependencies['stream'] = async (_messages, callbacks) => {
+    calls += 1;
+    callbacks.onDone();
+  };
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], first.options, {
+    stream: emptyStream,
+    execute: async () => resource,
+  });
+  assert.equal(calls, 1);
+  assert.deepEqual(first.errors, ['紫微阶段1/2返回空结果，请重试。']);
+  assert.equal(first.done(), 0);
+  assert.equal(first.options.memory.ziweiPhaseReading?.phases[0]?.status, 'failed');
+
+  const retry = harness(['第一阶段重试', '第二阶段重试', '重试汇总']);
+  retry.options.memory = first.options.memory;
+  retry.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], retry.options, {
+    stream: retry.stream,
+    execute: async () => resource,
+  });
+  assert.equal(retry.done(), 1);
+  assert.deepEqual(
+    retry.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'succeeded'],
+  );
+});
+
+test('紫微阶段归并空回答不形成全覆盖', async () => {
+  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  const h = harness([]);
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  let calls = 0;
+  const stream: ReadingDependencies['stream'] = async (_messages, callbacks) => {
+    calls += 1;
+    if (calls <= 2) callbacks.onChunk('答'.repeat(25_000));
+    callbacks.onDone();
+  };
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream,
+    execute: async () => resource,
+  });
+  assert.equal(calls, 3);
+  assert.ok(h.errors[0]?.includes('阶段归并'));
+  assert.equal(h.done(), 0);
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'succeeded'],
+  );
+});
+
+test('两份真实完整紫微盘超限时按主体分别分阶段并综合', async () => {
+  const primary = await makeCanonicalZiweiFullResource(
+    '甲主体',
+    'female',
+    { year: '1992', month: '8', day: '21' },
+    'ziwei-full-primary',
+  );
+  const partner = await makeCanonicalZiweiFullResource(
+    '乙主体',
+    'male',
+    { year: '1991', month: '3', day: '14' },
+    'ziwei-full-partner',
+  );
+  const h = harness([]);
+  h.options.memory.resources = [primary, partner];
+  h.options.subject = ziweiSubject;
+  await runReadingWorkflow([{ role: 'user', content: '紫微双主体原盘，问关系' }], h.options, {
+    stream: h.stream,
+    execute: async () => primary,
+  });
+  const phaseCount = h.options.memory.ziweiPhaseReading?.phases.length ?? 0;
+  assert.ok(phaseCount > 2);
+  assert.equal(h.sent.length, phaseCount + 1);
+  assert.ok(
+    h.sent.slice(0, phaseCount).some((batch) => batch[0]!.content.includes('主体：甲主体')),
+  );
+  assert.ok(
+    h.sent.slice(0, phaseCount).some((batch) => batch[0]!.content.includes('主体：乙主体')),
+  );
+  assert.ok(h.sent.at(-1)![0]!.content.includes('主体：甲主体'));
+  assert.ok(h.sent.at(-1)![0]!.content.includes('主体：乙主体'));
+  assert.ok(
+    h.options.memory.ziweiPhaseReading?.phases.every((item) => item.status === 'succeeded'),
+  );
+  assert.deepEqual(
+    new Set(h.options.memory.ziweiPhaseReading?.phases.map((item) => item.resourceKey)),
+    new Set([primary.key, partner.key]),
+  );
+  assert.equal(h.options.memory.resources.length, 2);
+});
+
+test('紫微双主体中途失败后重试只补失败主体阶段', async () => {
+  const primary = {
+    ...makeZiweiFullResource(2, 4000, '第一主体完整资料'.repeat(16_000)),
+    key: 'ziwei-full-primary',
+    title: '甲主体紫微完整运限资料',
+  };
+  const partner = {
+    ...makeZiweiFullResource(2, 4000, '第二主体完整资料'.repeat(16_000)),
+    key: 'ziwei-full-partner',
+    title: '乙主体紫微完整运限资料',
+  };
+  const h = harness([]);
+  h.options.memory.resources = [primary, partner];
+  h.options.subject = ziweiSubject;
+  const sent: ChatMessage[][] = [];
+  let calls = 0;
+  let fail = true;
+  const stream: ReadingDependencies['stream'] = async (messages, callbacks) => {
+    sent.push(messages);
+    calls += 1;
+    if (fail && calls === 3) {
+      callbacks.onError('乙主体阶段暂时失败');
+      return;
+    }
+    callbacks.onChunk(calls === 1 ? '甲主体阶段一成功' : '汇总成功');
+    callbacks.onDone();
+  };
+  const input = [{ role: 'user' as const, content: '紫微双主体原盘，问关系' }];
+  await runReadingWorkflow(input, h.options, { stream, execute: async () => primary });
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'succeeded', 'failed', 'pending'],
+  );
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.resourceKey),
+    [primary.key, primary.key, partner.key, partner.key],
+  );
+  assert.deepEqual(h.errors, ['乙主体阶段暂时失败']);
+  fail = false;
+  await runReadingWorkflow(input, h.options, { stream, execute: async () => primary });
+  assert.equal(calls, 6);
+  assert.ok(sent[3]![0]!.content.includes('主体：乙主体'));
+  assert.ok(sent[4]![0]!.content.includes('主体：乙主体'));
+  assert.ok(sent[5]![0]!.content.includes('主体：甲主体'));
+  assert.ok(sent[5]![0]!.content.includes('主体：乙主体'));
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'succeeded', 'succeeded', 'succeeded'],
+  );
+});
+
+test('紫微阶段失败后同问题重试只补失败阶段并保留成功阶段', async () => {
+  const h = harness([]);
+  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  const sent: ChatMessage[][] = [];
+  let calls = 0;
+  let fail = true;
+  const stream: ReadingDependencies['stream'] = async (messages, callbacks) => {
+    sent.push(messages);
+    calls += 1;
+    if (fail && calls === 2) {
+      callbacks.onError('阶段暂时失败');
+      return;
+    }
+    callbacks.onChunk(calls === 1 ? '第一阶段成功' : calls === 3 ? '第二阶段重试成功' : '最终汇总');
+    callbacks.onDone();
+  };
+  const input = [{ role: 'user' as const, content: '紫微完整原盘，问事业' }];
+  await runReadingWorkflow(input, h.options, { stream, execute: async () => resource });
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'failed'],
+  );
+  assert.deepEqual(h.errors, ['阶段暂时失败']);
+  fail = false;
+  await runReadingWorkflow(input, h.options, { stream, execute: async () => resource });
+  assert.equal(calls, 4);
+  assert.match(sent[2]![0]!.content, /阶段 2\/2/);
+  assert.doesNotMatch(sent[2]![0]!.content, /第一阶段成功/);
+  assert.deepEqual(
+    h.options.memory.ziweiPhaseReading?.phases.map((item) => item.status),
+    ['succeeded', 'succeeded'],
+  );
+});
+
+test('紫微阶段取消后换问题不会复用旧摘要', async () => {
+  const h = harness([]);
+  const resource = makeZiweiFullResource(2, 4000, '完整原始资料'.repeat(16000));
+  h.options.memory.resources = [resource];
+  h.options.subject = ziweiSubject;
+  const controller = new AbortController();
+  h.options.signal = controller.signal;
+  const cancelledStream: ReadingDependencies['stream'] = async (messages, callbacks) => {
+    void messages;
+    callbacks.onChunk('取消前摘要');
+    controller.abort();
+  };
+  await runReadingWorkflow([{ role: 'user', content: '紫微完整原盘，问事业' }], h.options, {
+    stream: cancelledStream,
+    execute: async () => resource,
+  });
+  assert.equal(h.options.memory.ziweiPhaseReading?.phases[0]?.status, 'cancelled');
+
+  const retry = harness(['新问题阶段一', '新问题阶段二', '新问题汇总']);
+  retry.options.memory = h.options.memory;
+  retry.options.subject = ziweiSubject;
+  await runReadingWorkflow(
+    [
+      { role: 'user', content: '紫微完整原盘，问事业' },
+      { role: 'assistant', content: '上一轮未完成' },
+      { role: 'user', content: '改问婚恋' },
+    ],
+    retry.options,
+    { stream: retry.stream, execute: async () => resource },
+  );
+  assert.equal(retry.sent.length, 3);
+  assert.ok(retry.sent.every((batch) => batch[0]!.content.includes('改问婚恋')));
+  assert.ok(retry.sent.every((batch) => !batch[0]!.content.includes('取消前摘要')));
+  assert.equal(retry.options.memory.ziweiPhaseReading?.question, '改问婚恋');
 });
 
 test('历史消息有余量时保留完整补充资料并按现有规则裁剪旧消息', async () => {

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -185,7 +185,6 @@ async function makeCanonicalZiweiFullResource(
   gender: 'male' | 'female',
   birth: { year: string; month: string; day: string },
   key: string,
-  oversized = true,
 ) {
   const input = buildZiweiChartInput({
     name,
@@ -208,9 +207,7 @@ async function makeCanonicalZiweiFullResource(
   return {
     key,
     title: `${name}紫微完整运限资料`,
-    text: oversized
-      ? `${name}原始完整资料`.repeat(16_000)
-      : formatPublicZiweiFullScopeText(runtime),
+    text: formatPublicZiweiFullScopeText(runtime),
     usable: true,
     structured: buildSerializableZiweiResult(runtime),
   } satisfies ReadingResource;
@@ -613,7 +610,6 @@ test('真实完整紫微规范正文未超限时进入最终stream', async () =>
     'female',
     { year: '1992', month: '8', day: '21' },
     'ziwei-full-real-text',
-    false,
   );
   h.options.memory.resources = [resource];
   h.options.subject = ziweiSubject;
@@ -726,7 +722,7 @@ test('紫微阶段归并空回答不形成全覆盖', async () => {
   );
 });
 
-test('两份真实完整紫微盘超限时按主体分别分阶段并综合', async () => {
+test('真实双人八字紫微全文自然超限时合并相邻运段且完整保留双方资料', async () => {
   const primary = await makeCanonicalZiweiFullResource(
     '甲主体',
     'female',
@@ -742,13 +738,46 @@ test('两份真实完整紫微盘超限时按主体分别分阶段并综合', as
   const h = harness([]);
   h.options.memory.resources = [primary, partner];
   h.options.subject = ziweiSubject;
-  await runReadingWorkflow([{ role: 'user', content: '紫微双主体原盘，问关系' }], h.options, {
+  const baziPrompts: string[] = [];
+  for (const person of [
+    { name: '甲主体', gender: 'female', year: 1992, month: 8, day: 21 },
+    { name: '乙主体', gender: 'male', year: 1991, month: 3, day: 14 },
+  ]) {
+    const response = await handlePublicApiRequest(
+      new Request('https://aov.cc/api/v1/bazi/prompt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...person,
+          dateType: 'solar',
+          timeIndex: 4,
+          timeZoneId: 'Asia/Shanghai',
+          baziFortuneScope: 'full',
+          responseMode: 'full',
+          question: '结合双方完整运限分析关系的发展阶段。',
+        }),
+      }),
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    baziPrompts.push(`【${person.name}八字资料】\n${body.data.prompt}`);
+  }
+  const initial = `${baziPrompts.join('\n\n')}\n\n【问题】结合双方完整运限分析关系的发展阶段。`;
+  assert.ok(initial.length < 49_000);
+  assert.ok(initial.length + primary.text.length + partner.text.length > 49_000);
+  assert.deepEqual(structuredClone([primary, partner]), [primary, partner]);
+  await runReadingWorkflow([{ role: 'user', content: initial }], h.options, {
     stream: h.stream,
     execute: async () => primary,
   });
   const phaseCount = h.options.memory.ziweiPhaseReading?.phases.length ?? 0;
-  assert.ok(phaseCount > 2);
+  assert.deepEqual(h.errors, []);
+  assert.equal(phaseCount, 2);
   assert.equal(h.sent.length, phaseCount + 1);
+  for (const batch of h.sent) {
+    assert.ok(batch.reduce((sum, message) => sum + message.content.length, 0) <= 49_000);
+    assert.equal(batch[0]!.content.split(initial).length - 1, 1);
+  }
   assert.ok(
     h.sent.slice(0, phaseCount).some((batch) => batch[0]!.content.includes('主体：甲主体')),
   );
@@ -885,8 +914,17 @@ test('紫微阶段取消后换问题不会复用旧摘要', async () => {
     { stream: retry.stream, execute: async () => resource },
   );
   assert.equal(retry.sent.length, 3);
-  assert.ok(retry.sent.every((batch) => batch[0]!.content.includes('改问婚恋')));
-  assert.ok(retry.sent.every((batch) => !batch[0]!.content.includes('取消前摘要')));
+  for (const batch of retry.sent) {
+    assert.deepEqual(batch.at(-1), { role: 'user', content: '改问婚恋' });
+    assert.equal(
+      batch
+        .map((message) => message.content)
+        .join('\n')
+        .split('改问婚恋').length - 1,
+      1,
+    );
+    assert.ok(batch.every((message) => !message.content.includes('取消前摘要')));
+  }
   assert.equal(retry.options.memory.ziweiPhaseReading?.question, '改问婚恋');
 });
 

--- a/tests/ziwei-fortune-range.test.ts
+++ b/tests/ziwei-fortune-range.test.ts
@@ -3,11 +3,15 @@ import assert from 'node:assert/strict';
 import {
   buildZiweiChartInput,
   buildSerializableZiweiResult,
+  calculatePublicZiweiChartForScopes,
   calculateZiweiChart,
   formatZiweiFortuneTimeline,
 } from 'mingyu-core/ziwei';
 import { buildPublicZiweiPromptForRuntime } from 'mingyu-core/prompt/public-api';
-import { formatZiweiTargetLowerScopeFacts } from '../packages/core/src/prompt/ziwei';
+import {
+  formatZiweiFortuneTimelinePhase,
+  formatZiweiTargetLowerScopeFacts,
+} from '../packages/core/src/prompt/ziwei';
 
 const input = buildZiweiChartInput({
   name: '范围回归样本',
@@ -158,6 +162,77 @@ test('紫微全部资料覆盖已验证的童限和大限流年，不伪造下�
   assert.match(text, /目标时辰：辰时/);
   assert.ok(text.length < 14_000, `全部运限段过长：${text.length}`);
   assert.equal((text.match(/流年[甲乙丙丁戊己庚辛壬癸]/g) ?? []).length, 125);
+});
+
+test('紫微阶段格式化覆盖真实完整时间线边界、交界流月和目标下层事实', async () => {
+  const runtime = await calculatePublicZiweiChartForScopes(
+    input,
+    ['decadal', 'yearly', 'monthly', 'daily', 'hourly'],
+    {
+      skipAnalysis: true,
+      horoscopeContext: fixedContext,
+      fortuneRange: { scope: 'all', ...fixedContext },
+    },
+  );
+  const timeline = runtime.fortuneTimeline;
+  assert.ok(timeline);
+  assert.ok(timeline.periods.length > 1);
+  const phaseTexts = timeline.periods.map((period, periodIndex) =>
+    formatZiweiFortuneTimelinePhase(
+      timeline,
+      [
+        {
+          periodIndex,
+          startYearIndex: 0,
+          endYearIndex: period.years.length - 1,
+        },
+      ],
+      periodIndex + 1,
+      timeline.periods.length,
+    ),
+  );
+  for (const [periodIndex, period] of timeline.periods.entries()) {
+    const text = phaseTexts[periodIndex]!;
+    assert.match(text, new RegExp(`${period.label}.*${period.dateStr}至${period.endDateStr}`));
+    for (const year of period.years) {
+      assert.ok(
+        text.includes(`${year.age}岁｜${year.label}｜${year.dateStr}至${year.endDateStr}`),
+        `${period.label} 缺少 ${year.label} 的完整边界`,
+      );
+    }
+  }
+
+  const lowerFacts = formatZiweiTargetLowerScopeFacts(runtime);
+  assert.match(lowerFacts, /目标日期下层资料：/);
+  assert.match(lowerFacts, /流月：2026-08-06/);
+  assert.match(lowerFacts, /流日：2026-08-06/);
+  assert.match(lowerFacts, /流时：2026-08-06/);
+
+  const exactInput = { ...input, horoscopeDivide: 'exact' as const, yearDivide: 'exact' as const };
+  const boundaryDate = { dateStr: '2027-02-04', hourIndex: 4 } as const;
+  const boundaryRuntime = await calculateZiweiChart(exactInput, {
+    scopes: ['origin', 'yearly'],
+    skipAnalysis: true,
+    horoscopeContext: boundaryDate,
+    fortuneRange: { scope: 'year', ...boundaryDate },
+  });
+  const boundaryTimeline = boundaryRuntime.fortuneTimeline;
+  assert.ok(boundaryTimeline);
+  const boundaryPeriod = boundaryTimeline.periods[0];
+  assert.ok(boundaryPeriod);
+  const boundaryText = formatZiweiFortuneTimelinePhase(
+    boundaryTimeline,
+    [
+      {
+        periodIndex: 0,
+        startYearIndex: 0,
+        endYearIndex: boundaryPeriod.years.length - 1,
+      },
+    ],
+    1,
+    1,
+  );
+  assert.match(boundaryText, /上一流年12月交界段 2027-02-04/);
 });
 
 test('紫微全部运限的编号表可逐年还原四化、宫位、流曜和年系事实', async () => {


### PR DESCRIPTION
长篇双人八字与紫微资料超出单次上下文时，按主体和相邻运段分阶段解读，再汇总已完成阶段；保留完整原始事实，失败或取消后可按同一问题重试未完成阶段。未超限的资料继续一次解读。

紫微完整资料由现有后台线程生成，历史会话按主体及资料范围恢复，资料加载失败时提供重试。避免将整段原始任务重复附加到每次请求。

验证：真实双人排盘样本共59,399字，分为2次阶段请求和1次汇总，请求分别为46,018、45,630和30,548字，均在49,000字容量以内；模型响应为模拟流式输出。整合批次类型检查、69项定向测试、1832项单元测试及代码格式检查通过。

整合批次153项公开API测试、65项MCP测试、提示词回归及生产构建全部通过；真实预览已验证后台资料加载、首次发送、刷新后的历史恢复与追问，以及模拟后台首次失败后的真实重算恢复；320px页面无横向溢出。浏览器回答被拦截模拟，未调用外部模型。失败时重复提示的文案问题在后续住宅整合批次修正。


