### PR TITLE
优先补算目标时段并恢复资料规划失败

### DIFF
--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -1022,9 +1022,15 @@ export async function runReadingWorkflow(
         throw error;
       }
       if (!actions.length) break;
-      for (const action of actions) {
+      const actionPriority = { schema: 0, calculate: 1, classic: 2 };
+      const orderedActions = [...actions].sort(
+        (left, right) => actionPriority[left.kind] - actionPriority[right.kind],
+      );
+      let waitingForCalculationPlan = false;
+      for (const action of orderedActions) {
         guard();
         if (calls >= MAX_ACTIONS) break;
+        if (action.kind === 'classic' && waitingForCalculationPlan) continue;
         const key =
           action.kind === 'calculate'
             ? JSON.stringify({ ...action, target: action.target ?? 'primary' })
@@ -1052,6 +1058,7 @@ export async function runReadingWorkflow(
           const canRetrySchema = calls < MAX_ACTIONS;
           const schemaLoaded = await loadSchema(action.method);
           if (schemaLoaded || canRetrySchema) needsRefinement = true;
+          waitingForCalculationPlan = true;
           continue;
         }
         calls += 1;
@@ -1086,6 +1093,7 @@ export async function runReadingWorkflow(
           guard();
           rememberRetryFailure(key, action, error);
           needsRefinement = true;
+          if (action.kind === 'calculate') waitingForCalculationPlan = true;
           options.onNotice('部分补充资料暂未取得，将依据已有资料继续解读。');
         }
       }

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -904,12 +904,36 @@ export async function runReadingWorkflow(
   let planningRepairHint = '';
   const hasStoredFullZiwei = resources.some((resource) => Boolean(getZiweiFullResult(resource)));
   options.onProgress({ stage: 'preparing', text: '正在梳理问题与盘面' });
+  const schemaKeyForMethod = (method: string) => JSON.stringify({ kind: 'schema', method });
+  const getCalculationTargetInput = (action: Extract<ReadingAction, { kind: 'calculate' }>) => {
+    const sortedInput = () =>
+      Object.fromEntries(
+        Object.entries(action.input).sort(([left], [right]) => left.localeCompare(right)),
+      );
+    const schema = schemaResources.find((item) => item.key === schemaKeyForMethod(action.method));
+    if (!schema) return sortedInput();
+    try {
+      const parsed: unknown = JSON.parse(schema.text);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return sortedInput();
+      const properties = (parsed as Record<string, unknown>).properties;
+      if (!properties || typeof properties !== 'object' || Array.isArray(properties))
+        return sortedInput();
+      return Object.fromEntries(
+        Object.entries(action.input)
+          .filter(([field]) => Object.hasOwn(properties, field))
+          .sort(([left], [right]) => left.localeCompare(right)),
+      );
+    } catch {
+      return sortedInput();
+    }
+  };
   const retryFailureKey = (key: string, action: ReadingAction) =>
     action.kind === 'calculate'
       ? JSON.stringify({
           kind: action.kind,
           method: action.method,
           target: action.target ?? 'primary',
+          input: getCalculationTargetInput(action),
         })
       : key;
   const rememberRetryFailure = (key: string, action: ReadingAction, error: unknown) => {
@@ -923,7 +947,6 @@ export async function runReadingWorkflow(
     retryFailures.size
       ? `\n\n【上轮补算反馈】\n${[...retryFailures.values()].map((note) => `- ${note}`).join('\n')}\n`
       : '';
-  const schemaKeyForMethod = (method: string) => JSON.stringify({ kind: 'schema', method });
   const hasSchemaForMethod = (method: string) =>
     schemaResources.some((item) => item.key === schemaKeyForMethod(method));
   const loadSchema = async (method: string) => {

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -900,13 +900,47 @@ export async function runReadingWorkflow(
   const seen = new Set([...resources, ...schemaResources].map((item) => item.key));
   const notes: string[] = [];
   let calls = 0;
+  let planningRepairHint = '';
   const hasStoredFullZiwei = resources.some((resource) => Boolean(getZiweiFullResult(resource)));
   options.onProgress({ stage: 'preparing', text: '正在梳理问题与盘面' });
+  const schemaKeyForMethod = (method: string) => JSON.stringify({ kind: 'schema', method });
+  const hasSchemaForMethod = (method: string) =>
+    schemaResources.some((item) => item.key === schemaKeyForMethod(method));
+  const loadSchema = async (method: string) => {
+    if (hasSchemaForMethod(method)) return true;
+    if (calls >= MAX_ACTIONS) return false;
+    const key = schemaKeyForMethod(method);
+    const schemaAction: ReadingAction = { kind: 'schema', method };
+    calls += 1;
+    seen.add(key);
+    options.onProgress({ stage: 'consulting', text: '正在读取补算参数' });
+    try {
+      const resource = await deps.execute(schemaAction, options.signal, options.subject);
+      schemaResources.push({ ...resource, key, kind: 'schema' });
+      persistResources();
+      guard();
+      return true;
+    } catch (error) {
+      guard();
+      seen.delete(key);
+      notes.push(describeReadingFailure(schemaAction, error));
+      options.onNotice('补算参数暂未取得，将依据已有资料继续解读。');
+      return false;
+    }
+  };
+  const prefetchSubjectSchemas = async () => {
+    if (!subjectMethods) return;
+    for (const method of subjectMethods) {
+      if (!CALCULATIONS.includes(method as (typeof CALCULATIONS)[number])) continue;
+      if (calls >= MAX_ACTIONS) break;
+      await loadSchema(method);
+    }
+  };
   try {
     for (let round = 0; round < (isSimpleFollowup || hasStoredFullZiwei ? 0 : 2); round += 1) {
       let needsRefinement = false;
       guard();
-      const catalog = `【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
+      const catalog = `${planningRepairHint}【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
       const schemas = schemaResources.length
         ? `\n\n【补算参数】\n${schemaResources.map((item) => `${item.title}\n${item.text}`).join('\n\n')}`
         : '';
@@ -926,11 +960,15 @@ export async function runReadingWorkflow(
         actions = parseReadingPlan(await collectResponse(prepared, options, deps.stream));
       } catch (error) {
         guard();
-        // 格式不支持时沿用已准备资料；网络、限流等请求失败交由用户重试。
+        // 格式问题在现有准备轮次内补充结构提示；网络、限流等请求失败交由用户重试。
         if (
           error instanceof SyntaxError ||
           (error instanceof Error && /资料准备|一次补充/u.test(error.message))
         ) {
+          planningRepairHint =
+            '\n【资料准备修正】上一次返回未形成可执行资料动作。请输出可解析的 JSON 对象，顶层包含 actions 数组；动作使用 schema、calculate 或 classic 的既定字段，并保留目标主体与目标时段。\n';
+          await prefetchSubjectSchemas();
+          if (round + 1 < 2) continue;
           options.onNotice('本次自动补查未完成，解读将使用已有盘面与解读方法。');
           break;
         }
@@ -963,13 +1001,10 @@ export async function runReadingWorkflow(
           options.onNotice('当前会话没有第二人主体快照，已跳过伴侣补算。');
           continue;
         }
-        if (
-          action.kind === 'calculate' &&
-          !schemaResources.some(
-            (item) => item.key === JSON.stringify({ kind: 'schema', method: action.method }),
-          )
-        ) {
-          notes.push(`${action.method}补算所需参数格式未取得，无法断言目标时段。`);
+        if (action.kind === 'calculate' && !hasSchemaForMethod(action.method)) {
+          const canRetrySchema = calls < MAX_ACTIONS;
+          const schemaLoaded = await loadSchema(action.method);
+          if (schemaLoaded || canRetrySchema) needsRefinement = true;
           continue;
         }
         calls += 1;

--- a/src/lib/ai/reading-workflow.ts
+++ b/src/lib/ai/reading-workflow.ts
@@ -899,10 +899,30 @@ export async function runReadingWorkflow(
   };
   const seen = new Set([...resources, ...schemaResources].map((item) => item.key));
   const notes: string[] = [];
+  const retryFailures = new Map<string, string>();
   let calls = 0;
   let planningRepairHint = '';
   const hasStoredFullZiwei = resources.some((resource) => Boolean(getZiweiFullResult(resource)));
   options.onProgress({ stage: 'preparing', text: '正在梳理问题与盘面' });
+  const retryFailureKey = (key: string, action: ReadingAction) =>
+    action.kind === 'calculate'
+      ? JSON.stringify({
+          kind: action.kind,
+          method: action.method,
+          target: action.target ?? 'primary',
+        })
+      : key;
+  const rememberRetryFailure = (key: string, action: ReadingAction, error: unknown) => {
+    const note = describeReadingFailure(action, error);
+    retryFailures.set(retryFailureKey(key, action), note);
+  };
+  const clearRetryFailure = (key: string, action: ReadingAction) => {
+    retryFailures.delete(retryFailureKey(key, action));
+  };
+  const formatRetryFailures = () =>
+    retryFailures.size
+      ? `\n\n【上轮补算反馈】\n${[...retryFailures.values()].map((note) => `- ${note}`).join('\n')}\n`
+      : '';
   const schemaKeyForMethod = (method: string) => JSON.stringify({ kind: 'schema', method });
   const hasSchemaForMethod = (method: string) =>
     schemaResources.some((item) => item.key === schemaKeyForMethod(method));
@@ -916,6 +936,7 @@ export async function runReadingWorkflow(
     options.onProgress({ stage: 'consulting', text: '正在读取补算参数' });
     try {
       const resource = await deps.execute(schemaAction, options.signal, options.subject);
+      clearRetryFailure(key, schemaAction);
       schemaResources.push({ ...resource, key, kind: 'schema' });
       persistResources();
       guard();
@@ -923,7 +944,7 @@ export async function runReadingWorkflow(
     } catch (error) {
       guard();
       seen.delete(key);
-      notes.push(describeReadingFailure(schemaAction, error));
+      rememberRetryFailure(key, schemaAction, error);
       options.onNotice('补算参数暂未取得，将依据已有资料继续解读。');
       return false;
     }
@@ -940,7 +961,7 @@ export async function runReadingWorkflow(
     for (let round = 0; round < (isSimpleFollowup || hasStoredFullZiwei ? 0 : 2); round += 1) {
       let needsRefinement = false;
       guard();
-      const catalog = `${planningRepairHint}【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
+      const catalog = `${planningRepairHint}${formatRetryFailures()}【当前任务：准备解读资料】${currentTimeContext}\n请依据本次问题判断哪些额外资料能改变判断。输出一个JSON对象 {"actions":[]}，资料充足时使用空数组。每次最多4项。排盘类优先补齐当前阶段、所属上层运限和问题涉及的目标时段；占卜类优先保留本次起盘已有的时间、动变、牌阵或签谱事实。只有传统条文能改变取义时才查询。可选动作：\n1. {"kind":"schema","method":"${CALCULATIONS.join('或')}"}，查看补算参数。\n2. {"kind":"calculate","method":"方法编号","target":"primary","input":{}}（或使用 target:"partner"），按已读取的参数格式补算。双人解读时用 target 指定对象；primary 对应第一人，partner 对应第二人，两人分别填写各自的目标时段。参数取自用户明确提供的出生资料、地点、历法和目标时段，保持原盘的主体与计算口径；必要输入缺失时直接进入已有资料解读并指出具体缺项。partner 补算以本次已提供的第二人出生资料为依据。原始卦、课、牌、签沿用本次结果。\n3. {"kind":"classic","method":"方法编号","query":"具体星曜、日主月令、格局或卦名"}，查阅传统条文。方法编号：${Object.keys(READING_CLASSIC_TABLES).join('、')}。\n本轮仅完成资料选择，解读正文将在下一步生成。`;
       const schemas = schemaResources.length
         ? `\n\n【补算参数】\n${schemaResources.map((item) => `${item.title}\n${item.text}`).join('\n\n')}`
         : '';
@@ -969,6 +990,9 @@ export async function runReadingWorkflow(
             '\n【资料准备修正】上一次返回未形成可执行资料动作。请输出可解析的 JSON 对象，顶层包含 actions 数组；动作使用 schema、calculate 或 classic 的既定字段，并保留目标主体与目标时段。\n';
           await prefetchSubjectSchemas();
           if (round + 1 < 2) continue;
+          notes.push(
+            '本轮资料准备未取得可执行的补充动作，解读应依据当前已有盘面与已取得资料完成。',
+          );
           options.onNotice('本次自动补查未完成，解读将使用已有盘面与解读方法。');
           break;
         }
@@ -1016,6 +1040,7 @@ export async function runReadingWorkflow(
         try {
           const resource = await deps.execute(action, options.signal, options.subject);
           if (action.kind === 'schema') {
+            clearRetryFailure(key, action);
             schemaResources.push({ ...resource, key, kind: 'schema' });
             persistResources();
             guard();
@@ -1025,17 +1050,19 @@ export async function runReadingWorkflow(
             seen.delete(key);
             guard();
             needsRefinement = true;
-            notes.push(describeReadingFailure(action, new Error('未命中')));
+            rememberRetryFailure(key, action, new Error('未命中'));
             options.onNotice(`“${action.query}”未查到对应条文，已保留原有盘面资料。`);
             continue;
           }
+          clearRetryFailure(key, action);
           resources.push({ ...resource, key, kind: 'evidence' });
           persistResources();
           guard();
         } catch (error) {
           seen.delete(key);
           guard();
-          notes.push(describeReadingFailure(action, error));
+          rememberRetryFailure(key, action, error);
+          needsRefinement = true;
           options.onNotice('部分补充资料暂未取得，将依据已有资料继续解读。');
         }
       }
@@ -1048,7 +1075,7 @@ export async function runReadingWorkflow(
     const finalResources = resources.filter((item) => item.usable);
     const getFinalStatusNotes = (omitted: ReadingResource[]) => {
       const capacityNote = formatCapacityNotice('本轮解读', omitted).trim();
-      return [...notes, ...(capacityNote ? [capacityNote] : [])];
+      return [...notes, ...retryFailures.values(), ...(capacityNote ? [capacityNote] : [])];
     };
     const buildFinalAddition = (
       selected: ReadingResource[],

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -15,6 +15,9 @@ import { executeReadingAction, lookupReadingClassics } from '../src/lib/ai/readi
 import type { ReadingSubjectSnapshot } from '../src/lib/ai/reading-subject';
 import type { ChatMessage } from '../src/lib/ai/stream-client';
 import { handlePublicApiRequest } from '../src/lib/public-api/handler';
+import { defaultDraft } from '../src/components/DivinationPanel/constants';
+import { generateDivinationSession } from '../src/lib/divination/engine';
+import { buildDivinationReadingSubject } from '../src/lib/ai/reading-subject';
 import {
   buildSerializableZiweiResult,
   buildZiweiChartInput,
@@ -453,6 +456,89 @@ test('不同目标时段的补算成功不清除另一个失败状态', async ()
   assert.match(final, /bazi补充资料未取得：2027目标暂未取得/);
   assert.match(final, /TARGET_2028/);
   assert.deepEqual(h.chunks, ['保留失败状态的解读']);
+});
+
+test('皇极真实规划先列古籍时仍优先补算目标时点并保留纠错额度', async (t) => {
+  const question = '比较2026年8月24日15:30与2027年1月5日09:00的皇极变化';
+  const draft = {
+    ...defaultDraft,
+    method: 'huangji' as const,
+    question,
+    questionSource: 'custom' as const,
+    divinationTimeMode: 'custom' as const,
+    customDivinationDate: '2026-08-24',
+    customDivinationTime: '15:30',
+    divinationTimeStandard: 'beijing' as const,
+    huangjiMethod: 'standard' as const,
+  };
+  const session = await generateDivinationSession(draft);
+  const h = harness([
+    JSON.stringify({
+      actions: [
+        {
+          kind: 'calculate',
+          method: 'huangji',
+          target: 'primary',
+          input: { time: '2027-01-05 09:00:00', timezone: 'UTC+8' },
+        },
+        {
+          kind: 'classic',
+          method: 'huangji',
+          query: '跨冬至换年时皇极经世月经卦、旬纬卦的统辖规则',
+        },
+        {
+          kind: 'classic',
+          method: 'huangji',
+          query: '六十年统卦火风鼎范围内2027年的值年卦取序规则',
+        },
+        { kind: 'schema', method: 'huangji' },
+      ],
+    }),
+    JSON.stringify({
+      actions: [
+        { kind: 'classic', method: 'huangji', query: '跨冬至换年时皇极经世月经卦、旬纬卦统辖规则' },
+        {
+          kind: 'classic',
+          method: 'huangji',
+          query: '六十年统卦火风鼎范围内2027年的值年卦取序规则',
+        },
+        {
+          kind: 'calculate',
+          method: 'huangji',
+          target: 'primary',
+          input: { customDate: '2027-01-05T09:00:00+08:00' },
+        },
+        { kind: 'classic', method: 'huangji', query: '皇极经世冬至换年的具体时点与卦象变易规则' },
+      ],
+    }),
+    '根据实际目标盘解读',
+  ]);
+  h.options.subject = buildDivinationReadingSubject(draft, session);
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input, init) =>
+    handlePublicApiRequest(
+      new Request(new URL(String(input), 'https://aov.cc'), init),
+    )) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  const actions: string[] = [];
+  await runReadingWorkflow([{ role: 'user', content: session.prompt }], h.options, {
+    stream: h.stream,
+    execute: async (action, signal, subject) => {
+      actions.push(action.kind);
+      return executeReadingAction(action, signal, subject);
+    },
+  });
+  assert.deepEqual(h.errors, []);
+  assert.equal(h.done(), 1);
+  assert.deepEqual(actions.slice(0, 3), ['schema', 'calculate', 'calculate']);
+  assert.ok(actions.length <= 4);
+  const target = h.options.memory.resources.find((item) => item.structured?.dateTimeForecast);
+  assert.ok(target?.usable);
+  const forecast = target.structured!.dateTimeForecast as { civilTime: { dateTime: string } };
+  assert.match(forecast.civilTime.dateTime, /^2027-01-05[ T]09:00/);
+  assert.match(h.sent.at(-1)![0].content, /2027/);
 });
 
 test('没有主体快照时跳过自动补算并明确提示', async () => {

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -315,7 +315,7 @@ test('读取参数后补算，原始盘面与补充盘面同时保留', async ()
 test('准备格式错误后在剩余轮次读取真实参数并补算目标', async (t) => {
   const h = harness([
     '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}',
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"question":"分析2027年事业","baziFortuneYear":2027}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"question":"分析2027年事业","baziFortuneScope":"year","baziFortuneYear":2027}}]}',
     '格式恢复后的解读',
   ]);
   h.options.subject = baziSubject;
@@ -383,8 +383,8 @@ test('连续两次准备格式错误时最终上下文说明资料状态', async
 
 test('补算执行安全校验失败后带纠错反馈并成功重试', async (t) => {
   const h = harness([
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991,"baziFortuneYear":2027,"question":"分析2027年事业"}}]}',
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"baziFortuneYear":2027,"question":"分析2027年事业"}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991,"baziFortuneYear":2027,"question":"分析2027年事业","baziFortuneScope":"year"}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"baziFortuneYear":2027,"question":"分析2027年事业","baziFortuneScope":"year"}}]}',
     '重试后的解读',
   ]);
   h.options.subject = baziSubject;

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -381,8 +381,8 @@ test('连续两次准备格式错误时最终上下文说明资料状态', async
 
 test('补算执行安全校验失败后带纠错反馈并成功重试', async (t) => {
   const h = harness([
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991}}]}',
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991,"baziFortuneYear":2027}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"baziFortuneYear":2027}}]}',
     '重试后的解读',
   ]);
   h.options.subject = baziSubject;
@@ -390,7 +390,7 @@ test('补算执行安全校验失败后带纠错反馈并成功重试', async (t
     {
       key: JSON.stringify({ kind: 'schema', method: 'bazi' }),
       title: '八字补算参数',
-      text: '{"properties":{"year":{"type":"integer"}}}',
+      text: '{"properties":{"baziFortuneYear":{"type":"integer"}}}',
       usable: false,
       kind: 'schema',
     },
@@ -417,6 +417,39 @@ test('补算执行安全校验失败后带纠错反馈并成功重试', async (t
   assert.doesNotMatch(final, /bazi补充资料未取得/);
   assert.match(final, /1990|庚午/);
   assert.deepEqual(h.chunks, ['重试后的解读']);
+});
+
+test('不同目标时段的补算成功不清除另一个失败状态', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"baziFortuneYear":2027}},{"kind":"calculate","method":"bazi","input":{"baziFortuneYear":2028}}]}',
+    '{"actions":[]}',
+    '保留失败状态的解读',
+  ]);
+  h.options.subject = baziSubject;
+  h.options.memory.schemas = [
+    {
+      key: JSON.stringify({ kind: 'schema', method: 'bazi' }),
+      title: '八字补算参数',
+      text: '{"properties":{"baziFortuneYear":{"type":"integer"}}}',
+      usable: false,
+      kind: 'schema',
+    },
+  ];
+  const executed: string[] = [];
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => {
+      executed.push(action.kind);
+      if (action.kind === 'calculate' && action.input.baziFortuneYear === 2027)
+        throw new Error('2027目标暂未取得');
+      return { key: '', title: '2028目标', text: 'TARGET_2028', usable: true };
+    },
+  });
+  assert.deepEqual(executed, ['calculate', 'calculate']);
+  const final = h.sent[2][0].content;
+  assert.match(final, /bazi补充资料未取得：2027目标暂未取得/);
+  assert.match(final, /TARGET_2028/);
+  assert.deepEqual(h.chunks, ['保留失败状态的解读']);
 });
 
 test('没有主体快照时跳过自动补算并明确提示', async () => {

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -337,7 +337,7 @@ test('准备格式错误后在剩余轮次读取真实参数并补算目标', as
   });
   assert.deepEqual(executed, ['schema', 'calculate']);
   assert.match(h.sent[1][0].content, /properties/);
-  assert.match(h.sent[1][0].content, /可解析的 JSON 对象/);
+  assert.match(h.sent[1].at(-1)!.content, /可解析的 JSON 对象/);
   assert.match(h.sent[2][0].content, /1990|庚午/);
   assert.deepEqual(h.chunks, ['格式恢复后的解读']);
 });
@@ -412,7 +412,7 @@ test('补算执行安全校验失败后带纠错反馈并成功重试', async (t
     },
   });
   assert.deepEqual(executed, ['calculate', 'calculate']);
-  assert.match(h.sent[1][0].content, /补算主体与当前命盘不一致：year/);
+  assert.match(h.sent[1].at(-1)!.content, /补算主体与当前命盘不一致：year/);
   const final = h.sent[2][0].content;
   assert.doesNotMatch(final, /bazi补充资料未取得/);
   assert.match(final, /1990|庚午/);

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -365,6 +365,60 @@ test('缺少补算参数时先读取真实 schema 再在下一轮补算', async 
   assert.deepEqual(h.chunks, ['读取参数后的解读']);
 });
 
+test('连续两次准备格式错误时最终上下文说明资料状态', async () => {
+  const h = harness(['不是JSON', '仍不是JSON', '已有资料解读']);
+  await runReadingWorkflow([{ role: 'user', content: '塔罗：星星正位' }], h.options, {
+    stream: h.stream,
+    execute: async () => {
+      throw new Error('不应执行');
+    },
+  });
+  const final = h.sent.at(-1)![0].content;
+  assert.match(final, /本轮资料准备未取得可执行的补充动作/);
+  assert.doesNotMatch(final, /资料准备修正/);
+  assert.deepEqual(h.chunks, ['已有资料解读']);
+});
+
+test('补算执行安全校验失败后带纠错反馈并成功重试', async (t) => {
+  const h = harness([
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '重试后的解读',
+  ]);
+  h.options.subject = baziSubject;
+  h.options.memory.schemas = [
+    {
+      key: JSON.stringify({ kind: 'schema', method: 'bazi' }),
+      title: '八字补算参数',
+      text: '{"properties":{"year":{"type":"integer"}}}',
+      usable: false,
+      kind: 'schema',
+    },
+  ];
+  const executed: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input, init) =>
+    handlePublicApiRequest(
+      new Request(new URL(String(input), 'https://aov.cc'), init),
+    )) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], h.options, {
+    stream: h.stream,
+    execute: async (action, signal, subject) => {
+      executed.push(action.kind);
+      return executeReadingAction(action, signal, subject);
+    },
+  });
+  assert.deepEqual(executed, ['calculate', 'calculate']);
+  assert.match(h.sent[1][0].content, /补算主体与当前命盘不一致：year/);
+  const final = h.sent[2][0].content;
+  assert.doesNotMatch(final, /bazi补充资料未取得/);
+  assert.match(final, /1990|庚午/);
+  assert.deepEqual(h.chunks, ['重试后的解读']);
+});
+
 test('没有主体快照时跳过自动补算并明确提示', async () => {
   const h = harness([
     '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -315,7 +315,7 @@ test('读取参数后补算，原始盘面与补充盘面同时保留', async ()
 test('准备格式错误后在剩余轮次读取真实参数并补算目标', async (t) => {
   const h = harness([
     '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}',
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"question":"分析2027年事业","baziFortuneYear":2027}}]}',
     '格式恢复后的解读',
   ]);
   h.options.subject = baziSubject;
@@ -339,6 +339,8 @@ test('准备格式错误后在剩余轮次读取真实参数并补算目标', as
   assert.match(h.sent[1][0].content, /properties/);
   assert.match(h.sent[1].at(-1)!.content, /可解析的 JSON 对象/);
   assert.match(h.sent[2][0].content, /1990|庚午/);
+  assert.equal(h.options.memory.resources.length, 1);
+  assert.equal(h.options.memory.resources[0].usable, true);
   assert.deepEqual(h.chunks, ['格式恢复后的解读']);
 });
 
@@ -381,8 +383,8 @@ test('连续两次准备格式错误时最终上下文说明资料状态', async
 
 test('补算执行安全校验失败后带纠错反馈并成功重试', async (t) => {
   const h = harness([
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991,"baziFortuneYear":2027}}]}',
-    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"baziFortuneYear":2027}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1991,"baziFortuneYear":2027,"question":"分析2027年事业"}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990,"baziFortuneYear":2027,"question":"分析2027年事业"}}]}',
     '重试后的解读',
   ]);
   h.options.subject = baziSubject;
@@ -415,6 +417,7 @@ test('补算执行安全校验失败后带纠错反馈并成功重试', async (t
   assert.match(h.sent[1].at(-1)!.content, /补算主体与当前命盘不一致：year/);
   const final = h.sent[2][0].content;
   assert.doesNotMatch(final, /bazi补充资料未取得/);
+  assert.equal(h.options.memory.resources.length, 1);
   assert.match(final, /1990|庚午/);
   assert.deepEqual(h.chunks, ['重试后的解读']);
 });

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -312,6 +312,59 @@ test('读取参数后补算，原始盘面与补充盘面同时保留', async ()
   assert.doesNotMatch(final, /SCHEMA_SENTINEL_出生年份整数/);
 });
 
+test('准备格式错误后在剩余轮次读取真实参数并补算目标', async (t) => {
+  const h = harness([
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '格式恢复后的解读',
+  ]);
+  h.options.subject = baziSubject;
+  const executed: string[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input, init) =>
+    handlePublicApiRequest(
+      new Request(new URL(String(input), 'https://aov.cc'), init),
+    )) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], h.options, {
+    stream: h.stream,
+    execute: async (action, signal, subject) => {
+      executed.push(action.kind);
+      return executeReadingAction(action, signal, subject);
+    },
+  });
+  assert.deepEqual(executed, ['schema', 'calculate']);
+  assert.match(h.sent[1][0].content, /properties/);
+  assert.match(h.sent[1][0].content, /可解析的 JSON 对象/);
+  assert.match(h.sent[2][0].content, /1990|庚午/);
+  assert.deepEqual(h.chunks, ['格式恢复后的解读']);
+});
+
+test('缺少补算参数时先读取真实 schema 再在下一轮补算', async () => {
+  const h = harness([
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
+    '读取参数后的解读',
+  ]);
+  h.options.subject = baziSubject;
+  const executed: string[] = [];
+  await runReadingWorkflow([{ role: 'user', content: '八字原始盘面' }], h.options, {
+    stream: h.stream,
+    execute: async (action) => {
+      executed.push(action.kind);
+      return action.kind === 'schema'
+        ? { key: '', title: '八字参数', text: 'SCHEMA_AUTO', usable: false }
+        : { key: '', title: '目标流年', text: 'TARGET_AUTO', usable: true };
+    },
+  });
+  assert.deepEqual(executed, ['schema', 'calculate']);
+  assert.match(h.sent[1][0].content, /SCHEMA_AUTO/);
+  assert.match(h.sent[2][0].content, /TARGET_AUTO/);
+  assert.deepEqual(h.chunks, ['读取参数后的解读']);
+});
+
 test('没有主体快照时跳过自动补算并明确提示', async () => {
   const h = harness([
     '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',
@@ -329,7 +382,7 @@ test('没有主体快照时跳过自动补算并明确提示', async () => {
 });
 
 test('准备格式不兼容时明确提示并继续已有资料解读，网络失败保留重试', async () => {
-  const h = harness(['不是JSON', '已有资料解读']);
+  const h = harness(['不是JSON', '仍不是JSON', '已有资料解读']);
   await runReadingWorkflow([{ role: 'user', content: '塔罗：星星正位' }], h.options, {
     stream: h.stream,
     execute: async () => {


### PR DESCRIPTION
AI资料准备在格式错误时可于既有两轮内读取真实参数并纠错；失败反馈按主体及目标参数隔离。工具动作优先读取参数和补算目标时段，等待补算纠错时延后古籍查询，避免查询耗尽额度后目标时段仍缺失。

验证：40项AI工作流专项、类型、ESLint、Prettier与生产构建通过。新增回归复用真实模型返回的规划顺序，经真实处理入口取得2027-01-05 09:00的皇极结构化结果。

真实模型验证：本轮获批的3次请求已用完，发现并复现了古籍占用额度的问题；修复后真实轨迹回放通过，尚未再次发起付费模型请求。因此本PR不宣称真实模型端到端验收已完成。

沿用现有模型、两轮规划和四次工具额度，未增加依赖或发布。