### PR TITLE
补全奇门终身局的实际日月应期与阶段边界

### DIFF
--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -207,7 +207,31 @@ function getMonthClashTermFacts(
 
 function getStageIndexForDate(stages: QimenLifetimeStage[], date: string): number {
   const matched = stages.find((stage) => stage.calendarStart <= date && stage.calendarEnd >= date);
-  return matched?.stageIndex ?? stages[0]?.stageIndex ?? 0;
+  if (!matched) {
+    throw new Error(`动态事实日期 ${date} 不在任何人生阶段范围内。`);
+  }
+  return matched.stageIndex;
+}
+
+function validateStageCoverage(
+  stages: QimenLifetimeStage[],
+  start: LifetimeDateParts,
+  end: LifetimeDateParts,
+): void {
+  if (stages.length === 0) {
+    throw new Error('终身局阶段范围不能为空。');
+  }
+  const firstDate = stages.reduce(
+    (current, stage) => (stage.calendarStart < current ? stage.calendarStart : current),
+    stages[0].calendarStart,
+  );
+  const lastDate = stages.reduce(
+    (current, stage) => (stage.calendarEnd > current ? stage.calendarEnd : current),
+    stages[0].calendarEnd,
+  );
+  if (formatLifetimeDate(start) < firstDate || formatLifetimeDate(end) > lastDate) {
+    throw new Error(`periodRange 必须落在终身局阶段范围内（${firstDate} 至 ${lastDate}）。`);
+  }
 }
 
 function collectDailyRelationFacts(
@@ -271,6 +295,41 @@ function getDynamicOffsetMinutes(
   return timeContext?.fallbackOffsetMinutes ?? DEFAULT_CHINA_TIMEZONE_HOURS * 60;
 }
 
+function appendMonthClashCluster(
+  clusters: QimenEventCluster[],
+  baseChart: QimenData,
+  stages: QimenLifetimeStage[],
+  year: number,
+  flowYearGanZhi: string,
+  start: LifetimeDateParts,
+  end: LifetimeDateParts,
+  timeContext: QimenDynamicTimeContext | undefined,
+  getPalaceName: (palace: number) => string,
+): void {
+  const flowYearBranch = flowYearGanZhi[1];
+  const clashBranch = OPPOSITE_BRANCHES[flowYearBranch];
+  const clashPalace = clashBranch ? diPanPalaces[clashBranch] : undefined;
+  if (!clashPalace) return;
+
+  const termFacts = getMonthClashTermFacts(clashBranch, year, start, end, timeContext);
+  if (termFacts.length === 0) return;
+
+  const termDates = termFacts.map((fact) => fact.date);
+  clusters.push({
+    key: `cluster:${year}:month-clash:${clashBranch}:${termDates.join(',')}`,
+    stageIndex: getStageIndexForDate(stages, termFacts[0]!.date),
+    timeSpan: `${termDates.join('、')}${clashBranch}月建交节`,
+    triggerDates: termFacts,
+    topics: ['career', 'relocation'],
+    triggerFact: `${year}年流年${flowYearGanZhi}对应的${clashBranch}月建交节日为${termFacts.map((fact) => fact.dateTime ?? fact.date).join('、')}，该月支与年支相冲，落${getPalaceName(clashPalace)}。`,
+    interactionAnalysis: `月建${clashBranch}与${flowYearGanZhi}年支${flowYearBranch}构成相冲；交节日期按目标时区的真实当地时间列出。`,
+    supportEvidence: [`${clashBranch}月建交节日：${termDates.join('、')}`],
+    counterEvidence: [],
+    rhythm: '快',
+    verificationQuestions: [`交节日前后是否出现阶段性决策、迁动或环境变化？`],
+  });
+}
+
 /**
  * 扫描指定时间范围内的流年动态事件簇
  */
@@ -287,12 +346,38 @@ export function scanLifetimeDynamicEvents(
 
   const start = parseLifetimePeriodDate(periodRange.startDate, 'periodRange.startDate');
   const end = parseLifetimePeriodDate(periodRange.endDate, 'periodRange.endDate');
+  validateStageCoverage(stages, start, end);
   const startYear = start.year;
   const endYear = end.year;
   const maxEndYear = endYear;
 
   const getPalaceName = (p: number) =>
     baseChart.jiuGongGe.find((item) => item.gong === p)?.name || `${p}宫`;
+
+  // 查询从一月开始时，补查上一干支年的丑月小寒节点；该节点落在当前公历年一月。
+  if (start.month === 1 && startYear > 1) {
+    const previousFlowYear = startYear - 1;
+    const previousMidYearDate = new Date(
+      createUtcTimestamp(previousFlowYear, 5, 15, 12, 0, 0),
+    );
+    const previousYearGanZhi = getDivinationTime(
+      previousMidYearDate,
+      DEFAULT_CHINA_TIMEZONE_HOURS * 60,
+    ).ganzhi.year;
+    if (previousYearGanZhi[1] === '未') {
+      appendMonthClashCluster(
+        clusters,
+        baseChart,
+        stages,
+        previousFlowYear,
+        previousYearGanZhi,
+        start,
+        end,
+        timeContext,
+        getPalaceName,
+      );
+    }
+  }
 
   for (let y = startYear; y <= maxEndYear; y++) {
     const midYearDate = new Date(createUtcTimestamp(y, 5, 15, 12, 0, 0));
@@ -321,11 +406,15 @@ export function scanLifetimeDynamicEvents(
     const basePalace = baseChart.jiuGongGe.find((p) => p.gong === taiSuiPalaceNum);
     if (!basePalace) continue;
 
-    // 匹配所属阶段卡
-    const yStr = `${y}-06-15`;
-    const matchedStage =
-      stages.find((s) => s.calendarStart <= yStr && s.calendarEnd >= yStr) || stages[0];
-    const stageIndex = matchedStage ? matchedStage.stageIndex : 0;
+    // 用请求范围内的年度代表日匹配阶段卡，避免年初或年末窗口落到代表日之外。
+    const yearRepresentative = { year: y, month: 6, day: 15 };
+    const representativeDate =
+      dateKey(yearRepresentative) < dateKey(start)
+        ? start
+        : dateKey(yearRepresentative) > dateKey(end)
+          ? end
+          : yearRepresentative;
+    const stageIndex = getStageIndexForDate(stages, formatLifetimeDate(representativeDate));
 
     const topics: QimenTopic[] = [];
     const supportEvidence: string[] = [];
@@ -443,27 +532,17 @@ export function scanLifetimeDynamicEvents(
     });
 
     // 细化年月日关键节点：节令只记录真实交节日，日级只记录已有本命关系命中的当地日期。
-    const clashBranch = OPPOSITE_BRANCHES[flowYearBranch];
-    const clashPalace = clashBranch ? diPanPalaces[clashBranch] : undefined;
-    if (clashPalace) {
-      const termFacts = getMonthClashTermFacts(clashBranch, y, start, end, timeContext);
-      if (termFacts.length > 0) {
-        const termDates = termFacts.map((fact) => fact.date);
-        clusters.push({
-          key: `cluster:${y}:month-clash:${clashBranch}:${termDates.join(',')}`,
-          stageIndex: termFacts[0] ? getStageIndexForDate(stages, termFacts[0].date) : stageIndex,
-          timeSpan: `${termDates.join('、')}${clashBranch}月建交节`,
-          triggerDates: termFacts,
-          topics: ['career', 'relocation'],
-          triggerFact: `${y}年流年${flowYearGanZhi}对应的${clashBranch}月建交节日为${termFacts.map((fact) => fact.dateTime ?? fact.date).join('、')}，该月支与年支相冲，落${getPalaceName(clashPalace)}。`,
-          interactionAnalysis: `月建${clashBranch}与${flowYearGanZhi}年支${flowYearBranch}构成相冲；交节日期按目标时区的真实当地时间列出。`,
-          supportEvidence: [`${clashBranch}月建交节日：${termDates.join('、')}`],
-          counterEvidence: [],
-          rhythm: '快',
-          verificationQuestions: [`交节日前后是否出现阶段性决策、迁动或环境变化？`],
-        });
-      }
-    }
+    appendMonthClashCluster(
+      clusters,
+      baseChart,
+      stages,
+      y,
+      flowYearGanZhi,
+      start,
+      end,
+      timeContext,
+      getPalaceName,
+    );
 
     const yearStart = { year: y, month: 1, day: 1 };
     const yearEnd = { year: y, month: 12, day: 31 };

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -1,18 +1,24 @@
 /**
  * @file 奇门终身局动态扫描与事件聚类模块
  * @description 根据用户请求的时间区间（periodRange），按年扫描流年太岁引动、
- * 空亡填实、马星引动与年家盘叠合，聚类生成结构化事件簇（Event Clusters）。
+ * 空亡填实、马星引动与年家盘叠合，并列出可复核的交节日与日支关系。
  */
 
+import { SolarTerm } from 'tyme4ts';
 import type {
   QimenData,
   QimenEventCluster,
   QimenLifetimeStage,
   QimenTopic,
 } from '../../../../types/divination';
-import { DEFAULT_CHINA_TIMEZONE_HOURS } from '../../../../calendar/civil-time';
+import {
+  DEFAULT_CHINA_TIMEZONE_HOURS,
+  resolveCivilTime,
+  type CivilDateTimeParts,
+} from '../../../../calendar/civil-time';
 import { getHistoricalTimezoneOffsetAt } from '../../../../calendar/historical-timezone';
 import { createUtcTimestamp, daysInGregorianMonth } from '../../../../calendar/date-validation';
+import { TimeManager, getDivinationTime } from '../../../../calendar/timeManager';
 import { generateQimen } from '../index';
 import { diPanPalaces } from './_constants';
 
@@ -75,6 +81,180 @@ const OPPOSITE_BRANCHES: Record<string, string> = {
   亥: '巳',
 };
 
+const MONTH_BRANCH_TERM_INDEX: Record<string, number> = {
+  寅: 3,
+  卯: 5,
+  辰: 7,
+  巳: 9,
+  午: 11,
+  未: 13,
+  申: 15,
+  酉: 17,
+  戌: 19,
+  亥: 21,
+  子: 23,
+  丑: 1,
+};
+
+type LifetimeDateParts = ReturnType<typeof parseLifetimePeriodDate>;
+
+interface LifetimeDateFact {
+  date: string;
+  dateTime?: string;
+  ganzhi?: string;
+  relation?: string;
+}
+
+function formatLifetimeDate(value: Pick<CivilDateTimeParts, 'year' | 'month' | 'day'>): string {
+  return `${String(value.year).padStart(4, '0')}-${String(value.month).padStart(2, '0')}-${String(value.day).padStart(2, '0')}`;
+}
+
+function formatLifetimeDateTime(value: CivilDateTimeParts): string {
+  return `${formatLifetimeDate(value)} ${String(value.hour).padStart(2, '0')}:${String(value.minute).padStart(2, '0')}:${String(value.second).padStart(2, '0')}`;
+}
+
+function dateKey(value: Pick<CivilDateTimeParts, 'year' | 'month' | 'day'>): number {
+  return value.year * 10000 + value.month * 100 + value.day;
+}
+
+function isDateWithin(
+  value: Pick<CivilDateTimeParts, 'year' | 'month' | 'day'>,
+  start: LifetimeDateParts,
+  end: LifetimeDateParts,
+): boolean {
+  const key = dateKey(value);
+  return key >= dateKey(start) && key <= dateKey(end);
+}
+
+function nextLifetimeDate(value: LifetimeDateParts): LifetimeDateParts {
+  const next = new Date(
+    createUtcTimestamp(value.year, value.month - 1, value.day, 12, 0, 0) + 86400000,
+  );
+  return {
+    year: next.getUTCFullYear(),
+    month: next.getUTCMonth() + 1,
+    day: next.getUTCDate(),
+  };
+}
+
+function resolveLifetimeNoon(
+  value: LifetimeDateParts,
+  timeContext: QimenDynamicTimeContext | undefined,
+): { date: Date; offsetMinutes: number } {
+  const timeZoneId = timeContext?.timeZoneId?.trim();
+  const resolved = resolveCivilTime(
+    {
+      ...value,
+      hour: 12,
+      minute: 0,
+      second: 0,
+      ...(timeZoneId
+        ? { timeZoneId }
+        : {
+            timezone:
+              timeContext?.timezone ??
+              (timeContext?.fallbackOffsetMinutes ?? DEFAULT_CHINA_TIMEZONE_HOURS * 60) / 60,
+          }),
+    },
+    { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
+  );
+  return { date: new Date(resolved.utcTimestamp), offsetMinutes: resolved.timezone * 60 };
+}
+
+function getTermInstant(termYear: number, termIndex: number): Date {
+  const termTime = SolarTerm.fromIndex(termYear, termIndex).getJulianDay().getSolarTime();
+  const resolved = resolveCivilTime({
+    year: termTime.getYear(),
+    month: termTime.getMonth(),
+    day: termTime.getDay(),
+    hour: termTime.getHour(),
+    minute: termTime.getMinute(),
+    second: termTime.getSecond(),
+    timezone: DEFAULT_CHINA_TIMEZONE_HOURS,
+  });
+  return new Date(resolved.utcTimestamp);
+}
+
+function getLocalTermFact(
+  termYear: number,
+  termIndex: number,
+  timeContext: QimenDynamicTimeContext | undefined,
+): LifetimeDateFact {
+  const termInstant = getTermInstant(termYear, termIndex);
+  const offsetMinutes = getDynamicOffsetMinutes(termInstant, timeContext);
+  const localTime = TimeManager.getWallClockParts(termInstant, offsetMinutes);
+  return {
+    date: formatLifetimeDate(localTime),
+    dateTime: formatLifetimeDateTime(localTime),
+  };
+}
+
+function getMonthClashTermFacts(
+  branch: string,
+  year: number,
+  start: LifetimeDateParts,
+  end: LifetimeDateParts,
+  timeContext: QimenDynamicTimeContext | undefined,
+): LifetimeDateFact[] {
+  const termIndex = MONTH_BRANCH_TERM_INDEX[branch];
+  if (termIndex === undefined) return [];
+
+  const facts: LifetimeDateFact[] = [];
+  for (let termYear = Math.max(1, year - 1); termYear <= year + 1; termYear += 1) {
+    const fact = getLocalTermFact(termYear, termIndex, timeContext);
+    const parts = parseLifetimePeriodDate(fact.date, '交节日期');
+    if (isDateWithin(parts, start, end) && !facts.some((item) => item.date === fact.date)) {
+      facts.push({ ...fact, relation: `${branch}月建交节` });
+    }
+  }
+  return facts;
+}
+
+function getStageIndexForDate(stages: QimenLifetimeStage[], date: string): number {
+  const matched = stages.find((stage) => stage.calendarStart <= date && stage.calendarEnd >= date);
+  return matched?.stageIndex ?? stages[0]?.stageIndex ?? 0;
+}
+
+function collectDailyRelationFacts(
+  start: LifetimeDateParts,
+  end: LifetimeDateParts,
+  baseChart: QimenData,
+  timeContext: QimenDynamicTimeContext | undefined,
+): Map<string, LifetimeDateFact[]> {
+  const groups = new Map<string, LifetimeDateFact[]>();
+  const horseBranch = baseChart.horseStar?.branch;
+  const voidBranches = new Set(baseChart.voidBranches ?? []);
+  let current = start;
+
+  while (dateKey(current) <= dateKey(end)) {
+    const dateText = formatLifetimeDate(current);
+    const { date, offsetMinutes } = resolveLifetimeNoon(current, timeContext);
+    const dayGanZhi = getDivinationTime(date, offsetMinutes).ganzhi.day;
+    const dayBranch = dayGanZhi.charAt(1);
+    const relations: Array<[string, string]> = [];
+
+    if (voidBranches.has(dayBranch)) {
+      relations.push(['void-fill', `本命空亡填实（${Array.from(voidBranches).join('、')}）`]);
+    }
+    if (horseBranch && dayBranch === horseBranch) {
+      relations.push(['horse-same', `日支同本命驿马（${horseBranch}）`]);
+    }
+    if (horseBranch && OPPOSITE_BRANCHES[horseBranch] === dayBranch) {
+      relations.push(['horse-clash', `日支冲本命驿马（${horseBranch}）`]);
+    }
+
+    for (const [kind, relation] of relations) {
+      const facts = groups.get(kind) ?? [];
+      facts.push({ date: dateText, ganzhi: dayGanZhi, relation });
+      groups.set(kind, facts);
+    }
+
+    current = nextLifetimeDate(current);
+  }
+
+  return groups;
+}
+
 function getIanaOffsetMinutesAt(date: Date, timeZoneId: string): number {
   const offsetMinutes = getHistoricalTimezoneOffsetAt(date, timeZoneId) * 60;
   if (!Number.isFinite(offsetMinutes) || offsetMinutes < -720 || offsetMinutes > 840) {
@@ -107,17 +287,14 @@ export function scanLifetimeDynamicEvents(
   juMethod: 'chaibu' | 'zhirun' = 'chaibu',
   timeContext?: QimenDynamicTimeContext,
 ): QimenEventCluster[] {
+  validateLifetimePeriodRange(periodRange);
   const clusters: QimenEventCluster[] = [];
 
-  const startYear = parseInt(periodRange.startDate.slice(0, 4), 10);
-  const endYear = parseInt(periodRange.endDate.slice(0, 4), 10);
-
-  if (isNaN(startYear) || isNaN(endYear) || endYear < startYear) {
-    return clusters;
-  }
-
-  // 限制扫描范围最多 30 年，防止过度计算
-  const maxEndYear = Math.min(endYear, startYear + 30);
+  const start = parseLifetimePeriodDate(periodRange.startDate, 'periodRange.startDate');
+  const end = parseLifetimePeriodDate(periodRange.endDate, 'periodRange.endDate');
+  const startYear = start.year;
+  const endYear = end.year;
+  const maxEndYear = endYear;
 
   const getPalaceName = (p: number) =>
     baseChart.jiuGongGe.find((item) => item.gong === p)?.name || `${p}宫`;
@@ -270,56 +447,81 @@ export function scanLifetimeDynamicEvents(
       verificationQuestions: Array.from(new Set(verificationQuestions)),
     });
 
-    // 细化年月日关键节点扫描（针对短周期或重点转折年份扫描关键月日节令触发）
-    if (maxEndYear - startYear <= 3) {
-      // 提取该年与年支冲合的关键月（以月将与节令月支考察）
-      const clashBranchMap: Record<string, string> = {
-        子: '午',
-        丑: '未',
-        寅: '申',
-        卯: '酉',
-        辰: '戌',
-        巳: '亥',
-        午: '子',
-        未: '丑',
-        申: '寅',
-        酉: '卯',
-        戌: '辰',
-        亥: '巳',
-      };
-      const clashBranch = clashBranchMap[flowYearBranch];
-      const clashPalace = clashBranch ? diPanPalaces[clashBranch] : undefined;
-
-      if (clashPalace) {
+    // 细化年月日关键节点：节令只记录真实交节日，日级只记录已有本命关系命中的当地日期。
+    const clashBranch = OPPOSITE_BRANCHES[flowYearBranch];
+    const clashPalace = clashBranch ? diPanPalaces[clashBranch] : undefined;
+    if (clashPalace) {
+      const termFacts = getMonthClashTermFacts(clashBranch, y, start, end, timeContext);
+      if (termFacts.length > 0) {
+        const termDates = termFacts.map((fact) => fact.date);
         clusters.push({
-          key: `cluster:${y}:month-clash:${clashBranch}`,
-          stageIndex,
-          timeSpan: `${y}年${clashBranch}月建交气节点`,
+          key: `cluster:${y}:month-clash:${clashBranch}:${termDates.join(',')}`,
+          stageIndex: termFacts[0] ? getStageIndexForDate(stages, termFacts[0].date) : stageIndex,
+          timeSpan: `${termDates.join('、')}${clashBranch}月建交节`,
+          triggerDates: termFacts,
           topics: ['career', 'relocation'],
-          triggerFact: `${y}年流月逢${clashBranch}月建冲起${getPalaceName(clashPalace)}，形成月令冲合震荡。`,
-          interactionAnalysis: `月令与岁气本命对冲，气机骤变，主关键事务抉择或环境转折。`,
-          supportEvidence: [`逢冲则动，利于突破僵局与陈旧瓶颈`],
-          counterEvidence: [`月令逢冲动应强烈，需防急躁冒进导致节外生枝`],
+          triggerFact: `${y}年流年${flowYearGanZhi}对应的${clashBranch}月建交节日为${termFacts.map((fact) => fact.dateTime ?? fact.date).join('、')}，该月支与年支相冲，落${getPalaceName(clashPalace)}。`,
+          interactionAnalysis: `月建${clashBranch}与${flowYearGanZhi}年支${flowYearBranch}构成相冲；交节日期按目标时区的真实当地时间列出。`,
+          supportEvidence: [`${clashBranch}月建交节日：${termDates.join('、')}`],
+          counterEvidence: [],
           rhythm: '快',
-          verificationQuestions: [`该月份是否有阶段性关键决策、动迁走动或人事变动？`],
+          verificationQuestions: [`交节日前后是否出现阶段性决策、迁动或环境变化？`],
         });
       }
+    }
 
-      // 若具体指定了日期范围，增加关键日辰触发点
-      if (periodRange.startDate.length >= 10) {
-        clusters.push({
-          key: `cluster:${periodRange.startDate}:day-nodal`,
-          stageIndex,
-          timeSpan: `${periodRange.startDate}至${periodRange.endDate}关键动应日`,
-          topics: ['career'],
-          triggerFact: `指定日期窗口引动本命${getPalaceName(taiSuiPalaceNum)}，形成日辰时空感应。`,
-          interactionAnalysis: `日辰为事之先声，时令地气在此区间交汇显现。`,
-          supportEvidence: [`日辰引动为具体事项之契机发端`],
-          counterEvidence: [`日力轻微，需配合月建大势研判`],
-          rhythm: '快',
-          verificationQuestions: [`指定日前后是否有具体的签约、会谈或突发事件发生？`],
-        });
+    const yearStart = { year: y, month: 1, day: 1 };
+    const yearEnd = { year: y, month: 12, day: 31 };
+    const dailyStart = dateKey(start) > dateKey(yearStart) ? start : yearStart;
+    const dailyEnd = dateKey(end) < dateKey(yearEnd) ? end : yearEnd;
+    const dailyGroups = collectDailyRelationFacts(dailyStart, dailyEnd, baseChart, timeContext);
+    const dailyRelationMeta: Record<
+      string,
+      {
+        label: string;
+        topics: QimenTopic[];
+        rhythm: '快' | '中' | '慢' | '待机';
+        question: string;
       }
+    > = {
+      'void-fill': {
+        label: '本命空亡填实',
+        topics: ['career'],
+        rhythm: '中',
+        question: '这些日辰是否对应原先悬而未决事项出现实质推进？',
+      },
+      'horse-same': {
+        label: '日支同本命驿马',
+        topics: ['relocation'],
+        rhythm: '快',
+        question: '这些日辰是否对应出行、迁动或跨区域安排？',
+      },
+      'horse-clash': {
+        label: '日支冲本命驿马',
+        topics: ['relocation'],
+        rhythm: '快',
+        question: '这些日辰是否对应行程变化、迁动或节奏加速？',
+      },
+    };
+
+    for (const [relationKey, facts] of dailyGroups) {
+      const relation = dailyRelationMeta[relationKey];
+      if (!relation || facts.length === 0) continue;
+      const dateTexts = facts.map((fact) => fact.date);
+      const dailyStageIndex = getStageIndexForDate(stages, dateTexts[0] as string);
+      clusters.push({
+        key: `cluster:${y}:day:${relationKey}:${dateTexts[0]}-${dateTexts[dateTexts.length - 1]}`,
+        stageIndex: dailyStageIndex,
+        timeSpan: `${y}年${relation.label}`,
+        triggerDates: facts,
+        topics: relation.topics,
+        triggerFact: `${y}年窗口内有${facts.length}个日干支符合${relation.label}。`,
+        interactionAnalysis: `按当地民用日读取日支与本命${relation.label}关系，结合具体日期核验该层时间关系。`,
+        supportEvidence: [`命中日干支：${facts.map((fact) => fact.ganzhi).join('、')}`],
+        counterEvidence: [],
+        rhythm: relation.rhythm,
+        verificationQuestions: [relation.question],
+      });
     }
   }
 

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -205,33 +205,9 @@ function getMonthClashTermFacts(
   return isDateWithin(parts, start, end) ? [{ ...fact, relation: `${branch}月建交节` }] : [];
 }
 
-function getStageIndexForDate(stages: QimenLifetimeStage[], date: string): number {
+function getStageIndexForDate(stages: QimenLifetimeStage[], date: string): number | undefined {
   const matched = stages.find((stage) => stage.calendarStart <= date && stage.calendarEnd >= date);
-  if (!matched) {
-    throw new Error(`动态事实日期 ${date} 不在任何人生阶段范围内。`);
-  }
-  return matched.stageIndex;
-}
-
-function validateStageCoverage(
-  stages: QimenLifetimeStage[],
-  start: LifetimeDateParts,
-  end: LifetimeDateParts,
-): void {
-  if (stages.length === 0) {
-    throw new Error('终身局阶段范围不能为空。');
-  }
-  const firstDate = stages.reduce(
-    (current, stage) => (stage.calendarStart < current ? stage.calendarStart : current),
-    stages[0].calendarStart,
-  );
-  const lastDate = stages.reduce(
-    (current, stage) => (stage.calendarEnd > current ? stage.calendarEnd : current),
-    stages[0].calendarEnd,
-  );
-  if (formatLifetimeDate(start) < firstDate || formatLifetimeDate(end) > lastDate) {
-    throw new Error(`periodRange 必须落在终身局阶段范围内（${firstDate} 至 ${lastDate}）。`);
-  }
+  return matched?.stageIndex;
 }
 
 function collectDailyRelationFacts(
@@ -345,7 +321,6 @@ export function scanLifetimeDynamicEvents(
 
   const start = parseLifetimePeriodDate(periodRange.startDate, 'periodRange.startDate');
   const end = parseLifetimePeriodDate(periodRange.endDate, 'periodRange.endDate');
-  validateStageCoverage(stages, start, end);
   const startYear = start.year;
   const endYear = end.year;
   const maxEndYear = endYear;
@@ -356,9 +331,7 @@ export function scanLifetimeDynamicEvents(
   // 查询从一月开始时，补查上一干支年的丑月小寒节点；该节点落在当前公历年一月。
   if (start.month === 1 && startYear > 1) {
     const previousFlowYear = startYear - 1;
-    const previousMidYearDate = new Date(
-      createUtcTimestamp(previousFlowYear, 5, 15, 12, 0, 0),
-    );
+    const previousMidYearDate = new Date(createUtcTimestamp(previousFlowYear, 5, 15, 12, 0, 0));
     const previousYearGanZhi = getDivinationTime(
       previousMidYearDate,
       DEFAULT_CHINA_TIMEZONE_HOURS * 60,
@@ -578,7 +551,7 @@ export function scanLifetimeDynamicEvents(
     for (const [relationKey, facts] of dailyGroups) {
       const relation = dailyRelationMeta[relationKey];
       if (!relation || facts.length === 0) continue;
-      const stageGroups = new Map<number, LifetimeDateFact[]>();
+      const stageGroups = new Map<number | undefined, LifetimeDateFact[]>();
       for (const fact of facts) {
         const dailyStageIndex = getStageIndexForDate(stages, fact.date);
         const stageFacts = stageGroups.get(dailyStageIndex) ?? [];

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -297,7 +297,6 @@ function getDynamicOffsetMinutes(
 
 function appendMonthClashCluster(
   clusters: QimenEventCluster[],
-  baseChart: QimenData,
   stages: QimenLifetimeStage[],
   year: number,
   flowYearGanZhi: string,
@@ -367,7 +366,6 @@ export function scanLifetimeDynamicEvents(
     if (previousYearGanZhi[1] === '未') {
       appendMonthClashCluster(
         clusters,
-        baseChart,
         stages,
         previousFlowYear,
         previousYearGanZhi,
@@ -534,7 +532,6 @@ export function scanLifetimeDynamicEvents(
     // 细化年月日关键节点：节令只记录真实交节日，日级只记录已有本命关系命中的当地日期。
     appendMonthClashCluster(
       clusters,
-      baseChart,
       stages,
       y,
       flowYearGanZhi,

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -199,15 +199,10 @@ function getMonthClashTermFacts(
   const termIndex = MONTH_BRANCH_TERM_INDEX[branch];
   if (termIndex === undefined) return [];
 
-  const facts: LifetimeDateFact[] = [];
-  for (let termYear = Math.max(1, year - 1); termYear <= year + 1; termYear += 1) {
-    const fact = getLocalTermFact(termYear, termIndex, timeContext);
-    const parts = parseLifetimePeriodDate(fact.date, '交节日期');
-    if (isDateWithin(parts, start, end) && !facts.some((item) => item.date === fact.date)) {
-      facts.push({ ...fact, relation: `${branch}月建交节` });
-    }
-  }
-  return facts;
+  // 丑月自次年小寒开始，仍属于本年立春起算的干支年。
+  const fact = getLocalTermFact(branch === '丑' ? year + 1 : year, termIndex, timeContext);
+  const parts = parseLifetimePeriodDate(fact.date, '交节日期');
+  return isDateWithin(parts, start, end) ? [{ ...fact, relation: `${branch}月建交节` }] : [];
 }
 
 function getStageIndexForDate(stages: QimenLifetimeStage[], date: string): number {
@@ -507,21 +502,29 @@ export function scanLifetimeDynamicEvents(
     for (const [relationKey, facts] of dailyGroups) {
       const relation = dailyRelationMeta[relationKey];
       if (!relation || facts.length === 0) continue;
-      const dateTexts = facts.map((fact) => fact.date);
-      const dailyStageIndex = getStageIndexForDate(stages, dateTexts[0] as string);
-      clusters.push({
-        key: `cluster:${y}:day:${relationKey}:${dateTexts[0]}-${dateTexts[dateTexts.length - 1]}`,
-        stageIndex: dailyStageIndex,
-        timeSpan: `${y}年${relation.label}`,
-        triggerDates: facts,
-        topics: relation.topics,
-        triggerFact: `${y}年窗口内有${facts.length}个日干支符合${relation.label}。`,
-        interactionAnalysis: `按当地民用日读取日支与本命${relation.label}关系，结合具体日期核验该层时间关系。`,
-        supportEvidence: [`命中日干支：${facts.map((fact) => fact.ganzhi).join('、')}`],
-        counterEvidence: [],
-        rhythm: relation.rhythm,
-        verificationQuestions: [relation.question],
-      });
+      const stageGroups = new Map<number, LifetimeDateFact[]>();
+      for (const fact of facts) {
+        const dailyStageIndex = getStageIndexForDate(stages, fact.date);
+        const stageFacts = stageGroups.get(dailyStageIndex) ?? [];
+        stageFacts.push(fact);
+        stageGroups.set(dailyStageIndex, stageFacts);
+      }
+      for (const [dailyStageIndex, stageFacts] of stageGroups) {
+        const dateTexts = stageFacts.map((fact) => fact.date);
+        clusters.push({
+          key: `cluster:${y}:day:${relationKey}:${dateTexts[0]}-${dateTexts[dateTexts.length - 1]}`,
+          stageIndex: dailyStageIndex,
+          timeSpan: `${y}年${relation.label}`,
+          triggerDates: stageFacts,
+          topics: relation.topics,
+          triggerFact: `${y}年本阶段窗口内有${stageFacts.length}个日干支符合${relation.label}。`,
+          interactionAnalysis: `按当地民用日读取日支与本命${relation.label}关系，结合具体日期核验该层时间关系。`,
+          supportEvidence: [`日支关系：${stageFacts[0]?.relation}`],
+          counterEvidence: [],
+          rhythm: relation.rhythm,
+          verificationQuestions: [relation.question],
+        });
+      }
     }
   }
 

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
@@ -7,11 +7,13 @@
 import type { QimenLifetimeData } from '../../../../types/divination';
 import { formatFixedTimezoneOffset } from '../../../../calendar/civil-time';
 
-type TriggerDate = NonNullable<NonNullable<QimenLifetimeData['eventClusters']>[number]['triggerDates']>[number];
+type TriggerDate = NonNullable<
+  NonNullable<QimenLifetimeData['eventClusters']>[number]['triggerDates']
+>[number];
 
 function formatTriggerDate(item: TriggerDate): string {
   const detail = [item.ganzhi, item.relation].filter(Boolean).join('，');
-  return detail ? `${item.dateTime ?? item.date}（${detail}）` : item.dateTime ?? item.date;
+  return detail ? `${item.dateTime ?? item.date}（${detail}）` : (item.dateTime ?? item.date);
 }
 
 function formatTriggerDates(items: TriggerDate[]): string[] {
@@ -21,12 +23,7 @@ function formatTriggerDates(items: TriggerDate[]): string[] {
   const outputs: Output[] = [];
   const groups = new Map<string, DateGroup>();
   for (const item of items) {
-    if (
-      !item.dateTime &&
-      item.ganzhi &&
-      item.relation &&
-      /^\d{4}-\d{2}-\d{2}$/u.test(item.date)
-    ) {
+    if (!item.dateTime && item.ganzhi && item.relation && /^\d{4}-\d{2}-\d{2}$/u.test(item.date)) {
       const month = item.date.slice(0, 7);
       const key = `${month}|${item.relation}`;
       let group = groups.get(key);
@@ -207,7 +204,9 @@ export function buildLifetimePrompt(data: QimenLifetimeData, question?: string):
   if (data.eventClusters && data.eventClusters.length > 0) {
     lines.push(`【周期触发与事件簇】`);
     for (const ec of data.eventClusters) {
-      lines.push(`${ec.timeSpan} ${ec.triggerFact}（节奏：${ec.rhythm}）`);
+      lines.push(
+        `${ec.timeSpan}${ec.stageIndex === undefined ? '（阶段表范围外）' : ''} ${ec.triggerFact}（节奏：${ec.rhythm}）`,
+      );
       if (ec.triggerDates && ec.triggerDates.length > 0) {
         lines.push(...formatTriggerDates(ec.triggerDates));
       }

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
@@ -167,6 +167,18 @@ export function buildLifetimePrompt(data: QimenLifetimeData, question?: string):
     lines.push(`【周期触发与事件簇】`);
     for (const ec of data.eventClusters) {
       lines.push(`${ec.timeSpan} ${ec.triggerFact}（节奏：${ec.rhythm}）`);
+      if (ec.triggerDates && ec.triggerDates.length > 0) {
+        lines.push(
+          `  可复核日期：${ec.triggerDates
+            .map((item) => {
+              const detail = [item.ganzhi, item.relation].filter(Boolean).join('，');
+              return detail
+                ? `${item.dateTime ?? item.date}（${detail}）`
+                : (item.dateTime ?? item.date);
+            })
+            .join('、')}`,
+        );
+      }
       lines.push(`  动态交互：${ec.interactionAnalysis}`);
       if (ec.supportEvidence.length > 0) {
         lines.push(`  增益因素：${ec.supportEvidence.join('；')}`);

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-prompt.ts
@@ -7,6 +7,47 @@
 import type { QimenLifetimeData } from '../../../../types/divination';
 import { formatFixedTimezoneOffset } from '../../../../calendar/civil-time';
 
+type TriggerDate = NonNullable<NonNullable<QimenLifetimeData['eventClusters']>[number]['triggerDates']>[number];
+
+function formatTriggerDate(item: TriggerDate): string {
+  const detail = [item.ganzhi, item.relation].filter(Boolean).join('，');
+  return detail ? `${item.dateTime ?? item.date}（${detail}）` : item.dateTime ?? item.date;
+}
+
+function formatTriggerDates(items: TriggerDate[]): string[] {
+  type DateGroup = { month: string; relation: string; entries: string[] };
+  type Output = { kind: 'group'; group: DateGroup } | { kind: 'single'; text: string };
+
+  const outputs: Output[] = [];
+  const groups = new Map<string, DateGroup>();
+  for (const item of items) {
+    if (
+      !item.dateTime &&
+      item.ganzhi &&
+      item.relation &&
+      /^\d{4}-\d{2}-\d{2}$/u.test(item.date)
+    ) {
+      const month = item.date.slice(0, 7);
+      const key = `${month}|${item.relation}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { month, relation: item.relation, entries: [] };
+        groups.set(key, group);
+        outputs.push({ kind: 'group', group });
+      }
+      group.entries.push(`${item.date.slice(8, 10)}日（${item.ganzhi}）`);
+    } else {
+      outputs.push({ kind: 'single', text: formatTriggerDate(item) });
+    }
+  }
+
+  return outputs.map((output) => {
+    if (output.kind === 'single') return `  可复核日期：${output.text}`;
+    const [year, month] = output.group.month.split('-');
+    return `  可复核日期：${year}年${month}月${output.group.entries.join('、')}；日干支关系：${output.group.relation}`;
+  });
+}
+
 /**
  * 构建终身局自包含提示词任务书
  */
@@ -168,16 +209,7 @@ export function buildLifetimePrompt(data: QimenLifetimeData, question?: string):
     for (const ec of data.eventClusters) {
       lines.push(`${ec.timeSpan} ${ec.triggerFact}（节奏：${ec.rhythm}）`);
       if (ec.triggerDates && ec.triggerDates.length > 0) {
-        lines.push(
-          `  可复核日期：${ec.triggerDates
-            .map((item) => {
-              const detail = [item.ganzhi, item.relation].filter(Boolean).join('，');
-              return detail
-                ? `${item.dateTime ?? item.date}（${detail}）`
-                : (item.dateTime ?? item.date);
-            })
-            .join('、')}`,
-        );
+        lines.push(...formatTriggerDates(ec.triggerDates));
       }
       lines.push(`  动态交互：${ec.interactionAnalysis}`);
       if (ec.supportEvidence.length > 0) {

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
@@ -309,8 +309,7 @@ export function buildLifetimeStages(
       const ageEnd = (yao === 8 ? 80 : yao * 10 - 1) + ageOffset;
       const curGong = yao % 2 === 1 ? zhiFuPalace : zhiShiPalace;
       const calendarStart = addYearsToCivilDate(anchorBaseDate, (yao - 1) * 10);
-      const nextCalendarStart =
-        yao < 8 ? addYearsToCivilDate(anchorBaseDate, yao * 10) : undefined;
+      const nextCalendarStart = yao < 8 ? addYearsToCivilDate(anchorBaseDate, yao * 10) : undefined;
       const { support, constraints } = evaluatePalaceSupportAndConstraints(curGong, baseChart);
 
       const yaoTitle =

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-stages.ts
@@ -11,6 +11,7 @@ import type {
   QimenTopicCandidate,
 } from '../../../../types/divination';
 import type { CivilDateTimeParts } from '../../../../calendar/civil-time';
+import { createUtcTimestamp } from '../../../../calendar/date-validation';
 import { diPanPalaces } from './_constants';
 import { getDunJiaStem } from './jushu';
 
@@ -23,6 +24,12 @@ function addYearsToCivilDate(date: CivilDateTimeParts, years: number): string {
   const d = new Date(Date.UTC(date.year, date.month - 1, date.day));
   d.setUTCFullYear(d.getUTCFullYear() + years);
   return d.toISOString().split('T')[0];
+}
+
+function subtractOneCivilDay(value: string): string {
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(createUtcTimestamp(year, month - 1, day) - 86400000);
+  return `${String(date.getUTCFullYear()).padStart(4, '0')}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
 }
 
 /**
@@ -177,7 +184,7 @@ export function buildLifetimeStages(
         ageStart: 0 + ageOffset,
         ageEnd: 16 + ageOffset,
         calStart: addYearsToCivilDate(anchorBaseDate, 0),
-        calEnd: addYearsToCivilDate(anchorBaseDate, 16),
+        calEnd: subtractOneCivilDay(addYearsToCivilDate(anchorBaseDate, 17)),
         gongs: yearPalaces,
         theme: '年柱主限：主家庭原生教养、长辈福荫护持、学识基础与先天命质形成。',
         markers: [`年干${yearStem}`, `年支${yearBranch}`],
@@ -188,7 +195,7 @@ export function buildLifetimeStages(
         ageStart: 17 + ageOffset,
         ageEnd: 32 + ageOffset,
         calStart: addYearsToCivilDate(anchorBaseDate, 17),
-        calEnd: addYearsToCivilDate(anchorBaseDate, 32),
+        calEnd: subtractOneCivilDay(addYearsToCivilDate(anchorBaseDate, 33)),
         gongs: monthPalaces,
         theme: '月柱主限：走出家庭踏入社会、人际圈层开拓、事业基石奠定与青年自我认知。',
         markers: [`月干${monthStem}`, `月支${monthBranch}`],
@@ -199,7 +206,7 @@ export function buildLifetimeStages(
         ageStart: 33 + ageOffset,
         ageEnd: 48 + ageOffset,
         calStart: addYearsToCivilDate(anchorBaseDate, 33),
-        calEnd: addYearsToCivilDate(anchorBaseDate, 48),
+        calEnd: subtractOneCivilDay(addYearsToCivilDate(anchorBaseDate, 49)),
         gongs: dayPalaces,
         theme: '日柱主限：人生核心建树期，自身心力智慧完全展现，家庭与社会中流砥柱。',
         markers: [`日干${dayStem}`],
@@ -264,6 +271,9 @@ export function buildLifetimeStages(
       const gong = ring[(startIdx + i) % ring.length];
       const ageStart = i * yearsPerStage + ageOffset;
       const ageEnd = (i + 1) * yearsPerStage - 1 + ageOffset;
+      const calendarStart = addYearsToCivilDate(anchorBaseDate, i * yearsPerStage);
+      const nextCalendarStart =
+        i < 8 ? addYearsToCivilDate(anchorBaseDate, (i + 1) * yearsPerStage) : undefined;
       const { support, constraints } = evaluatePalaceSupportAndConstraints(gong, baseChart);
 
       stages.push({
@@ -271,8 +281,10 @@ export function buildLifetimeStages(
         title: `行限第${i + 1}步（${getPalaceName(gong)}）`,
         ageStart,
         ageEnd,
-        calendarStart: addYearsToCivilDate(anchorBaseDate, i * yearsPerStage),
-        calendarEnd: addYearsToCivilDate(anchorBaseDate, (i + 1) * yearsPerStage - 1),
+        calendarStart,
+        calendarEnd: nextCalendarStart
+          ? subtractOneCivilDay(nextCalendarStart)
+          : addYearsToCivilDate(anchorBaseDate, (i + 1) * yearsPerStage - 1),
         dominantPalaces: [{ palace: gong, name: getPalaceName(gong) }],
         associatedMarkers: [`行限临${getPalaceName(gong)}`],
         stageTheme: `九宫巡行运限：当值${getPalaceName(gong)}，能量由该宫门星神干及奇仪克应主导。`,
@@ -296,6 +308,9 @@ export function buildLifetimeStages(
       const ageStart = (yao - 1) * 10 + ageOffset;
       const ageEnd = (yao === 8 ? 80 : yao * 10 - 1) + ageOffset;
       const curGong = yao % 2 === 1 ? zhiFuPalace : zhiShiPalace;
+      const calendarStart = addYearsToCivilDate(anchorBaseDate, (yao - 1) * 10);
+      const nextCalendarStart =
+        yao < 8 ? addYearsToCivilDate(anchorBaseDate, yao * 10) : undefined;
       const { support, constraints } = evaluatePalaceSupportAndConstraints(curGong, baseChart);
 
       const yaoTitle =
@@ -310,8 +325,10 @@ export function buildLifetimeStages(
         title: yaoTitle,
         ageStart,
         ageEnd,
-        calendarStart: addYearsToCivilDate(anchorBaseDate, (yao - 1) * 10),
-        calendarEnd: addYearsToCivilDate(anchorBaseDate, yao === 8 ? 80 : yao * 10 - 1),
+        calendarStart,
+        calendarEnd: nextCalendarStart
+          ? subtractOneCivilDay(nextCalendarStart)
+          : addYearsToCivilDate(anchorBaseDate, 80),
         dominantPalaces: [{ palace: curGong, name: getPalaceName(curGong) }],
         associatedMarkers: [
           yao % 2 === 1 ? `值符星${baseChart.zhiFu}` : `值使门${baseChart.zhiShi}`,

--- a/packages/core/src/divination/algorithms/qimen/lifetime.ts
+++ b/packages/core/src/divination/algorithms/qimen/lifetime.ts
@@ -95,6 +95,7 @@ export function calculateQimenLifetime(input: QimenLifetimeInput): QimenLifetime
       key: c.key,
       timeSpan: c.timeSpan,
       triggerFact: c.triggerFact,
+      ...(c.triggerDates ? { triggerDates: c.triggerDates } : {}),
       rhythm: c.rhythm,
     })),
     limitations: [

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -893,8 +893,8 @@ export interface QimenLifetimeStage {
 export interface QimenEventCluster {
   /** 事件簇唯一标识 */
   key: string;
-  /** 归属阶段索引 */
-  stageIndex: number;
+  /** 归属阶段索引；日期超出已列阶段时为空，仍保留日期关系事实。 */
+  stageIndex?: number;
   /** 时间跨度描述（如 "2027年"） */
   timeSpan: string;
   /** 可复核的日期级触发事实；不包含评分或未计算的日盘结论。 */

--- a/packages/core/src/types/divination.ts
+++ b/packages/core/src/types/divination.ts
@@ -897,6 +897,13 @@ export interface QimenEventCluster {
   stageIndex: number;
   /** 时间跨度描述（如 "2027年"） */
   timeSpan: string;
+  /** 可复核的日期级触发事实；不包含评分或未计算的日盘结论。 */
+  triggerDates?: Array<{
+    date: string;
+    dateTime?: string;
+    ganzhi?: string;
+    relation?: string;
+  }>;
   /** 涉及的人生主题 */
   topics: QimenTopic[];
   /** 触发盘事实（如流年干支、定局、太岁落宫） */
@@ -933,6 +940,7 @@ export interface QimenLifetimeEvidence {
     key: string;
     timeSpan: string;
     triggerFact: string;
+    triggerDates?: QimenEventCluster['triggerDates'];
     rhythm: string;
   }>;
   limitations: string[];

--- a/src/pages/ResultPage/components/QimenLifetimeBoard.tsx
+++ b/src/pages/ResultPage/components/QimenLifetimeBoard.tsx
@@ -460,6 +460,19 @@ export const QimenLifetimeBoard = memo(function QimenLifetimeBoard({
                   <span className="event-trigger">{cluster.triggerFact}</span>
                   <span className="event-rhythm">节奏：{cluster.rhythm}</span>
                 </div>
+                {cluster.triggerDates && cluster.triggerDates.length > 0 ? (
+                  <p className="event-dates">
+                    <strong>可复核日期：</strong>
+                    {cluster.triggerDates
+                      .map((item) => {
+                        const detail = [item.ganzhi, item.relation].filter(Boolean).join('，');
+                        return detail
+                          ? `${item.dateTime ?? item.date}（${detail}）`
+                          : (item.dateTime ?? item.date);
+                      })
+                      .join('、')}
+                  </p>
+                ) : null}
                 <p className="event-interaction">{cluster.interactionAnalysis}</p>
                 {cluster.supportEvidence.length > 0 ? (
                   <div className="event-evidence is-good">

--- a/src/pages/ResultPage/components/QimenLifetimeBoard.tsx
+++ b/src/pages/ResultPage/components/QimenLifetimeBoard.tsx
@@ -456,7 +456,10 @@ export const QimenLifetimeBoard = memo(function QimenLifetimeBoard({
             {data.eventClusters.map((cluster) => (
               <div key={cluster.key} className="qimen-lifetime-event-item">
                 <div className="event-head">
-                  <span className="event-time">{cluster.timeSpan}</span>
+                  <span className="event-time">
+                    {cluster.timeSpan}
+                    {cluster.stageIndex === undefined ? '（阶段表范围外）' : ''}
+                  </span>
                   <span className="event-trigger">{cluster.triggerFact}</span>
                   <span className="event-rhythm">节奏：{cluster.rhythm}</span>
                 </div>

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -11,6 +11,7 @@ import {
   scanLifetimeDynamicEvents,
 } from '../packages/core/src/divination/algorithms/qimen';
 import { getDivinationTime } from '../packages/core/src/calendar/timeManager';
+import { resolveCivilTime } from '../packages/core/src/calendar/civil-time';
 
 function verifiedChartSolar(chart: ReturnType<typeof generateQimen>, offset: number) {
   const expected = getDivinationTime(new Date(chart.timestamp), offset);
@@ -365,12 +366,129 @@ test('奇门终身局 P3：动态周期扫描与事件聚类（含年月日关�
     ),
     '短区间应生成月令关键节点事件簇',
   );
+  const triggerFacts = result.eventClusters.flatMap((ec) => ec.triggerDates ?? []);
+  const dailyFacts = triggerFacts.filter((fact) => fact.ganzhi);
+  assert.ok(triggerFacts.length > 0, '窗口内应保留实际日支关系日期');
+  assert.ok(triggerFacts.every((fact) => /^202[6-8]-\d{2}-\d{2}$/u.test(fact.date)));
+  assert.ok(dailyFacts.length > 0, '窗口内应保留日干支事实');
+  assert.ok(dailyFacts.every((fact) => typeof fact.ganzhi === 'string'));
+  assert.equal(
+    new Set(result.eventClusters.map((ec) => ec.key)).size,
+    result.eventClusters.length,
+    '事件簇主键必须唯一',
+  );
+  assert.ok(
+    result.eventClusters.every((ec) => !ec.key.endsWith(':day-nodal')),
+    '不能以整段窗口冒充日级节点',
+  );
+  const monthFacts = result.eventClusters
+    .filter((ec) => ec.key.includes(':month-clash:'))
+    .flatMap((ec) => ec.triggerDates ?? []);
+  assert.ok(monthFacts.length > 0, '月令节点应带真实交节日期');
+  assert.ok(monthFacts.every((fact) => /^202[6-8]-\d{2}-\d{2}$/u.test(fact.date)));
   for (const ec of result.eventClusters) {
     assert.ok(ec.key.startsWith('cluster:'));
     assert.ok(ec.topics.length > 0);
     assert.ok(ec.triggerFact.length > 0);
     assert.ok(ec.verificationQuestions.length > 0);
   }
+});
+
+test('奇门终身局日级关系应跨年裁切并保留当地日干支', () => {
+  const result = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00+08:00',
+    periodRange: {
+      startDate: '2025-01-01',
+      endDate: '2026-12-31',
+    },
+  });
+  const dates =
+    result.eventClusters
+      ?.flatMap((cluster) => cluster.triggerDates ?? [])
+      .filter((fact) => fact.ganzhi)
+      .map((fact) => fact.date) ?? [];
+  assert.ok(dates.length > 0);
+  assert.ok(dates.some((date) => date.startsWith('2025-')));
+  assert.ok(dates.some((date) => date.startsWith('2026-')));
+  assert.ok(result.eventClusters?.every((cluster) => !cluster.timeSpan.includes('至')));
+});
+
+test('奇门终身局日级关系应按纽约夏令时读取当地日期', () => {
+  const localNoon = resolveCivilTime({
+    year: 2024,
+    month: 3,
+    day: 10,
+    hour: 12,
+    minute: 0,
+    second: 0,
+    timeZoneId: 'America/New_York',
+  });
+  const expected = getDivinationTime(new Date(localNoon.utcTimestamp), -240).ganzhi.day;
+  const lifetime = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00',
+    periodRange: {
+      startDate: '2024-03-10',
+      endDate: '2024-03-10',
+    },
+    timeZoneId: 'America/New_York',
+  });
+  const { horseStar: _horseStar, ...baseChartWithoutHorse } = lifetime.baseChart;
+  const baseChart = { ...baseChartWithoutHorse, voidBranches: [expected.charAt(1)] };
+  const clusters = scanLifetimeDynamicEvents(
+    baseChart,
+    lifetime.stages,
+    { startDate: '2024-03-10', endDate: '2024-03-10' },
+    'zhuanpan',
+    'chaibu',
+    { timeZoneId: 'America/New_York' },
+  );
+  const fact = clusters
+    .flatMap((cluster) => cluster.triggerDates ?? [])
+    .find((item) => item.date === '2024-03-10');
+  assert.deepEqual(fact, {
+    date: '2024-03-10',
+    ganzhi: expected,
+    relation: `本命空亡填实（${expected.charAt(1)}）`,
+  });
+});
+
+test('奇门终身局日级关系应按 UTC+14 的当地日期读取跨 UTC 日', () => {
+  const localNoon = resolveCivilTime({
+    year: 2024,
+    month: 1,
+    day: 1,
+    hour: 12,
+    minute: 0,
+    second: 0,
+    timeZoneId: 'Pacific/Kiritimati',
+  });
+  const expected = getDivinationTime(new Date(localNoon.utcTimestamp), 840).ganzhi.day;
+  const lifetime = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00',
+    periodRange: {
+      startDate: '2024-01-01',
+      endDate: '2024-01-01',
+    },
+    timezone: 14,
+  });
+  const { horseStar: _horseStar, ...baseChartWithoutHorse } = lifetime.baseChart;
+  const baseChart = { ...baseChartWithoutHorse, voidBranches: [expected.charAt(1)] };
+  const clusters = scanLifetimeDynamicEvents(
+    baseChart,
+    lifetime.stages,
+    { startDate: '2024-01-01', endDate: '2024-01-01' },
+    'zhuanpan',
+    'chaibu',
+    { timezone: 14, fallbackOffsetMinutes: 840 },
+  );
+  const fact = clusters
+    .flatMap((cluster) => cluster.triggerDates ?? [])
+    .find((item) => item.date === '2024-01-01');
+  assert.deepEqual(fact, {
+    date: '2024-01-01',
+    ganzhi: expected,
+    relation: `本命空亡填实（${expected.charAt(1)}）`,
+  });
 });
 
 test('奇门终身局动态年盘失败应保留年份与原始原因', () => {
@@ -509,6 +627,13 @@ test('奇门终身局 P4：自包含提示词规范、多流派依据与合规�
   assert.match(prompt, /《御定奇门宝鉴》/);
   assert.match(prompt, /《奇门遁甲统宗》/);
   assert.match(prompt, /参考流派：宝鉴派、统宗派/);
+  const promptDateFact = data.eventClusters
+    ?.flatMap((cluster) => cluster.triggerDates ?? [])
+    .find((fact) => fact.ganzhi);
+  assert.ok(promptDateFact?.date, '提示词应带具体日级日期事实');
+  assert.match(prompt, new RegExp(promptDateFact?.date ?? '年-月-日'));
+  assert.doesNotMatch(prompt, /指定日期窗口引动本命/u);
+  assert.doesNotMatch(prompt, /至2027-12-31关键动应日/u);
 
   // 3. 严禁泄漏工程术语与内部层位键名
   assert.doesNotMatch(prompt, /ownerFactKeys/);

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -331,6 +331,16 @@ test('奇门终身局 P2：阶段划分引擎（四柱分限 vs 九宫巡行）'
   assert.equal(resultPillar.stages[2].ageEnd, 48);
   assert.equal(resultPillar.stages[3].ageStart, 49);
   assert.equal(resultPillar.stages[3].ageEnd, 80);
+  assert.deepEqual(
+    resultPillar.stages.map((stage) => [stage.calendarStart, stage.calendarEnd]),
+    [
+      ['1990-05-15', '2007-05-14'],
+      ['2007-05-15', '2023-05-14'],
+      ['2023-05-15', '2039-05-14'],
+      ['2039-05-15', '2070-05-15'],
+    ],
+    '生日非年初时阶段日历必须连续，不得留下整年空档',
+  );
 
   // 3. 符使卦轨模型（覆盖至 80 岁）
   const resultGuaGui = calculateQimenLifetime({
@@ -338,6 +348,8 @@ test('奇门终身局 P2：阶段划分引擎（四柱分限 vs 九宫巡行）'
     stagePolicy: { model: 'fuShiHexagramOrbit' },
   });
   assert.equal(resultGuaGui.stages.length, 8);
+  assert.equal(resultGuaGui.stages[0].calendarEnd, '2000-05-14');
+  assert.equal(resultGuaGui.stages[1].calendarStart, '2000-05-15');
   assert.equal(resultGuaGui.stages[7].ageEnd, 80);
 
   // 4. 虚岁系统测试
@@ -347,6 +359,22 @@ test('奇门终身局 P2：阶段划分引擎（四柱分限 vs 九宫巡行）'
   });
   assert.equal(resultNominal.stages[0].ageStart, 1);
   assert.equal(resultNominal.stages[0].ageEnd, 17);
+});
+
+test('奇门终身局动态扫描不得将阶段范围外日期归入首阶段', () => {
+  const lifetime = calculateQimenLifetime({ birthDateTime: '1990-05-15T14:30:00+08:00' });
+  assert.throws(
+    () =>
+      scanLifetimeDynamicEvents(
+        lifetime.baseChart,
+        lifetime.stages,
+        { startDate: '1989-01-01', endDate: '1989-12-31' },
+        'zhuanpan',
+        'chaibu',
+        { timezone: 8 },
+      ),
+    /periodRange 必须落在终身局阶段范围内/u,
+  );
 });
 
 test('奇门终身局 P3：动态周期扫描与事件聚类（含年月日关键节点）', () => {
@@ -453,6 +481,22 @@ test('奇门日级事件跨阶段时应逐日归属并保留全部日期', () =>
       .map((fact) => `${fact.date}:${fact.relation}`)
       .sort();
   assert.deepEqual(dates(clusters), dates(original));
+});
+
+test('奇门终身局一月窗口应回看上一干支年丑月交节', () => {
+  const result = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00+08:00',
+    periodRange: {
+      startDate: '2028-01-01',
+      endDate: '2028-01-31',
+    },
+  });
+  const chouMonth = result.eventClusters?.find((cluster) =>
+    cluster.key.startsWith('cluster:2027:month-clash:丑:'),
+  );
+  assert.ok(chouMonth, '一月窗口应保留上一干支年丑月的小寒节点');
+  assert.equal(chouMonth.triggerDates?.length, 1);
+  assert.match(chouMonth.triggerDates![0].date, /^2028-01-/u);
 });
 
 test('奇门终身局日级关系应跨年裁切并保留当地日干支', () => {
@@ -692,7 +736,28 @@ test('奇门终身局 P4：自包含提示词规范、多流派依据与合规�
     ?.flatMap((cluster) => cluster.triggerDates ?? [])
     .find((fact) => fact.ganzhi);
   assert.ok(promptDateFact?.date, '提示词应带具体日级日期事实');
-  assert.match(prompt, new RegExp(promptDateFact?.date ?? '年-月-日'));
+  const [promptFactYear, promptFactMonth, promptFactDay] = promptDateFact!.date.split('-');
+  assert.match(prompt, new RegExp(`${promptFactYear}年${promptFactMonth}月.*${promptFactDay}日`));
+  const promptDateLines = prompt.split('\n').filter((line) => line.includes('可复核日期：'));
+  const dailyFacts =
+    data.eventClusters
+      ?.flatMap((cluster) => cluster.triggerDates ?? [])
+      .filter((fact) => fact.ganzhi && fact.relation) ?? [];
+  for (const fact of dailyFacts) {
+    const [year, month, day] = fact.date.split('-');
+    const line = promptDateLines.find(
+      (candidate) =>
+        candidate.includes(`${year}年${month}月`) &&
+        candidate.includes(`${day}日（${fact.ganzhi}）`) &&
+        candidate.includes(`日干支关系：${fact.relation}`),
+    );
+    assert.ok(line, `提示词应保留 ${fact.date} ${fact.ganzhi} ${fact.relation}`);
+    assert.equal(
+      line!.split(`日干支关系：${fact.relation}`).length - 1,
+      1,
+      '同一月份同一关系只应输出一次关系说明',
+    );
+  }
   assert.doesNotMatch(prompt, /指定日期窗口引动本命/u);
   assert.doesNotMatch(prompt, /至2027-12-31关键动应日/u);
 

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -386,12 +386,73 @@ test('奇门终身局 P3：动态周期扫描与事件聚类（含年月日关�
     .flatMap((ec) => ec.triggerDates ?? []);
   assert.ok(monthFacts.length > 0, '月令节点应带真实交节日期');
   assert.ok(monthFacts.every((fact) => /^202[6-8]-\d{2}-\d{2}$/u.test(fact.date)));
+  const ziMonth = result.eventClusters.find((ec) =>
+    ec.key.startsWith('cluster:2026:month-clash:子:'),
+  );
+  assert.equal(ziMonth?.triggerDates?.length, 1);
+  assert.match(ziMonth!.triggerDates![0].date, /^2026-12-/u);
+  const chouMonth = result.eventClusters.find((ec) =>
+    ec.key.startsWith('cluster:2027:month-clash:丑:'),
+  );
+  assert.equal(chouMonth?.triggerDates?.length, 1);
+  assert.match(chouMonth!.triggerDates![0].date, /^2028-01-/u);
   for (const ec of result.eventClusters) {
     assert.ok(ec.key.startsWith('cluster:'));
     assert.ok(ec.topics.length > 0);
     assert.ok(ec.triggerFact.length > 0);
     assert.ok(ec.verificationQuestions.length > 0);
   }
+});
+
+test('奇门日级事件跨阶段时应逐日归属并保留全部日期', () => {
+  const lifetime = calculateQimenLifetime({ birthDateTime: '1990-05-15T14:30:00+08:00' });
+  const stages = [
+    {
+      ...lifetime.stages[0],
+      stageIndex: 0,
+      calendarStart: '2026-01-01',
+      calendarEnd: '2026-06-14',
+    },
+    {
+      ...lifetime.stages[0],
+      stageIndex: 1,
+      calendarStart: '2026-06-15',
+      calendarEnd: '2026-12-31',
+    },
+  ];
+  const clusters = scanLifetimeDynamicEvents(
+    lifetime.baseChart,
+    stages,
+    { startDate: '2026-01-01', endDate: '2026-12-31' },
+    'zhuanpan',
+    'chaibu',
+    { timezone: 8 },
+  ).filter((cluster) => cluster.key.includes(':day:'));
+  assert.ok(clusters.some((cluster) => cluster.stageIndex === 0));
+  assert.ok(clusters.some((cluster) => cluster.stageIndex === 1));
+  for (const cluster of clusters) {
+    const stage = stages[cluster.stageIndex];
+    assert.ok(cluster.triggerDates?.length);
+    assert.ok(
+      cluster.triggerDates!.every(
+        (fact) => fact.date >= stage.calendarStart && fact.date <= stage.calendarEnd,
+      ),
+    );
+  }
+  const original = scanLifetimeDynamicEvents(
+    lifetime.baseChart,
+    [{ ...stages[0], calendarEnd: '2026-12-31' }],
+    { startDate: '2026-01-01', endDate: '2026-12-31' },
+    'zhuanpan',
+    'chaibu',
+    { timezone: 8 },
+  ).filter((cluster) => cluster.key.includes(':day:'));
+  const dates = (items: typeof clusters) =>
+    items
+      .flatMap((cluster) => cluster.triggerDates ?? [])
+      .map((fact) => `${fact.date}:${fact.relation}`)
+      .sort();
+  assert.deepEqual(dates(clusters), dates(original));
 });
 
 test('奇门终身局日级关系应跨年裁切并保留当地日干支', () => {

--- a/tests/qimen-lifetime.test.ts
+++ b/tests/qimen-lifetime.test.ts
@@ -363,17 +363,22 @@ test('奇门终身局 P2：阶段划分引擎（四柱分限 vs 九宫巡行）'
 
 test('奇门终身局动态扫描不得将阶段范围外日期归入首阶段', () => {
   const lifetime = calculateQimenLifetime({ birthDateTime: '1990-05-15T14:30:00+08:00' });
-  assert.throws(
-    () =>
-      scanLifetimeDynamicEvents(
-        lifetime.baseChart,
-        lifetime.stages,
-        { startDate: '1989-01-01', endDate: '1989-12-31' },
-        'zhuanpan',
-        'chaibu',
-        { timezone: 8 },
-      ),
-    /periodRange 必须落在终身局阶段范围内/u,
+  const clusters = scanLifetimeDynamicEvents(
+    lifetime.baseChart,
+    lifetime.stages,
+    { startDate: '1989-01-01', endDate: '1989-12-31' },
+    'zhuanpan',
+    'chaibu',
+    { timezone: 8 },
+  );
+  assert.ok(clusters.length > 0);
+  assert.ok(clusters.every((cluster) => cluster.stageIndex === undefined));
+  assert.ok(clusters.some((cluster) => cluster.triggerDates?.length));
+  const keys = new Set(clusters.map((cluster) => cluster.key));
+  assert.ok(
+    lifetime.stages.every(
+      (stage) => stage.eventClusterKeys?.every((key) => !keys.has(key)) ?? true,
+    ),
   );
 });
 
@@ -459,7 +464,8 @@ test('奇门日级事件跨阶段时应逐日归属并保留全部日期', () =>
   assert.ok(clusters.some((cluster) => cluster.stageIndex === 0));
   assert.ok(clusters.some((cluster) => cluster.stageIndex === 1));
   for (const cluster of clusters) {
-    const stage = stages[cluster.stageIndex];
+    assert.notEqual(cluster.stageIndex, undefined);
+    const stage = stages[cluster.stageIndex!];
     assert.ok(cluster.triggerDates?.length);
     assert.ok(
       cluster.triggerDates!.every(


### PR DESCRIPTION
奇门终身局的日级应期改为真实日期、干支与触发关系，流月列出目标年份对应的实际节气交接时刻。修复阶段间漏年、年初小寒归属和出生前查询窗口；阶段表外的日期保留事实并明确归属状态。

提示词按年月紧凑排列，在31年样本中保留全部3806条日期，正文约105642字；长资料的AI分阶段传输由后续PR接通。

验证：奇门专项与跨时区回归、类型、公开API、MCP、提示词、格式和生产构建通过。全量曾发现的出生前一天范围错误已补回归并修复，最终整合全量仍在验收。

兼容：QimenEventCluster.stageIndex 改为可选，阶段表范围外返回 undefined，调用者应处理此情况。当前版本0.2.4，未发布。