### PR TITLE
接通五运六气年度排盘与AI解读入口

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -97,7 +97,7 @@
 6. 用户要从日期范围里选日子，调用 `almanac_prompt`；日期范围或参与人较多时使用分页参数。
 7. 用户提供一人的西方占星资料时调用 `astrolabe_prompt`；提供双方完整资料并询问关系时调用 `astrolabe_synastry_prompt`。
 8. 用户没有出生信息，只想要轻量启发、牌阵或签文时，用 `tarot_prompt`、`lenormand_prompt` 或 `ssgw_prompt`。
-9. 用户明确要求八宅、生肖犯太岁、太乙或七政四余时，使用对应的 `*_prompt` 工具；只要原始排盘则使用 `metaphysics_*`。
+9. 用户明确要求八宅、生肖犯太岁、太乙、五运六气、皇极经世或七政四余时，使用对应的 `*_prompt` 工具；只要原始排盘则使用 `metaphysics_*`。
 
 常见问题到工具：
 
@@ -124,6 +124,8 @@
 | 牌阵启发                         | `tarot_prompt`                 | `spreadType`、`question`                                                 |
 | 雷诺曼关系或选择牌阵             | `lenormand_prompt`             | `spreadType`、`question`                                                 |
 | 求签                             | `ssgw_prompt`                  | `question`                                                               |
+| 年度气候节律、司天在泉           | `wuyun_liuqi_prompt`           | `year` 或 `yearGanZhi`、`question`                                      |
+| 皇极经世宏观周期、值年卦          | `huangji_jingshi_prompt`       | `customDate` 或 `year` / `epochYear` / `elapsedYears`、`question`        |
 
 出生时辰未知时，不要自行补时辰。八字可以保守分析；紫微和八字紫微合参需要时辰，优先请用户补足后再调用。
 
@@ -254,7 +256,7 @@ pnpm mcp
 
 六爻、梅花易数、小六壬、金口诀、奇门遁甲、大六壬以及太乙月、日、时计默认使用当前时间。需要复盘历史时刻、按用户指定时间起卦，或让本地 MCP 与网页端自定时间保持一致时，传入 `customDate`。皇极经世可用 `customDate` 固定年月日时，五运六气应明确目标 `year` 或 `yearGanZhi`；这些资料按目标时点或年度解读，不作为出生本命。金口诀还可用 `jinkoujueMethod: "branch"` 与 `jinkoujueBranch` 直接指定地分。
 
-`customDate` 必须是带时区的 ISO 8601 时间字符串，例如 `2025-01-01T08:30:00+08:00`。适用工具包括 `divine_liuyao`、`liuyao_prompt`、`divine_meihua`、`meihua_prompt`、`divine_xiaoliuren`、`xiaoliuren_prompt`、`divine_jinkoujue`、`jinkoujue_prompt`、`divine_qimen`、`qimen_prompt`、`divine_liuren`、`liuren_prompt`、`metaphysics_taiyi` 和 `taiyi_prompt`（后三计）。
+`customDate` 必须是带时区的 ISO 8601 时间字符串，例如 `2025-01-01T08:30:00+08:00`。适用工具包括 `divine_liuyao`、`liuyao_prompt`、`divine_meihua`、`meihua_prompt`、`divine_xiaoliuren`、`xiaoliuren_prompt`、`divine_jinkoujue`、`jinkoujue_prompt`、`divine_qimen`、`qimen_prompt`、`divine_liuren`、`liuren_prompt`、`metaphysics_taiyi`、`taiyi_prompt`、`metaphysics_huangji_jingshi` 和 `huangji_jingshi_prompt`。
 
 ### 黄历择日参数
 

--- a/packages/core/src/divination/config.ts
+++ b/packages/core/src/divination/config.ts
@@ -31,6 +31,7 @@ export type DivinationMethodId =
       | 'astrolabe'
       | 'taiyi'
       | 'huangji'
+      | 'wuyun'
     >;
 
 export const DIVINATION_METHOD_OPTIONS: Array<{
@@ -77,6 +78,11 @@ export const DIVINATION_METHOD_OPTIONS: Array<{
     value: 'huangji',
     label: '皇极经世',
     description: '由元会运世逐层推至值年、月经、旬纬、日卦与时经卦。',
+  },
+  {
+    value: 'wuyun',
+    label: '五运六气',
+    description: '按目标年度推演岁运、五步主客运与六步主客气的年度节律。',
   },
   {
     value: 'ssgw',

--- a/packages/core/src/divination/engine/method-text.ts
+++ b/packages/core/src/divination/engine/method-text.ts
@@ -23,6 +23,7 @@ function getPromptMethod(method: Exclude<DivinationMethodId, 'random'>, data?: D
   if (method === 'huangji' && data && !(data as HuangjiJingshiResult).forecast) {
     return 'huangji-cycle';
   }
+  if (method === 'wuyun') return 'wuyun-liuqi';
   return method;
 }
 
@@ -58,6 +59,8 @@ function buildMethodTaskText(method: Exclude<DivinationMethodId, 'random'>, data
       return !data || (data as HuangjiJingshiResult).forecast
         ? '依据元会运世位置、会内统卦、运卦、六十年统卦、十年卦、值年卦以及月经、旬纬、日卦和时经卦回答【问题】。'
         : '依据元会运世周期资料回答【问题】，说明目标年在周期层级中的位置、当前进度与下一周期边界。';
+    case 'wuyun':
+      return '依据岁运、司天在泉、五步主客运、六步主客气、符会与年度病机资料回答【问题】。';
     default:
       return '请结合占卜信息回答【问题】。';
   }

--- a/packages/core/src/divination/session.ts
+++ b/packages/core/src/divination/session.ts
@@ -245,7 +245,6 @@ const RANDOM_METHODS: DivinationSessionMethod[] = [
   'qimen',
   'liuren',
   'taiyi',
-  'wuyun',
   'tarot',
   'ssgw',
   'lenormand',

--- a/packages/core/src/divination/session.ts
+++ b/packages/core/src/divination/session.ts
@@ -11,6 +11,7 @@ import { drawRandomSign, resolveSignByNumber } from './algorithms/ssgw';
 import { generateXiaoliuren } from './algorithms/xiaoliuren';
 import { generateTaiyi } from '../taiyi/index';
 import { calculateHuangjiJingshi, type HuangjiJingshiResult } from '../huangji-jingshi';
+import { calculateWuyunLiuqi } from '../wuyun-liuqi';
 import { calculateZhugeNumber, castKongmingHexagram } from '../name-number/oracles';
 import { drawTarotSpread, type TarotDrawOptions, type TarotManualCardInput } from './tarot';
 import { isEarthlyBranch } from '../ganzhi';
@@ -53,6 +54,7 @@ import type {
   TarotSpreadType,
   TaiyiResult,
   TaiyiScope,
+  WuyunLiuqiResult,
   XiaoliurenDivinationMethod,
 } from '../types/divination';
 
@@ -108,6 +110,8 @@ export interface DivinationRequest {
   taiyi?: { year?: number; scope?: TaiyiScope };
   /** 皇极经世兼容值年输入；省略 year 时按 divinationTime（未填则当前时间）排年月日时卦。 */
   huangji?: { year?: number };
+  /** 五运六气年度输入；省略时按当前北京时间所在公历年计算。 */
+  wuyun?: { year?: number; yearGanZhi?: string };
   prompt?: Omit<DivinationPromptOptions, 'method' | 'data' | 'question' | 'currentTime'>;
 }
 
@@ -221,6 +225,14 @@ function formatAiChart(
       `宫位：${item.houses.map((point) => `第${point.house}宫宫头${point.formatted}`).join('；')}`,
       `相位：${item.aspects.map((aspect) => `${aspect.body1}${aspect.symbol}${aspect.body2}，容许度${aspect.orb.toFixed(2)}°`).join('；') || '无'}`,
     );
+  } else if (method === 'wuyun') {
+    const item = data as WuyunLiuqiResult;
+    base.push(
+      `年度资料：${item.input.year === undefined ? '' : `${item.input.year}年`}${item.input.yearGanZhi}；岁运${item.annualMovement.name}${item.annualMovement.toneName}${item.annualMovement.strength}；司天${item.sitian.name}；在泉${item.zaiquan.name}`,
+      `五步主客运：${item.movementSteps.map((step) => `${step.label}${step.hostMovement.element}/${step.guestMovement.element}（${step.hostGuestRelation.kind}）`).join('；')}`,
+      `六步主客气：${item.qiSteps.map((step) => `${step.label}${step.hostQi.name}/${step.guestQi.name}（${step.hostGuestRelation.kind}）`).join('；')}`,
+      item.pathomechanism?.summary ?? '',
+    );
   }
   return base.join('\n');
 }
@@ -233,6 +245,7 @@ const RANDOM_METHODS: DivinationSessionMethod[] = [
   'qimen',
   'liuren',
   'taiyi',
+  'wuyun',
   'tarot',
   'ssgw',
   'lenormand',
@@ -365,6 +378,27 @@ export function validateDivinationRequest(request: DivinationRequest): void {
       throw new Error('皇极经世年份与年月日时起盘时间不能同时提供。');
     }
   }
+  if (request.method === 'wuyun' && request.wuyun) {
+    const { year, yearGanZhi } = request.wuyun;
+    if (year === undefined && yearGanZhi === undefined) {
+      throw new Error('五运六气需要提供 year 或 yearGanZhi。');
+    }
+    if (year !== undefined && (!Number.isSafeInteger(year) || year < 1 || year > 9999)) {
+      throw new Error('五运六气年份必须是 1-9999 之间的整数。');
+    }
+    if (yearGanZhi !== undefined && typeof yearGanZhi !== 'string') {
+      throw new Error('五运六气 yearGanZhi 必须是有效年干支。');
+    }
+  }
+}
+
+function resolveCurrentCivilYear() {
+  return Number(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: 'Asia/Shanghai',
+      year: 'numeric',
+    }).format(new Date()),
+  );
 }
 
 function generateData(
@@ -463,6 +497,13 @@ function generateData(
               date: customDate ?? new Date(),
               question: request.question?.trim(),
             },
+      );
+    case 'wuyun':
+      return calculateWuyunLiuqi(
+        request.wuyun &&
+          (request.wuyun.year !== undefined || request.wuyun.yearGanZhi !== undefined)
+          ? request.wuyun
+          : { year: resolveCurrentCivilYear() },
       );
   }
 }

--- a/packages/core/src/divination/session.ts
+++ b/packages/core/src/divination/session.ts
@@ -1,3 +1,4 @@
+import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 import type { DivinationMethodId } from './config';
 import { generateAlmanacSelection } from './algorithms/almanac';
 import { generateAstrolabe } from './algorithms/astrolabe';
@@ -54,7 +55,6 @@ import type {
   TarotSpreadType,
   TaiyiResult,
   TaiyiScope,
-  WuyunLiuqiResult,
   XiaoliurenDivinationMethod,
 } from '../types/divination';
 

--- a/packages/core/src/prompt/divination-detail.ts
+++ b/packages/core/src/prompt/divination-detail.ts
@@ -19,6 +19,7 @@ import type {
 import { formatAstrolabeForPrompt } from './astrolabe';
 import { formatDivinationInfo } from './divination';
 import type { HuangjiJingshiResult } from '../huangji-jingshi';
+import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 import { formatHuangjiCivilYear } from '../huangji-jingshi/standard';
 import { formatAlmanacGods } from '../divination/almanac-evidence';
 
@@ -267,6 +268,28 @@ function formatHuangjiDetail(data: HuangjiJingshiResult) {
   ];
 }
 
+function formatWuyunDetail(data: WuyunLiuqiResult) {
+  return [
+    `年干支：${data.input.yearGanZhi}${data.input.year === undefined ? '' : `（公历${data.input.year}年）`}`,
+    `岁运：${data.annualMovement.name}${data.annualMovement.toneName}${data.annualMovement.strength}；司天${data.sitian.name}；在泉${data.zaiquan.name}`,
+    `年度关系：${data.annualRelation.kind}；司天化令${data.annualClassification.sitianTransformation}；${data.annualClassification.governance}`,
+    `年度符会：${data.annualConformities.names.join('、') || '未形成五类符会'}`,
+    `五步主客运：${data.movementSteps
+      .map(
+        (item) =>
+          `${item.label}${item.gregorianStart && item.gregorianEnd ? `（${item.gregorianStart}至${item.gregorianEnd}）` : ''}主${item.hostMovement.toneName}${item.hostMovement.element}客${item.guestMovement.toneName}${item.guestMovement.element}${item.hostGuestRelation.kind}`,
+      )
+      .join('；')}`,
+    `六步主客气：${data.qiSteps
+      .map(
+        (item) =>
+          `${item.label}${item.gregorianStart && item.gregorianEnd ? `（${item.gregorianStart}至${item.gregorianEnd}）` : ''}主${item.hostQi.name}客${item.guestQi.name}${item.hostGuestRelation.kind}`,
+      )
+      .join('；')}`,
+    data.pathomechanism?.summary ?? '',
+  ].filter(Boolean);
+}
+
 /** 输出比摘要更完整的、可直接拼入任务书的占法资料。 */
 export function formatDetailedDivinationInfo(method: SupportedMethod, data: DivinationData) {
   const detail = (() => {
@@ -297,6 +320,8 @@ export function formatDetailedDivinationInfo(method: SupportedMethod, data: Divi
         return formatTaiyiDetail(data as TaiyiResult);
       case 'huangji':
         return formatHuangjiDetail(data as HuangjiJingshiResult);
+      case 'wuyun':
+        return formatWuyunDetail(data as WuyunLiuqiResult);
       default:
         return [];
     }

--- a/packages/core/src/prompt/divination-detail.ts
+++ b/packages/core/src/prompt/divination-detail.ts
@@ -19,7 +19,6 @@ import type {
 import { formatAstrolabeForPrompt } from './astrolabe';
 import { formatDivinationInfo } from './divination';
 import type { HuangjiJingshiResult } from '../huangji-jingshi';
-import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 import { formatHuangjiCivilYear } from '../huangji-jingshi/standard';
 import { formatAlmanacGods } from '../divination/almanac-evidence';
 
@@ -268,30 +267,9 @@ function formatHuangjiDetail(data: HuangjiJingshiResult) {
   ];
 }
 
-function formatWuyunDetail(data: WuyunLiuqiResult) {
-  return [
-    `年干支：${data.input.yearGanZhi}${data.input.year === undefined ? '' : `（公历${data.input.year}年）`}`,
-    `岁运：${data.annualMovement.name}${data.annualMovement.toneName}${data.annualMovement.strength}；司天${data.sitian.name}；在泉${data.zaiquan.name}`,
-    `年度关系：${data.annualRelation.kind}；司天化令${data.annualClassification.sitianTransformation}；${data.annualClassification.governance}`,
-    `年度符会：${data.annualConformities.names.join('、') || '未形成五类符会'}`,
-    `五步主客运：${data.movementSteps
-      .map(
-        (item) =>
-          `${item.label}${item.gregorianStart && item.gregorianEnd ? `（${item.gregorianStart}至${item.gregorianEnd}）` : ''}主${item.hostMovement.toneName}${item.hostMovement.element}客${item.guestMovement.toneName}${item.guestMovement.element}${item.hostGuestRelation.kind}`,
-      )
-      .join('；')}`,
-    `六步主客气：${data.qiSteps
-      .map(
-        (item) =>
-          `${item.label}${item.gregorianStart && item.gregorianEnd ? `（${item.gregorianStart}至${item.gregorianEnd}）` : ''}主${item.hostQi.name}客${item.guestQi.name}${item.hostGuestRelation.kind}`,
-      )
-      .join('；')}`,
-    data.pathomechanism?.summary ?? '',
-  ].filter(Boolean);
-}
-
 /** 输出比摘要更完整的、可直接拼入任务书的占法资料。 */
 export function formatDetailedDivinationInfo(method: SupportedMethod, data: DivinationData) {
+  if (method === 'wuyun') return formatDivinationInfo(method, data);
   const detail = (() => {
     switch (method) {
       case 'liuyao':
@@ -320,8 +298,6 @@ export function formatDetailedDivinationInfo(method: SupportedMethod, data: Divi
         return formatTaiyiDetail(data as TaiyiResult);
       case 'huangji':
         return formatHuangjiDetail(data as HuangjiJingshiResult);
-      case 'wuyun':
-        return formatWuyunDetail(data as WuyunLiuqiResult);
       default:
         return [];
     }

--- a/packages/core/src/prompt/divination-enhanced.ts
+++ b/packages/core/src/prompt/divination-enhanced.ts
@@ -1,3 +1,4 @@
+import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 import { formatWuyunLiuqiFacts } from '../wuyun-liuqi';
 import { formatAstrolabeForPrompt } from './astrolabe';
 import { formatLiurenLesson, formatLiurenTransmission } from './liuren-facts';
@@ -17,7 +18,6 @@ import type {
   SupplementaryInfo,
   TarotData,
   TaiyiResult,
-  WuyunLiuqiResult,
   XiaoliurenData,
   JinkoujueData,
 } from '../types/divination';

--- a/packages/core/src/prompt/divination-enhanced.ts
+++ b/packages/core/src/prompt/divination-enhanced.ts
@@ -16,6 +16,7 @@ import type {
   SupplementaryInfo,
   TarotData,
   TaiyiResult,
+  WuyunLiuqiResult,
   XiaoliurenData,
   JinkoujueData,
 } from '../types/divination';
@@ -1134,6 +1135,39 @@ export function formatTaiyiInfo(data: TaiyiResult) {
     .join('\n');
 }
 
+export function formatWuyunLiuqiInfo(data: WuyunLiuqiResult) {
+  const targetYear = data.input.year === undefined ? '' : `公历${data.input.year}年`;
+  const movementLines = data.movementSteps.map((step) => {
+    const dates =
+      step.gregorianStart && step.gregorianEnd
+        ? `，${step.gregorianStart}至${step.gregorianEnd}`
+        : '';
+    return `${step.label}${dates}：主运${step.hostMovement.toneName}${step.hostMovement.element}；客运${step.guestMovement.toneName}${step.guestMovement.element}；${step.hostGuestRelation.kind}`;
+  });
+  const qiLines = data.qiSteps.map((step) => {
+    const dates =
+      step.gregorianStart && step.gregorianEnd
+        ? `，${step.gregorianStart}至${step.gregorianEnd}`
+        : '';
+    return `${step.label}${dates}：主气${step.hostQi.name}；客气${step.guestQi.name}；${step.hostGuestRelation.kind}`;
+  });
+  return [
+    '占法：五运六气',
+    `目标年度：${targetYear}${data.input.yearGanZhi}（${data.input.yearGanZhiSource}）`,
+    `岁运：${data.annualMovement.name}（${data.annualMovement.toneName}，${data.annualMovement.strength}）`,
+    `司天：${data.sitian.name}；在泉：${data.zaiquan.name}`,
+    `司天化令：${data.annualClassification.sitianTransformation}；${data.annualClassification.governance}；中运与司天为${data.annualRelation.kind}`,
+    `年度符会：${data.annualConformities.names.length ? data.annualConformities.names.join('、') : '未形成五类符会'}`,
+    data.pathomechanism?.summary ?? '',
+    '五步主客运：',
+    ...movementLines,
+    '六步主客气：',
+    ...qiLines,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
 export function formatHuangjiInfo(data: HuangjiJingshiResult) {
   const forecast = data.forecast;
   if (!forecast) {
@@ -1228,6 +1262,8 @@ export function formatEnhancedDivinationInfo(
       return formatTaiyiInfo(data as TaiyiResult);
     case 'huangji':
       return formatHuangjiInfo(data as HuangjiJingshiResult);
+    case 'wuyun':
+      return formatWuyunLiuqiInfo(data as WuyunLiuqiResult);
     default:
       return '占卜信息暂不可用';
   }

--- a/packages/core/src/prompt/divination-enhanced.ts
+++ b/packages/core/src/prompt/divination-enhanced.ts
@@ -1,3 +1,4 @@
+import { formatWuyunLiuqiFacts } from '../wuyun-liuqi';
 import { formatAstrolabeForPrompt } from './astrolabe';
 import { formatLiurenLesson, formatLiurenTransmission } from './liuren-facts';
 import { formatMeihuaFacts } from './meihua-facts';
@@ -1136,36 +1137,7 @@ export function formatTaiyiInfo(data: TaiyiResult) {
 }
 
 export function formatWuyunLiuqiInfo(data: WuyunLiuqiResult) {
-  const targetYear = data.input.year === undefined ? '' : `公历${data.input.year}年`;
-  const movementLines = data.movementSteps.map((step) => {
-    const dates =
-      step.gregorianStart && step.gregorianEnd
-        ? `，${step.gregorianStart}至${step.gregorianEnd}`
-        : '';
-    return `${step.label}${dates}：主运${step.hostMovement.toneName}${step.hostMovement.element}；客运${step.guestMovement.toneName}${step.guestMovement.element}；${step.hostGuestRelation.kind}`;
-  });
-  const qiLines = data.qiSteps.map((step) => {
-    const dates =
-      step.gregorianStart && step.gregorianEnd
-        ? `，${step.gregorianStart}至${step.gregorianEnd}`
-        : '';
-    return `${step.label}${dates}：主气${step.hostQi.name}；客气${step.guestQi.name}；${step.hostGuestRelation.kind}`;
-  });
-  return [
-    '占法：五运六气',
-    `目标年度：${targetYear}${data.input.yearGanZhi}（${data.input.yearGanZhiSource}）`,
-    `岁运：${data.annualMovement.name}（${data.annualMovement.toneName}，${data.annualMovement.strength}）`,
-    `司天：${data.sitian.name}；在泉：${data.zaiquan.name}`,
-    `司天化令：${data.annualClassification.sitianTransformation}；${data.annualClassification.governance}；中运与司天为${data.annualRelation.kind}`,
-    `年度符会：${data.annualConformities.names.length ? data.annualConformities.names.join('、') : '未形成五类符会'}`,
-    data.pathomechanism?.summary ?? '',
-    '五步主客运：',
-    ...movementLines,
-    '六步主客气：',
-    ...qiLines,
-  ]
-    .filter(Boolean)
-    .join('\n');
+  return `占法：五运六气\n${formatWuyunLiuqiFacts(data)}`;
 }
 
 export function formatHuangjiInfo(data: HuangjiJingshiResult) {

--- a/packages/core/src/prompt/divination.ts
+++ b/packages/core/src/prompt/divination.ts
@@ -24,6 +24,7 @@ import type {
   QimenData,
   SsgwData,
   TaiyiResult,
+  WuyunLiuqiResult,
   TarotData,
   XiaoliurenData,
   SupplementaryInfo,
@@ -549,6 +550,30 @@ export function getDivinationSummaryBlocks(
         ].filter(Boolean),
       };
     }
+    case 'wuyun': {
+      const item = data as WuyunLiuqiResult;
+      const targetYear =
+        item.input.year === undefined
+          ? item.input.yearGanZhi
+          : `${item.input.year}年${item.input.yearGanZhi}`;
+      return {
+        title: '五运六气年度结果',
+        tags: [
+          targetYear,
+          `${item.annualMovement.name}·${item.annualMovement.strength}`,
+          `司天${item.sitian.name}`,
+        ],
+        lines: [
+          `在泉：${item.zaiquan.name}`,
+          `司天化令：${item.annualClassification.sitianTransformation}；${item.annualClassification.governance}`,
+          `中运与司天：${item.annualRelation.kind}`,
+          `年度符会：${item.annualConformities.names.length ? item.annualConformities.names.join('、') : '未形成五类符会'}`,
+          `五步主客运：${item.movementSteps.map((step) => `${step.label}${step.hostMovement.element}/${step.guestMovement.element}（${step.hostGuestRelation.kind}）`).join('；')}`,
+          `六步主客气：${item.qiSteps.map((step) => `${step.label}${step.hostQi.name}/${step.guestQi.name}（${step.hostGuestRelation.kind}）`).join('；')}`,
+          item.pathomechanism?.summary ?? '',
+        ].filter(Boolean),
+      };
+    }
     default:
       return { title: '占卜结果', tags: [], lines: [] };
   }
@@ -677,7 +702,12 @@ function formatSsgwPrompt(data: SsgwData) {
 }
 
 export function buildDivinationPromptDocument(options: DivinationPromptOptions): PromptDocument {
-  const promptMethodId = options.method === 'huangji' ? 'huangji-jingshi' : options.method;
+  const promptMethodId =
+    options.method === 'huangji'
+      ? 'huangji-jingshi'
+      : options.method === 'wuyun'
+        ? 'wuyun-liuqi'
+        : options.method;
   const hasPromptSelection =
     options.topicId !== undefined ||
     options.subtopicId !== undefined ||
@@ -724,7 +754,12 @@ export function buildDivinationPromptDocument(options: DivinationPromptOptions):
         ? buildLiurenTemplateText(liurenTemplate, options.data as LiurenData)
         : '';
   const supplementaryText = formatSupplementaryInfo(options.supplementaryInfo, options.method);
-  const promptSchoolMethod = options.method === 'huangji' ? 'huangji-jingshi' : options.method;
+  const promptSchoolMethod =
+    options.method === 'huangji'
+      ? 'huangji-jingshi'
+      : options.method === 'wuyun'
+        ? 'wuyun-liuqi'
+        : options.method;
   const singleCardGuidance =
     options.method === 'tarot' && (options.data as TarotData).cards.length === 1
       ? buildPromptSection('传统依据', '塔罗单牌以牌位职能、正逆位、牌组属性与单牌牌义为主要资料。')

--- a/packages/core/src/prompt/divination.ts
+++ b/packages/core/src/prompt/divination.ts
@@ -1,3 +1,4 @@
+import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 import { formatLiurenLesson, formatLiurenTransmission } from './liuren-facts';
 import { buildTaskText } from '../divination/engine/method-text';
 import { formatJinkoujueRelations, formatJinkoujueMovementRules } from './jinkoujue-facts';
@@ -24,7 +25,6 @@ import type {
   QimenData,
   SsgwData,
   TaiyiResult,
-  WuyunLiuqiResult,
   TarotData,
   XiaoliurenData,
   SupplementaryInfo,

--- a/packages/core/src/prompt/guidance.ts
+++ b/packages/core/src/prompt/guidance.ts
@@ -1,4 +1,7 @@
 export const PROMPT_GUIDANCE_TEXT = {
+  'wuyun-liuqi': {
+    tradition: '以年干定岁运太过不及，以年支定司天在泉，再看五步主客运与六步主客气的阶段关系。',
+  },
   bazi: {
     tradition:
       '子平法先看月令、根气、透干与全局制化，再定旺衰、格局和调候；十神落实人事，岁运以原局为根，神煞仅作旁证。',

--- a/packages/core/src/prompt/guidance.ts
+++ b/packages/core/src/prompt/guidance.ts
@@ -1,6 +1,7 @@
 export const PROMPT_GUIDANCE_TEXT = {
   'wuyun-liuqi': {
     tradition: '以年干定岁运太过不及，以年支定司天在泉，再看五步主客运与六步主客气的阶段关系。',
+    sources: '参考《素问》运气七篇与吴谦《运气要诀》。',
   },
   bazi: {
     tradition:

--- a/packages/core/src/prompt/guidance.ts
+++ b/packages/core/src/prompt/guidance.ts
@@ -136,6 +136,7 @@ export type DivinationPromptGuidanceMethod =
   | 'liuren'
   | 'taiyi'
   | 'huangji'
+  | 'wuyun'
   | 'tarot'
   | 'lenormand'
   | 'ssgw'
@@ -254,10 +255,11 @@ export function buildCustomQuestionTask(subject = '以上资料', method?: strin
   return buildPromptTask(`请依据${subject.trim() || '以上资料'}回答【问题】`, method);
 }
 
-export function buildPromptGuidanceSections(method: PromptGuidanceId) {
+export function buildPromptGuidanceSections(method: PromptGuidanceId | 'wuyun') {
+  const guidanceMethod = method === 'wuyun' ? 'wuyun-liuqi' : method;
   // 签谱提示词只允许携带本次签谱资料；签文、典故和解签由盘面资料本身提供。
-  if (method === 'ssgw') return '';
-  const guidance = PROMPT_GUIDANCE_TEXT[method];
+  if (guidanceMethod === 'ssgw') return '';
+  const guidance = PROMPT_GUIDANCE_TEXT[guidanceMethod];
   // 书目名称不参与本次判断，完整来源仍保留在结构化证据中。
   const blocks = 'tradition' in guidance ? guidance.tradition : '';
 
@@ -282,7 +284,8 @@ export function insertPromptSectionBeforeHeading(prompt: string, heading: string
 
 /** 生成核心提示词使用的传统依据段落。 */
 export function buildPromptGuidance(method: string) {
-  return method in PROMPT_GUIDANCE_TEXT
-    ? buildPromptGuidanceSections(method as PromptGuidanceId)
+  const guidanceMethod = method === 'wuyun' ? 'wuyun-liuqi' : method;
+  return guidanceMethod in PROMPT_GUIDANCE_TEXT
+    ? buildPromptGuidanceSections(guidanceMethod as PromptGuidanceId)
     : '';
 }

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -7,6 +7,7 @@ import type { HistoricalTimezoneEvidence } from '../calendar/historical-timezone
 import type { TrueSolarTimeEvidenceFields } from '../calendar/true-solar-time';
 import type { HuangjiJingshiResult } from '../huangji-jingshi';
 import type { KongmingHexagramResult, ZhugeNumberResult } from '../name-number';
+import type { WuyunLiuqiResult } from '../wuyun-liuqi';
 
 export type { RandomOptions, RandomSource } from '../shared/random';
 export type { CoreResultMeta } from '../shared/result';
@@ -29,7 +30,8 @@ export type DivinationType =
   | 'lenormand'
   | 'astrolabe'
   | 'taiyi'
-  | 'huangji';
+  | 'huangji'
+  | 'wuyun';
 
 export type MeihuaDivinationMethod =
   'time' | 'number' | 'sound' | 'character' | 'direction' | 'random' | 'timeTrigram';
@@ -1713,7 +1715,8 @@ export type DivinationData =
   | LenormandData
   | AstrolabeData
   | TaiyiResult
-  | HuangjiJingshiResult;
+  | HuangjiJingshiResult
+  | WuyunLiuqiResult;
 
 export interface SupplementaryInfo {
   /** 求测人性别，用于补充解读背景，不参与起盘算法。 */

--- a/packages/core/src/wuyun-liuqi/index.ts
+++ b/packages/core/src/wuyun-liuqi/index.ts
@@ -716,6 +716,64 @@ function formatElementDirection(
   return isKe(firstElement, secondElement) ? `${first}克${second}` : `${second}克${first}`;
 }
 
+export function formatWuyunLiuqiFacts(result: WuyunLiuqiCalculation): string {
+  return [
+    `年干支：${result.input.yearGanZhi}${result.input.year === undefined ? '' : `（公历 ${result.input.year} 年）`}`,
+    `日期口径：${result.calendarDateStatus === '公历日期已换算' ? '节令边界同时列出公历日期' : '按节气与传统序日表示各步边界'}`,
+    `岁运：${result.annualMovement.name}（${result.annualMovement.toneName}），${result.annualMovement.strength}（${result.annualMovement.yinYang}干）`,
+    `司天：${result.sitian.name}`,
+    `在泉：${result.zaiquan.name}`,
+    `司天化令：${result.annualClassification.sitianTransformation}；南北政：${result.annualClassification.governance}`,
+    `司天与中运：${result.annualRelation.kind}；${result.annualRelation.basis}`,
+    `年度五行作用：${formatElementDirection('中运', result.annualMovement.element, `司天${result.sitian.name}`, result.sitian.element)}；${formatElementDirection('中运', result.annualMovement.element, `在泉${result.zaiquan.name}`, result.zaiquan.element)}；${formatElementDirection(`司天${result.sitian.name}`, result.sitian.element, `在泉${result.zaiquan.name}`, result.zaiquan.element)}`,
+    `年度符会：${result.annualConformities.names.length ? result.annualConformities.names.join('、') : '未形成天符、岁会、太乙天符、同天符或同岁会'}`,
+    result.pathomechanism
+      ? result.pathomechanism.summary
+      : evaluateWuyunLiuqiPathomechanism({
+          annualMovement: result.annualMovement,
+          sitian: result.sitian,
+          yearGanZhi: result.input.yearGanZhi,
+          annualConformities: result.annualConformities,
+        }).summary,
+    '五步主客运：',
+    ...result.movementSteps.map((step) => {
+      const dates =
+        step.gregorianStart && step.gregorianEnd
+          ? `；公历${step.gregorianStart}至${step.gregorianEnd}`
+          : '';
+      const current =
+        result.input.year && step.gregorianStart && step.gregorianEnd
+          ? isDateInRange(
+              { year: result.input.year, month: 6, day: 30 },
+              parseCivilDate(step.gregorianStart),
+              parseCivilDate(step.gregorianEnd),
+            )
+            ? '；年中落在此步'
+            : ''
+          : '';
+      return `${step.order}. ${step.label}（${step.periodRule}${dates}${current}）：主运${step.hostMovement.toneName}（${step.hostMovement.element}）；客运${step.guestMovement.toneName}（${step.guestMovement.element}）${step.guestRole ? `（${step.guestRole}）` : ''}；主客关系${step.hostGuestRelation.kind}；${formatElementDirection(`主运${step.hostMovement.toneName}`, step.hostMovement.element, `客运${step.guestMovement.toneName}`, step.guestMovement.element)}`;
+    }),
+    '六步主客气：',
+    ...result.qiSteps.map((step) => {
+      const dates =
+        step.gregorianStart && step.gregorianEnd
+          ? `；公历${step.gregorianStart}至${step.gregorianEnd}`
+          : '';
+      const current =
+        result.input.year && step.gregorianStart && step.gregorianEnd
+          ? isDateInRange(
+              { year: result.input.year, month: 6, day: 30 },
+              parseCivilDate(step.gregorianStart),
+              parseCivilDate(step.gregorianEnd),
+            )
+            ? '；年中落在此步'
+            : ''
+          : '';
+      return `${step.order}. ${step.label}（${step.solarTerms.join('、')}${dates}${current}）：主气${step.hostQi.name}；客气${step.guestQi.name}${step.guestRole ? `（${step.guestRole}）` : ''}；主客关系${step.hostGuestRelation.kind}；${formatElementDirection(`主气${step.hostQi.name}`, step.hostQi.element, `客气${step.guestQi.name}`, step.guestQi.element)}${step.hostGuestRelation.fireOrder ? `；二火加临：${step.hostGuestRelation.fireOrder}` : ''}`;
+    }),
+  ].join('\n');
+}
+
 export function buildWuyunLiuqiPrompt(
   result: WuyunLiuqiCalculation,
   question?: string,
@@ -725,62 +783,7 @@ export function buildWuyunLiuqiPrompt(
   const normalizedQuestion = normalizeQuestion(question);
   const sections: string[] = [
     '【传统依据】\n以年干定岁运太过不及，以年支定司天在泉，再看五步主客运与六步主客气的阶段关系。',
-    [
-      '【盘面资料】',
-      `年干支：${result.input.yearGanZhi}${result.input.year === undefined ? '' : `（公历 ${result.input.year} 年）`}`,
-      `日期口径：${result.calendarDateStatus === '公历日期已换算' ? '节令边界同时列出公历日期' : '按节气与传统序日表示各步边界'}`,
-      `岁运：${result.annualMovement.name}（${result.annualMovement.toneName}），${result.annualMovement.strength}（${result.annualMovement.yinYang}干）`,
-      `司天：${result.sitian.name}`,
-      `在泉：${result.zaiquan.name}`,
-      `司天化令：${result.annualClassification.sitianTransformation}；南北政：${result.annualClassification.governance}`,
-      `司天与中运：${result.annualRelation.kind}；${result.annualRelation.basis}`,
-      `年度五行作用：${formatElementDirection('中运', result.annualMovement.element, `司天${result.sitian.name}`, result.sitian.element)}；${formatElementDirection('中运', result.annualMovement.element, `在泉${result.zaiquan.name}`, result.zaiquan.element)}；${formatElementDirection(`司天${result.sitian.name}`, result.sitian.element, `在泉${result.zaiquan.name}`, result.zaiquan.element)}`,
-      `年度符会：${result.annualConformities.names.length ? result.annualConformities.names.join('、') : '未形成天符、岁会、太乙天符、同天符或同岁会'}`,
-      result.pathomechanism
-        ? result.pathomechanism.summary
-        : evaluateWuyunLiuqiPathomechanism({
-            annualMovement: result.annualMovement,
-            sitian: result.sitian,
-            yearGanZhi: result.input.yearGanZhi,
-            annualConformities: result.annualConformities,
-          }).summary,
-      '五步主客运：',
-      ...result.movementSteps.map((step) => {
-        const dates =
-          step.gregorianStart && step.gregorianEnd
-            ? `；公历${step.gregorianStart}至${step.gregorianEnd}`
-            : '';
-        const current =
-          result.input.year && step.gregorianStart && step.gregorianEnd
-            ? isDateInRange(
-                { year: result.input.year, month: 6, day: 30 },
-                parseCivilDate(step.gregorianStart),
-                parseCivilDate(step.gregorianEnd),
-              )
-              ? '；年中落在此步'
-              : ''
-            : '';
-        return `${step.order}. ${step.label}（${step.periodRule}${dates}${current}）：主运${step.hostMovement.toneName}（${step.hostMovement.element}）；客运${step.guestMovement.toneName}（${step.guestMovement.element}）${step.guestRole ? `（${step.guestRole}）` : ''}；主客关系${step.hostGuestRelation.kind}；${formatElementDirection(`主运${step.hostMovement.toneName}`, step.hostMovement.element, `客运${step.guestMovement.toneName}`, step.guestMovement.element)}`;
-      }),
-      '六步主客气：',
-      ...result.qiSteps.map((step) => {
-        const dates =
-          step.gregorianStart && step.gregorianEnd
-            ? `；公历${step.gregorianStart}至${step.gregorianEnd}`
-            : '';
-        const current =
-          result.input.year && step.gregorianStart && step.gregorianEnd
-            ? isDateInRange(
-                { year: result.input.year, month: 6, day: 30 },
-                parseCivilDate(step.gregorianStart),
-                parseCivilDate(step.gregorianEnd),
-              )
-              ? '；年中落在此步'
-              : ''
-            : '';
-        return `${step.order}. ${step.label}（${step.solarTerms.join('、')}${dates}${current}）：主气${step.hostQi.name}；客气${step.guestQi.name}${step.guestRole ? `（${step.guestRole}）` : ''}；主客关系${step.hostGuestRelation.kind}；${formatElementDirection(`主气${step.hostQi.name}`, step.hostQi.element, `客气${step.guestQi.name}`, step.guestQi.element)}${step.hostGuestRelation.fireOrder ? `；二火加临：${step.hostGuestRelation.fireOrder}` : ''}`;
-      }),
-    ].join('\n'),
+    `【盘面资料】\n${formatWuyunLiuqiFacts(result)}`,
   ];
   const task = buildPromptTask(
     normalizedQuestion ? '请结合年度运气资料回答【问题】。' : '请解读年度运气节律。',

--- a/src/components/DivinationPanel/DivinationForm.tsx
+++ b/src/components/DivinationPanel/DivinationForm.tsx
@@ -185,7 +185,12 @@ function PromptSelectionFields({
   updateDraft,
 }: Pick<DivinationFormProps, 'draft' | 'updateDraft'>) {
   if (draft.method === 'ssgw') return null;
-  const methodId = draft.method === 'huangji' ? 'huangji-jingshi' : draft.method;
+  const methodId =
+    draft.method === 'huangji'
+      ? 'huangji-jingshi'
+      : draft.method === 'wuyun'
+        ? 'wuyun-liuqi'
+        : draft.method;
   const capability = getPromptMethodCapability(methodId);
   const topicOptions = getPromptTopicOptions(methodId);
   const topicId = topicOptions.some((item) => item.id === draft.promptTopicId)
@@ -284,7 +289,9 @@ export function DivinationForm({
   const questionPlaceholder =
     draft.method === 'huangji'
       ? '例如：这个时点整体处于怎样的时势阶段，接下来应把握什么主线？'
-      : '例如：我现在该主动推进，还是先稳住等待更好的时机？';
+      : draft.method === 'wuyun'
+        ? '例如：2026年全年气候节律与需要关注的重点是什么？'
+        : '例如：我现在该主动推进，还是先稳住等待更好的时机？';
   const submitButtonText =
     draft.method === 'almanac'
       ? '开始择日'
@@ -292,7 +299,9 @@ export function DivinationForm({
         ? '生成星盘'
         : draft.method === 'huangji'
           ? '生成皇极盘'
-          : '开始占卜';
+          : draft.method === 'wuyun'
+            ? '生成五运六气盘'
+            : '开始占卜';
   const timeActionLabel =
     draft.method === 'huangji'
       ? '起盘'
@@ -1705,6 +1714,45 @@ export function DivinationForm({
             )
           ) : null}
 
+          {draft.method === 'wuyun' ? (
+            <div className="divination-extra-panel divination-time-panel">
+              <div className="form-row-flex">
+                <div className="form-item">
+                  <label htmlFor="wuyun-year-input">目标年份</label>
+                  <input
+                    id="wuyun-year-input"
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={4}
+                    className="form-input"
+                    placeholder="例如 2026"
+                    value={draft.wuyunYear}
+                    onChange={(event) =>
+                      updateDraft('wuyunYear', event.target.value.replace(/[^\d]/g, '').slice(0, 4))
+                    }
+                  />
+                </div>
+                <div className="form-item">
+                  <label htmlFor="wuyun-year-ganzhi-input">目标年干支（可选）</label>
+                  <input
+                    id="wuyun-year-ganzhi-input"
+                    type="text"
+                    maxLength={2}
+                    className="form-input"
+                    placeholder="例如 丙午"
+                    value={draft.wuyunYearGanZhi}
+                    onChange={(event) =>
+                      updateDraft('wuyunYearGanZhi', event.target.value.trim().slice(0, 2))
+                    }
+                  />
+                </div>
+              </div>
+              <small className="workspace-ui-field-hint">
+                可只填写年份或年干支；同时填写时会核对两者对应同一年度。
+              </small>
+            </div>
+          ) : null}
+
           {supportsTrueSolarTime && divinationTimeStandard === 'true-solar' ? (
             <div className="divination-extra-panel divination-time-panel divination-solar-place-panel">
               <div className="form-row">
@@ -1729,7 +1777,8 @@ export function DivinationForm({
 
           {draft.method !== 'almanac' &&
           draft.method !== 'astrolabe' &&
-          draft.method !== 'huangji' ? (
+          draft.method !== 'huangji' &&
+          draft.method !== 'wuyun' ? (
             <div className="form-row-flex divination-subject-fields">
               <div className="form-item">
                 <label htmlFor="divination-gender-select">性别（可选）</label>

--- a/src/components/DivinationPanel/DivinationForm.tsx
+++ b/src/components/DivinationPanel/DivinationForm.tsx
@@ -1726,7 +1726,7 @@ export function DivinationForm({
                     maxLength={4}
                     className="form-input"
                     placeholder="例如 2026"
-                    value={draft.wuyunYear}
+                    value={draft.wuyunYear ?? ''}
                     onChange={(event) =>
                       updateDraft('wuyunYear', event.target.value.replace(/[^\d]/g, '').slice(0, 4))
                     }
@@ -1740,7 +1740,7 @@ export function DivinationForm({
                     maxLength={2}
                     className="form-input"
                     placeholder="例如 丙午"
-                    value={draft.wuyunYearGanZhi}
+                    value={draft.wuyunYearGanZhi ?? ''}
                     onChange={(event) =>
                       updateDraft('wuyunYearGanZhi', event.target.value.trim().slice(0, 2))
                     }

--- a/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
+++ b/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
@@ -18,6 +18,7 @@ import {
   type HuangjiPeriodHexagram,
 } from 'mingyu-core/huangji-jingshi';
 import { TAIYI_PALACES } from 'mingyu-core/taiyi';
+import type { WuyunLiuqiResult } from 'mingyu-core/wuyun-liuqi';
 import type { KongmingHexagramResult, ZhugeNumberResult } from 'mingyu-core/name-number';
 import { getKongmingInterpretation, getZhugeInterpretation } from 'mingyu-core/name-number';
 import { analyzeAlmanacEvidence, formatAlmanacGods } from 'mingyu-core/divination/almanac';
@@ -3269,6 +3270,93 @@ function HuangjiTraditionalBoard({
   );
 }
 
+function WuyunTraditionalBoard({
+  data,
+  session,
+}: {
+  data: WuyunLiuqiResult;
+  session?: DivinationSession;
+}) {
+  const targetYear = data.input.year === undefined ? '' : `${data.input.year}年`;
+  const target = `${targetYear}${data.input.yearGanZhi}`;
+  const formatRange = (start?: string, end?: string) =>
+    start && end ? `公历${start}至${end}` : '按传统节气序日';
+
+  return (
+    <TraditionalBoardShell
+      title="五运六气年度盘"
+      subtitle={`${target} · ${data.annualMovement.name}${data.annualMovement.toneName} · 司天${data.sitian.name}`}
+      className="traditional-wuyun-board"
+    >
+      <TraditionalMeta
+        items={[
+          ['占事', session?.question],
+          ['目标年度', target],
+          [
+            '岁运',
+            `${data.annualMovement.name}${data.annualMovement.toneName}${data.annualMovement.strength}`,
+          ],
+          ['司天', data.sitian.name],
+          ['在泉', data.zaiquan.name],
+          [
+            '政化',
+            `${data.annualClassification.sitianTransformation} · ${data.annualClassification.governance}`,
+          ],
+        ]}
+      />
+      <TraditionalFacts
+        items={[
+          ['中运与司天', data.annualRelation.kind],
+          ['年度符会', data.annualConformities.names.join('、') || '未形成五类符会'],
+          ['年度病机', data.pathomechanism?.summary],
+        ]}
+      />
+
+      <section className="traditional-wuyun-steps" aria-label="五步主客运">
+        <h4>五步主客运</h4>
+        <div className="traditional-fact-grid">
+          {data.movementSteps.map((step) => (
+            <div key={step.label}>
+              <span>
+                {step.label} · {formatRange(step.gregorianStart, step.gregorianEnd)}
+              </span>
+              <strong>
+                主运{step.hostMovement.toneName}
+                {step.hostMovement.element}；客运{step.guestMovement.toneName}
+                {step.guestMovement.element}
+              </strong>
+              <small>
+                {step.hostGuestRelation.kind}
+                {step.guestRole ? ` · ${step.guestRole}` : ''}
+              </small>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="traditional-wuyun-steps" aria-label="六步主客气">
+        <h4>六步主客气</h4>
+        <div className="traditional-fact-grid">
+          {data.qiSteps.map((step) => (
+            <div key={step.label}>
+              <span>
+                {step.label} · {formatRange(step.gregorianStart, step.gregorianEnd)}
+              </span>
+              <strong>
+                主气{step.hostQi.name}；客气{step.guestQi.name}
+              </strong>
+              <small>
+                {step.hostGuestRelation.kind}
+                {step.guestRole ? ` · ${step.guestRole}` : ''}
+              </small>
+            </div>
+          ))}
+        </div>
+      </section>
+    </TraditionalBoardShell>
+  );
+}
+
 const LIUREN_BRANCH_POSITIONS: Record<string, { row: number; column: number }> = {
   巳: { row: 1, column: 1 },
   午: { row: 1, column: 2 },
@@ -3598,6 +3686,7 @@ const DIVINATION_METHOD_LABELS: Record<string, string> = {
   astrolabe: '古典星盘',
   taiyi: '太乙神数',
   huangji: '皇极经世',
+  wuyun: '五运六气',
   liuren: '大六壬',
   zhuge: '诸葛神数',
   kongming: '孔明神卦',
@@ -3647,6 +3736,16 @@ function formatDivinationSessionShareText(session: DivinationSession): string {
     lines.push(
       `四位：人元【${formatPosition(d.positions.renYuan)}】 贵神【${formatPosition(d.positions.guiShen)}】 将神【${formatPosition(d.positions.jiangShen)}】 地分【${formatPosition(d.positions.diFen)}】`,
     );
+  } else if (session.method === 'wuyun') {
+    const d = session.data as WuyunLiuqiResult;
+    lines.push(
+      `目标年度：${d.input.year === undefined ? '' : `${d.input.year}年`}${d.input.yearGanZhi}`,
+    );
+    lines.push(
+      `岁运：${d.annualMovement.name}${d.annualMovement.toneName}${d.annualMovement.strength}`,
+    );
+    lines.push(`司天：${d.sitian.name}  在泉：${d.zaiquan.name}`);
+    lines.push(`符会：${d.annualConformities.names.join('、') || '未形成五类符会'}`);
   }
 
   return lines.join('\n');
@@ -3733,6 +3832,11 @@ export function TraditionalDivinationBoard({
     case 'huangji':
       boardContent = (
         <HuangjiTraditionalBoard data={session.data as HuangjiJingshiResult} session={session} />
+      );
+      break;
+    case 'wuyun':
+      boardContent = (
+        <WuyunTraditionalBoard data={session.data as WuyunLiuqiResult} session={session} />
       );
       break;
     case 'liuren':

--- a/src/components/DivinationPanel/constants.ts
+++ b/src/components/DivinationPanel/constants.ts
@@ -81,6 +81,8 @@ export const defaultDraft: DivinationDraft = {
   astrolabeLongitude: '116.4074',
   astrolabeTimezone: '8',
   taiyiYear: String(new Date().getFullYear()),
+  wuyunYear: String(new Date().getFullYear()),
+  wuyunYearGanZhi: '',
   zhugeText: '',
   kongmingMethod: 'random',
   kongmingPattern: '',

--- a/src/lib/ai/reading-subject.ts
+++ b/src/lib/ai/reading-subject.ts
@@ -10,6 +10,7 @@ import {
 import type { DivinationDraft, DivinationSession } from '@/lib/divination/engine';
 import type { HuangjiJingshiResult } from 'mingyu-core/huangji-jingshi';
 import type { TaiyiResult } from 'mingyu-core/types';
+import type { WuyunLiuqiResult } from 'mingyu-core/wuyun-liuqi';
 
 export type ReadingSubjectSource = QueryPromptState['promptSource'] | 'taiyi' | 'huangji' | 'wuyun';
 
@@ -315,12 +316,13 @@ export function buildDivinationReadingSubject(
   _draft: DivinationDraft,
   session: DivinationSession,
 ): ReadingSubjectSnapshot | undefined {
-  if (session.method !== 'taiyi' && session.method !== 'huangji') return undefined;
+  if (session.method !== 'taiyi' && session.method !== 'huangji' && session.method !== 'wuyun')
+    return undefined;
 
   const lockedInputs: Record<string, Record<string, unknown>> = {};
   const range: Record<string, unknown> = {
     source: session.method,
-    targetKind: 'time-divination',
+    targetKind: session.method === 'wuyun' ? 'annual-divination' : 'time-divination',
   };
 
   if (session.method === 'taiyi') {
@@ -330,7 +332,7 @@ export function buildDivinationReadingSubject(
     range.taiyiScope = result.scope;
     range.taiyiDateTime = result.dateTime;
     if (dateParts) range.taiyiTarget = dateParts;
-  } else {
+  } else if (session.method === 'huangji') {
     const result = session.data as HuangjiJingshiResult;
     const mode = result.input?.mode ?? '年月日时';
     lockedInputs.huangji = { _mode: mode };
@@ -342,6 +344,14 @@ export function buildDivinationReadingSubject(
     if (result.dateTimeForecast?.civilTime?.dateTime) {
       range.huangjiDateTime = result.dateTimeForecast.civilTime.dateTime;
     }
+  } else {
+    const result = session.data as WuyunLiuqiResult;
+    lockedInputs.wuyun = {
+      ...(result.input.year === undefined ? {} : { year: result.input.year }),
+      yearGanZhi: result.input.yearGanZhi,
+    };
+    if (result.input.year !== undefined) range.wuyunYear = result.input.year;
+    range.wuyunYearGanZhi = result.input.yearGanZhi;
   }
 
   const fingerprint = stableStringify({ source: session.method, lockedInputs, range });

--- a/src/lib/divination/engine/index.ts
+++ b/src/lib/divination/engine/index.ts
@@ -64,7 +64,6 @@ const CONCRETE_DIVINATION_METHODS: Array<Exclude<DivinationMethodId, 'random'>> 
   'qimen',
   'liuren',
   'taiyi',
-  'wuyun',
   'tarot',
   'ssgw',
   'lenormand',

--- a/src/lib/divination/engine/index.ts
+++ b/src/lib/divination/engine/index.ts
@@ -22,6 +22,7 @@ import type {
 } from '../../../types/divination';
 import type { DivinationMethodId } from 'mingyu-core/divination/config';
 import type { HuangjiJingshiResult } from 'mingyu-core/huangji-jingshi';
+import type { WuyunLiuqiResult } from 'mingyu-core/wuyun-liuqi';
 import { convertTrueSolarTime, formatSolarDateTimeParts, TimeManager } from 'mingyu-core/calendar';
 import { daysInSolarMonth } from '../../date-validation';
 import {
@@ -63,6 +64,7 @@ const CONCRETE_DIVINATION_METHODS: Array<Exclude<DivinationMethodId, 'random'>> 
   'qimen',
   'liuren',
   'taiyi',
+  'wuyun',
   'tarot',
   'ssgw',
   'lenormand',
@@ -160,6 +162,9 @@ export type DivinationDraft = {
   promptScope?: string;
   taiyiYear: string;
   taiyiScope?: TaiyiScope;
+  /** 历史草稿可能没有年度字段；五运六气提交时再校验必填。 */
+  wuyunYear?: string;
+  wuyunYearGanZhi?: string;
   zhugeText: string;
   kongmingMethod?: 'random' | 'manual';
   kongmingPattern?: string;
@@ -209,7 +214,8 @@ export function buildDivinationPrompt(
   options: BuildDivinationPromptOptions = {},
 ) {
   const isCustomQuestion = Boolean(options.isCustomQuestion);
-  const promptMethodId = method === 'huangji' ? 'huangji-jingshi' : method;
+  const promptMethodId =
+    method === 'huangji' ? 'huangji-jingshi' : method === 'wuyun' ? 'wuyun-liuqi' : method;
   const hasPromptSelection =
     options.topicId !== undefined ||
     options.subtopicId !== undefined ||
@@ -264,7 +270,8 @@ export function buildDivinationPrompt(
           ? buildPromptTask('依据唯一牌位与基础牌义回答【问题】。', 'lenormand-single')
           : buildTaskText(method, data);
   const taskText = selection ? buildPromptSelectionTask(baseTaskText, selection) : baseTaskText;
-  const promptSchoolMethod = method === 'huangji' ? 'huangji-jingshi' : method;
+  const promptSchoolMethod =
+    method === 'huangji' ? 'huangji-jingshi' : method === 'wuyun' ? 'wuyun-liuqi' : method;
   const selectedSchools = options.schools?.length
     ? normalizePromptSchoolIds(promptSchoolMethod as PromptSchoolMethod, options.schools)
     : [];
@@ -324,7 +331,10 @@ function buildSupplementaryInfo(draft: DivinationDraft): SupplementaryInfo | und
   const info: SupplementaryInfo = {};
 
   const usesDedicatedBirthInfo =
-    draft.method === 'almanac' || draft.method === 'astrolabe' || draft.method === 'huangji';
+    draft.method === 'almanac' ||
+    draft.method === 'astrolabe' ||
+    draft.method === 'huangji' ||
+    draft.method === 'wuyun';
   if (!usesDedicatedBirthInfo && draft.gender) {
     info.gender = draft.gender;
   }
@@ -526,6 +536,10 @@ function validateDraft(draft: DivinationDraft) {
     assertNumberRange(year, '太乙年计年份', 1900, 2200);
   }
 
+  if (draft.method === 'wuyun') {
+    resolveWuyunInput(draft);
+  }
+
   if (draft.method === 'almanac') {
     if (!draft.almanacStartDate || !draft.almanacEndDate) {
       throw new Error('黄历择日需要选择开始日期和结束日期');
@@ -557,6 +571,22 @@ function readIntegerText(value: string, label: string) {
     throw new Error(`${label}必须是整数`);
   }
   return Number(text);
+}
+
+function resolveWuyunInput(draft: DivinationDraft) {
+  const yearText = draft.wuyunYear?.trim() ?? '';
+  const yearGanZhi = draft.wuyunYearGanZhi?.trim() ?? '';
+  if (!yearText && !yearGanZhi) {
+    throw new Error('五运六气需要填写目标年份或年干支');
+  }
+  const year = yearText ? readIntegerText(yearText, '五运六气目标年份') : undefined;
+  if (year !== undefined) {
+    assertNumberRange(year, '五运六气目标年份', 1, 9999);
+  }
+  return {
+    ...(year === undefined ? {} : { year }),
+    ...(yearGanZhi ? { yearGanZhi } : {}),
+  };
 }
 
 function readOptionalPositiveIntegerText(value: string) {
@@ -980,6 +1010,14 @@ export async function generateDivinationSession(
       });
       break;
     }
+    case 'wuyun': {
+      const module = await import('mingyu-core/wuyun-liuqi');
+      data = module.calculateWuyunLiuqi({
+        ...resolveWuyunInput(draft),
+        question: inputQuestion,
+      }) as WuyunLiuqiResult;
+      break;
+    }
     case 'tarot': {
       const module = await import('mingyu-core/divination/tarot');
       data = module.drawTarotSpread(
@@ -1061,7 +1099,8 @@ export async function generateDivinationSession(
     method === 'almanac' && !inputQuestion
       ? buildAlmanacSessionTitle(data as AlmanacData)
       : inputQuestion;
-  const promptMethodId = method === 'huangji' ? 'huangji-jingshi' : method;
+  const promptMethodId =
+    method === 'huangji' ? 'huangji-jingshi' : method === 'wuyun' ? 'wuyun-liuqi' : method;
   const selection =
     draft.promptTopicId !== undefined ||
     draft.promptSubtopicId !== undefined ||

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -137,6 +137,7 @@ const divinationMarks: Record<DivinationWorkspaceId, string> = {
   jinkoujue: '金',
   taiyi: '太',
   huangji: '皇',
+  wuyun: '运',
   ssgw: '签',
   zhuge: '诸',
   kongming: '孔',

--- a/src/traditional-charts.css
+++ b/src/traditional-charts.css
@@ -1596,6 +1596,17 @@
   border-right: 0;
 }
 
+.traditional-wuyun-steps {
+  display: grid;
+  gap: 8px;
+}
+
+.traditional-wuyun-steps h4 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 14px;
+}
+
 .traditional-huangji-related strong {
   color: color-mix(in srgb, var(--chart-accent) 68%, var(--text-strong));
   font-size: 24px;

--- a/tests/ai-reading-non-natal-timing.test.ts
+++ b/tests/ai-reading-non-natal-timing.test.ts
@@ -243,6 +243,10 @@ test('网页五运六气会话保留固定年度并把同一目标交给 AI 补�
   assert.match(session.prompt, /2026年/u);
   assert.match(session.prompt, /丙午/u);
   assert.match(session.prompt, /五步主客运/u);
+  assert.match(session.prompt, /年度五行作用/u);
+  assert.match(session.prompt, /春分后第13日/u);
+  assert.match(session.prompt, /六步主客气/u);
+  assert.doesNotMatch(session.prompt, /公历年年中换算|明确年干支/u);
   const subject = buildDivinationReadingSubject(draft, session);
   assert.ok(subject);
   assert.deepEqual(subject?.allowedMethods, ['wuyun']);

--- a/tests/ai-reading-non-natal-timing.test.ts
+++ b/tests/ai-reading-non-natal-timing.test.ts
@@ -231,6 +231,45 @@ test('网页太乙与皇极会话建立真实目标快照并锁定术式口径',
   });
 });
 
+test('网页五运六气会话保留固定年度并把同一目标交给 AI 补算', async () => {
+  const draft = buildTimingDraft({
+    method: 'wuyun',
+    question: '2026年全年运气与时令重点是什么？',
+    wuyunYear: '2026',
+    wuyunYearGanZhi: '丙午',
+  });
+  const session = await generateDivinationSession(draft);
+  assert.equal(session.method, 'wuyun');
+  assert.match(session.prompt, /2026年/u);
+  assert.match(session.prompt, /丙午/u);
+  assert.match(session.prompt, /五步主客运/u);
+  const subject = buildDivinationReadingSubject(draft, session);
+  assert.ok(subject);
+  assert.deepEqual(subject?.allowedMethods, ['wuyun']);
+  assert.equal(subject?.range.targetKind, 'annual-divination');
+  assert.equal(subject?.lockedInputs.wuyun.year, 2026);
+  assert.equal(subject?.lockedInputs.wuyun.yearGanZhi, '丙午');
+
+  await withRealApi(async () => {
+    const resource = await executeReadingAction(
+      {
+        kind: 'calculate',
+        method: 'wuyun',
+        input: { year: 2026, yearGanZhi: '丙午', question: draft.question },
+      },
+      undefined,
+      subject,
+    );
+    const result = resource.structured as Record<string, unknown>;
+    const input = result.input as Record<string, unknown>;
+    assert.equal(input.year, 2026);
+    assert.equal(input.yearGanZhi, '丙午');
+    assert.equal((result.movementSteps as unknown[]).length, 5);
+    assert.equal((result.qiSteps as unknown[]).length, 6);
+    assert.match(resource.text, /司天/u);
+  });
+});
+
 test('皇极自定义纪元按年坐标核验并在追问时保持原纪元', async () => {
   const subject: ReadingSubjectSnapshot = {
     id: 'huangji-custom-epoch',

--- a/tests/traditional-divination-board.test.ts
+++ b/tests/traditional-divination-board.test.ts
@@ -11,6 +11,7 @@ import { generateQimen } from 'mingyu-core/divination/qimen';
 import { drawRandomSign } from 'mingyu-core/divination/ssgw';
 import { drawTarotSpread } from 'mingyu-core/divination/tarot';
 import { generateXiaoliuren } from 'mingyu-core/divination/xiaoliuren';
+import { calculateWuyunLiuqi } from 'mingyu-core/wuyun-liuqi';
 import { TraditionalDivinationBoard } from '../src/components/DivinationPanel/TraditionalDivinationBoard';
 import type { DivinationSession } from '../src/lib/divination/engine';
 import type { DivinationData, QimenData } from '../src/types/divination';
@@ -39,11 +40,20 @@ test('主要占卜传统盘应能使用当前核心数据直接渲染', () => {
     ['tarot', drawTarotSpread('single'), /塔罗/],
     ['ssgw', drawRandomSign(FIXED_DATE), /签/],
     ['lenormand', drawLenormandSpread('single'), /雷诺曼/],
+    ['wuyun', calculateWuyunLiuqi({ year: 2026 }), /五运六气年度盘/],
   ];
 
   for (const [method, data, expected] of cases) {
     assert.match(renderBoard(method, data), expected, `${method}传统盘渲染失败`);
   }
+});
+
+test('五运六气年度盘展示全年主客运气事实', () => {
+  const html = renderBoard('wuyun', calculateWuyunLiuqi({ year: 2026 }));
+  assert.match(html, /丙午/u);
+  assert.match(html, /五步主客运/u);
+  assert.match(html, /六步主客气/u);
+  assert.match(html, /司天/u);
 });
 
 test('缺少可选格局标签的旧奇门记录仍应正常渲染', () => {


### PR DESCRIPTION
五运六气可从工作台按公历年或年干支排盘，并将五步主客运、六步主客气及年度关系完整带入 AI 解读。网页、公开接口与提示词共用资料格式，年度身份保留在解读请求中。

验证：包含本批的集成版本通过 1868 项单元测试、155 项 API、65 项 MCP、类型检查、提示词检查与生产构建；干净安装核心包后实际计算 2026 年五步六气成功。本 PR 的全部 CI 与 Pages 检查通过。

真实预览验证了默认 2026 年、指定 2030 年庚戌、年干支不一致报错、刷新后历史回放，以及实际提示词的完整五步六气日期和关系。320 像素宽度下结果页和提示词页均无横向溢出。外部模型与 Android 真机尚未验证。

核心包版本保持 0.2.4。本 PR 为审查候选，未合并或发布。
