### PR TITLE
保留成功补算资料并完善失败重试和取消处理

### DIFF
--- a/src/lib/ai/android-custom-ai.ts
+++ b/src/lib/ai/android-custom-ai.ts
@@ -89,6 +89,7 @@ export async function streamAndroidDirectAi(
   aiConfig: AiRequestConfig,
   callbacks: DirectStreamCallbacks,
   signal?: AbortSignal,
+  plugin: AndroidDirectAiPlugin = AndroidDirectAi,
 ): Promise<void> {
   const config = normalizeAndroidDirectAiConfig(aiConfig);
   const requestId = createRequestId();
@@ -109,11 +110,11 @@ export async function streamAndroidDirectAi(
   };
 
   const handleAbort = () => {
-    void AndroidDirectAi.cancelStream({ requestId }).catch(() => undefined);
+    void plugin.cancelStream({ requestId }).catch(() => undefined);
     finish();
   };
 
-  listener = await AndroidDirectAi.addListener('streamEvent', (event) => {
+  listener = await plugin.addListener('streamEvent', (event) => {
     if (settled || event.requestId !== requestId) return;
     if (event.type === 'chunk') {
       if (event.content) {
@@ -142,13 +143,23 @@ export async function streamAndroidDirectAi(
   signal?.addEventListener('abort', handleAbort, { once: true });
 
   try {
-    await AndroidDirectAi.streamChat({ requestId, ...config, messages });
+    await plugin.streamChat({ requestId, ...config, messages });
   } catch (error) {
+    if (settled || signal?.aborted || isAbortError(error)) {
+      finish();
+      return completion;
+    }
     callbacks.onError(formatNativeError(error, '无法从当前设备直连自定义 AI。'));
     finish();
   }
 
   return completion;
+}
+
+function isAbortError(error: unknown): boolean {
+  return Boolean(
+    error && typeof error === 'object' && 'name' in error && error.name === 'AbortError',
+  );
 }
 
 export async function fetchAndroidDirectAiModels(aiConfig: AiRequestConfig): Promise<string[]> {

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -889,7 +889,11 @@ export async function runReadingWorkflow(
   const mismatchedMethodNotice = options.subject
     ? '已跳过与当前命盘类型不符的补充资料。'
     : '已跳过与当前术式不符的补充资料。';
-  const resources = storedResources.filter((item) => !isSchemaResource(item));
+  const resources = storedResources.filter((item) => !isSchemaResource(item) && item.usable);
+  const persistResources = () => {
+    options.memory.resources = [...resources];
+    options.memory.schemas = [...schemaResources];
+  };
   const seen = new Set([...resources, ...schemaResources].map((item) => item.key));
   const notes: string[] = [];
   let calls = 0;
@@ -973,18 +977,25 @@ export async function runReadingWorkflow(
         });
         try {
           const resource = await deps.execute(action, options.signal, options.subject);
-          guard();
           if (action.kind === 'schema') {
             schemaResources.push({ ...resource, key, kind: 'schema' });
+            persistResources();
+            guard();
             continue;
           }
           if (action.kind === 'classic' && !resource.usable) {
+            seen.delete(key);
+            guard();
             needsRefinement = true;
             notes.push(describeReadingFailure(action, new Error('未命中')));
             options.onNotice(`“${action.query}”未查到对应条文，已保留原有盘面资料。`);
+            continue;
           }
           resources.push({ ...resource, key, kind: 'evidence' });
+          persistResources();
+          guard();
         } catch (error) {
+          seen.delete(key);
           guard();
           notes.push(describeReadingFailure(action, error));
           options.onNotice('部分补充资料暂未取得，将依据已有资料继续解读。');
@@ -995,8 +1006,7 @@ export async function runReadingWorkflow(
         break;
     }
     guard();
-    options.memory.resources = resources;
-    options.memory.schemas = schemaResources;
+    persistResources();
     const finalResources = resources.filter((item) => item.usable);
     const getFinalStatusNotes = (omitted: ReadingResource[]) => {
       const capacityNote = formatCapacityNotice('本轮解读', omitted).trim();

--- a/src/lib/ai/stream-client.ts
+++ b/src/lib/ai/stream-client.ts
@@ -56,7 +56,7 @@ export async function streamAiChat(messages: ChatMessage[], options: StreamOptio
     try {
       await streamAndroidDirectAi(messages, aiConfig, { onChunk, onDone, onError }, signal);
     } catch (error) {
-      if (isAbortError(error)) return;
+      if (isAbortError(error) || signal?.aborted) return;
       onError(error instanceof Error ? error.message : '无法从当前设备直连自定义 AI。');
     }
     return;

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -363,6 +363,149 @@ test('查询失败保留盘面且明确说明', async () => {
   assert.equal(h.done(), 1);
 });
 
+test('补算成功后后续资料准备失败仍保留已取得资料', async () => {
+  const memory: ReadingMemory = { resources: [] };
+  const errors: string[] = [];
+  const executed: string[] = [];
+  let planningCalls = 0;
+  const options: ReadingOptions = {
+    memory,
+    subject: baziSubject,
+    onProgress: () => {},
+    onNotice: () => {},
+    onError: (message) => errors.push(message),
+    onChunk: () => {},
+    onDone: () => {},
+  };
+  const stream: ReadingDependencies['stream'] = async (_messages, callbacks) => {
+    planningCalls += 1;
+    if (planningCalls === 1) {
+      callbacks.onChunk(
+        JSON.stringify({
+          actions: [
+            { kind: 'schema', method: 'bazi' },
+            { kind: 'calculate', method: 'bazi', input: { year: 1990 } },
+          ],
+        }),
+      );
+      callbacks.onDone();
+      return;
+    }
+    callbacks.onError('后续准备失败');
+  };
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], options, {
+    stream,
+    execute: async (action) => {
+      executed.push(action.kind);
+      return action.kind === 'schema'
+        ? { key: '', title: '八字参数', text: '参数格式', usable: false }
+        : { key: '', title: '目标流年', text: '补算事实', usable: true };
+    },
+  });
+
+  assert.deepEqual(executed, ['schema', 'calculate']);
+  assert.equal(memory.resources[0]?.text, '补算事实');
+  assert.equal(memory.schemas?.[0]?.text, '参数格式');
+  assert.deepEqual(errors, ['后续准备失败']);
+});
+
+test('补算返回后立即取消仍保留成功资料', async () => {
+  const controller = new AbortController();
+  const schema: ReadingResource = {
+    key: JSON.stringify({ kind: 'schema', method: 'bazi' }),
+    title: '八字参数',
+    text: '参数格式',
+    usable: false,
+    kind: 'schema',
+  };
+  const memory: ReadingMemory = { resources: [], schemas: [schema] };
+  const errors: string[] = [];
+  const options: ReadingOptions = {
+    memory,
+    subject: baziSubject,
+    signal: controller.signal,
+    onProgress: () => {},
+    onNotice: () => {},
+    onError: (message) => errors.push(message),
+    onChunk: () => {},
+    onDone: () => {},
+  };
+  const stream: ReadingDependencies['stream'] = async (_messages, callbacks) => {
+    callbacks.onChunk(
+      JSON.stringify({
+        actions: [{ kind: 'calculate', method: 'bazi', input: { year: 1990 } }],
+      }),
+    );
+    callbacks.onDone();
+  };
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], options, {
+    stream,
+    execute: async () => {
+      controller.abort();
+      return { key: '', title: '目标流年', text: '取消前已取得', usable: true };
+    },
+  });
+
+  assert.equal(memory.resources[0]?.text, '取消前已取得');
+  assert.deepEqual(errors, []);
+});
+
+test('未命中的古籍查询不会占用已见键并可在下一轮重试', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"schema","method":"bazi"},{"kind":"classic","method":"bazi","query":"不存在的条文"}]}',
+    '{"actions":[{"kind":"classic","method":"bazi","query":"不存在的条文"}]}',
+    '重试后的解读',
+  ]);
+  h.options.memory.resources = [
+    {
+      key: JSON.stringify({ kind: 'classic', method: 'bazi', query: '不存在的条文' }),
+      title: '历史未命中条文',
+      text: '',
+      usable: false,
+    },
+  ];
+  let attempts = 0;
+  await runReadingWorkflow([{ role: 'user', content: '八字原始资料' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => {
+      if (action.kind === 'schema')
+        return { key: '', title: '八字参数', text: '参数格式', usable: false };
+      attempts += 1;
+      return attempts === 1
+        ? { key: '', title: '未命中条文', text: '', usable: false }
+        : { key: '', title: '补充条文', text: '甲木参天', usable: true };
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.equal(h.options.memory.resources.length, 1);
+  assert.equal(h.options.memory.resources[0]?.text, '甲木参天');
+  assert.deepEqual(h.chunks, ['重试后的解读']);
+});
+
+test('失败的古籍查询不会占用已见键并可在下一轮重试', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"schema","method":"bazi"},{"kind":"classic","method":"bazi","query":"甲木"}]}',
+    '{"actions":[{"kind":"classic","method":"bazi","query":"甲木"}]}',
+    '失败后重试的解读',
+  ]);
+  let attempts = 0;
+  await runReadingWorkflow([{ role: 'user', content: '八字原始资料' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => {
+      if (action.kind === 'schema')
+        return { key: '', title: '八字参数', text: '参数格式', usable: false };
+      attempts += 1;
+      if (attempts === 1) throw new Error('条文服务暂时失败');
+      return { key: '', title: '补充条文', text: '甲木参天', usable: true };
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.equal(h.options.memory.resources[0]?.text, '甲木参天');
+  assert.deepEqual(h.chunks, ['失败后重试的解读']);
+});
+
 test('取消准备后不执行补查或最终解读，也不写入其他会话资料', async () => {
   const h = harness([]),
     controller = new AbortController();

--- a/tests/android-custom-ai.test.ts
+++ b/tests/android-custom-ai.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   isAndroidDirectCustomAi,
   normalizeAndroidDirectAiConfig,
+  streamAndroidDirectAi,
 } from '../src/lib/ai/android-custom-ai';
 
 test('Android 自定义 AI 应选择设备直连，内置 AI 仍走服务端', () => {
@@ -63,4 +64,65 @@ test('Android 自定义 AI 直连应拒绝不安全地址和缺失配置', () =>
       }),
     /接口、密钥和模型/,
   );
+});
+
+test('Android 直连取消后底层普通拒绝不触发失败回调', async () => {
+  let started!: () => void;
+  const streamStarted = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  let rejectStream!: (error: unknown) => void;
+  let cancelCalls = 0;
+  const plugin = {
+    addListener: async (
+      _eventName: 'streamEvent',
+      _listener: (event: {
+        requestId: string;
+        type: 'chunk' | 'done' | 'error';
+        content?: string;
+        message?: string;
+      }) => void,
+    ) => ({ remove: async () => {} }),
+    cancelStream: async (_options: { requestId: string }) => {
+      cancelCalls += 1;
+    },
+    streamChat: async (_options: {
+      requestId: string;
+      apiKey: string;
+      baseUrl: string;
+      model: string;
+      messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+    }) => {
+      started();
+      await new Promise<void>((_resolve, reject) => {
+        rejectStream = reject;
+      });
+    },
+    fetchModels: async (_options: { apiKey: string; baseUrl: string }) => ({ models: [] }),
+  };
+  const controller = new AbortController();
+  const errors: string[] = [];
+  const request = streamAndroidDirectAi(
+    [{ role: 'user', content: '测试问题' }],
+    {
+      mode: 'custom',
+      apiKey: 'test-key',
+      baseUrl: 'https://api.example.com/v1',
+      model: 'test-model',
+    },
+    {
+      onChunk: () => {},
+      onDone: () => {},
+      onError: (message) => errors.push(message),
+    },
+    controller.signal,
+    plugin,
+  );
+  await streamStarted;
+  controller.abort();
+  rejectStream(new Error('请求已取消'));
+  await request;
+
+  assert.equal(cancelCalls, 1);
+  assert.deepEqual(errors, []);
 });


### PR DESCRIPTION
AI连续补算过程中，已成功取得的资料现在会立即保存，后续准备失败或取消后可继续复用。古籍未命中和查询失败会释放重试记录，避免追问时永久跳过未取得的资料。

Android自定义AI取消请求后，底层延迟返回的普通错误不再触发失败提示。

验证：整合批次类型检查、69项定向测试、1832项单元测试及代码格式检查通过；包含补算后失败、取消、未命中重试和Android桥接延迟错误回归。Android桥接使用测试替身，未进行真机验证。整合批次153项API测试、65项MCP测试、提示词回归与生产构建也已通过。

