### PR TITLE
优化奇门长时限补算性能并保留服务错误原因

### DIFF
--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -444,7 +444,7 @@ export function scanLifetimeDynamicEvents(
 
   const getPalaceName = (p: number) =>
     baseChart.jiuGongGe.find((item) => item.gong === p)?.name || `${p}宫`;
-  const ianaNoonValidator = createIanaNoonValidator(timeContext);
+  let ianaNoonValidator: IanaNoonValidator | undefined;
 
   // 查询从一月开始时，补查上一干支年的丑月小寒节点；该节点落在当前公历年一月。
   if (start.month === 1 && startYear > 1) {
@@ -636,6 +636,7 @@ export function scanLifetimeDynamicEvents(
     const yearEnd = { year: y, month: 12, day: 31 };
     const dailyStart = dateKey(start) > dateKey(yearStart) ? start : yearStart;
     const dailyEnd = dateKey(end) < dateKey(yearEnd) ? end : yearEnd;
+    ianaNoonValidator ??= createIanaNoonValidator(timeContext);
     const dailyGroups = collectDailyRelationFacts(
       dailyStart,
       dailyEnd,

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -4,7 +4,7 @@
  * 空亡填实、马星引动与年家盘叠合，并列出可复核的交节日与日支关系。
  */
 
-import { SolarTerm } from 'tyme4ts';
+import { SolarDay, SolarTerm } from 'tyme4ts';
 import type {
   QimenData,
   QimenEventCluster,
@@ -137,28 +137,141 @@ function nextLifetimeDate(value: LifetimeDateParts): LifetimeDateParts {
   };
 }
 
-function resolveLifetimeNoon(
+type IanaNoonValidator = {
+  formatter: Intl.DateTimeFormat;
+  previousOffsetHours?: number;
+  initialized: boolean;
+};
+
+type IanaWallClockParts = Pick<
+  CivilDateTimeParts,
+  'year' | 'month' | 'day' | 'hour' | 'minute' | 'second'
+>;
+
+function createIanaNoonValidator(
+  timeContext: QimenDynamicTimeContext | undefined,
+): IanaNoonValidator | undefined {
+  const timeZoneId = timeContext?.timeZoneId?.trim();
+  if (!timeZoneId) return undefined;
+  try {
+    return {
+      formatter: new Intl.DateTimeFormat('en-CA', {
+        timeZone: timeZoneId,
+        calendar: 'gregory',
+        numberingSystem: 'latn',
+        hourCycle: 'h23',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }),
+      initialized: false,
+    };
+  } catch {
+    throw new Error(`无法识别 IANA 时区 ${timeZoneId}。`);
+  }
+}
+
+function getIanaWallClockParts(
+  formatter: Intl.DateTimeFormat,
+  timestamp: number,
+): IanaWallClockParts {
+  const values = Object.fromEntries(
+    formatter
+      .formatToParts(new Date(timestamp))
+      .filter((item) => item.type !== 'literal')
+      .map((item) => [item.type, Number(item.value)]),
+  ) as Partial<IanaWallClockParts>;
+  return {
+    year: values.year!,
+    month: values.month!,
+    day: values.day!,
+    hour: values.hour!,
+    minute: values.minute!,
+    second: values.second!,
+  };
+}
+
+function getIanaOffsetHoursAt(formatter: Intl.DateTimeFormat, timestamp: number): number {
+  const parts = getIanaWallClockParts(formatter, timestamp);
+  const representedAsUtc = createUtcTimestamp(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return Number(((representedAsUtc - Math.floor(timestamp / 1000) * 1000) / 3600000).toFixed(6));
+}
+
+function sameIanaWallClockParts(first: IanaWallClockParts, second: IanaWallClockParts): boolean {
+  return (
+    first.year === second.year &&
+    first.month === second.month &&
+    first.day === second.day &&
+    first.hour === second.hour &&
+    first.minute === second.minute &&
+    first.second === second.second
+  );
+}
+
+/**
+ * 验证当地正午在 IANA 时区中真实存在，并在异常边界复用完整解析以保留缺失/歧义报错。
+ * 正常日期只需两次 Intl 读取，避免逐日构造完整 SolarTime 与 73 个候选时区样本。
+ */
+function validateIanaNoon(
+  value: LifetimeDateParts,
+  timeZoneId: string,
+  validator: IanaNoonValidator,
+): void {
+  const target: IanaWallClockParts = { ...value, hour: 12, minute: 0, second: 0 };
+  const wallTimestamp = createUtcTimestamp(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+  );
+  const sampledOffsetHours = getIanaOffsetHoursAt(validator.formatter, wallTimestamp);
+  const candidateTimestamp = wallTimestamp - sampledOffsetHours * 3600000;
+  const candidate = getIanaWallClockParts(validator.formatter, candidateTimestamp);
+  const previousOffsetHours = validator.previousOffsetHours;
+  const offsetChanged =
+    previousOffsetHours !== undefined && Math.abs(previousOffsetHours - sampledOffsetHours) > 1e-6;
+  if (!sameIanaWallClockParts(candidate, target) || offsetChanged) {
+    const resolved = resolveCivilTime(
+      { ...target, timeZoneId },
+      { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
+    );
+    validator.previousOffsetHours = resolved.timezone;
+  } else {
+    validator.previousOffsetHours = sampledOffsetHours;
+  }
+  validator.initialized = true;
+}
+
+function validateLifetimeNoon(
   value: LifetimeDateParts,
   timeContext: QimenDynamicTimeContext | undefined,
-): { date: Date; offsetMinutes: number } {
+  ianaNoonValidator: IanaNoonValidator | undefined,
+): void {
   const timeZoneId = timeContext?.timeZoneId?.trim();
-  const resolved = resolveCivilTime(
-    {
-      ...value,
-      hour: 12,
-      minute: 0,
-      second: 0,
-      ...(timeZoneId
-        ? { timeZoneId }
-        : {
-            timezone:
-              timeContext?.timezone ??
-              (timeContext?.fallbackOffsetMinutes ?? DEFAULT_CHINA_TIMEZONE_HOURS * 60) / 60,
-          }),
-    },
-    { defaultTimezone: DEFAULT_CHINA_TIMEZONE_HOURS },
-  );
-  return { date: new Date(resolved.utcTimestamp), offsetMinutes: resolved.timezone * 60 };
+  if (!timeZoneId) return;
+  if (!ianaNoonValidator) {
+    throw new Error(`无法识别 IANA 时区 ${timeZoneId}。`);
+  }
+  if (!ianaNoonValidator.initialized) {
+    const wallTimestamp = createUtcTimestamp(value.year, value.month - 1, value.day, 12, 0, 0);
+    ianaNoonValidator.previousOffsetHours = getIanaOffsetHoursAt(
+      ianaNoonValidator.formatter,
+      wallTimestamp - 86400000,
+    );
+  }
+  validateIanaNoon(value, timeZoneId, ianaNoonValidator);
 }
 
 function getTermInstant(termYear: number, termIndex: number): Date {
@@ -215,6 +328,7 @@ function collectDailyRelationFacts(
   end: LifetimeDateParts,
   baseChart: QimenData,
   timeContext: QimenDynamicTimeContext | undefined,
+  ianaNoonValidator: IanaNoonValidator | undefined,
 ): Map<string, LifetimeDateFact[]> {
   const groups = new Map<string, LifetimeDateFact[]>();
   const horseBranch = baseChart.horseStar?.branch;
@@ -223,8 +337,11 @@ function collectDailyRelationFacts(
 
   while (dateKey(current) <= dateKey(end)) {
     const dateText = formatLifetimeDate(current);
-    const { date, offsetMinutes } = resolveLifetimeNoon(current, timeContext);
-    const dayGanZhi = getDivinationTime(date, offsetMinutes).ganzhi.day;
+    validateLifetimeNoon(current, timeContext, ianaNoonValidator);
+    const dayGanZhi = SolarDay.fromYmd(current.year, current.month, current.day)
+      .getLunarDay()
+      .getSixtyCycle()
+      .getName();
     const dayBranch = dayGanZhi.charAt(1);
     const relations: Array<[string, string]> = [];
 
@@ -327,6 +444,7 @@ export function scanLifetimeDynamicEvents(
 
   const getPalaceName = (p: number) =>
     baseChart.jiuGongGe.find((item) => item.gong === p)?.name || `${p}宫`;
+  const ianaNoonValidator = createIanaNoonValidator(timeContext);
 
   // 查询从一月开始时，补查上一干支年的丑月小寒节点；该节点落在当前公历年一月。
   if (start.month === 1 && startYear > 1) {
@@ -518,7 +636,13 @@ export function scanLifetimeDynamicEvents(
     const yearEnd = { year: y, month: 12, day: 31 };
     const dailyStart = dateKey(start) > dateKey(yearStart) ? start : yearStart;
     const dailyEnd = dateKey(end) < dateKey(yearEnd) ? end : yearEnd;
-    const dailyGroups = collectDailyRelationFacts(dailyStart, dailyEnd, baseChart, timeContext);
+    const dailyGroups = collectDailyRelationFacts(
+      dailyStart,
+      dailyEnd,
+      baseChart,
+      timeContext,
+      ianaNoonValidator,
+    );
     const dailyRelationMeta: Record<
       string,
       {

--- a/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
+++ b/packages/core/src/divination/algorithms/qimen/helpers/lifetime-dynamic.ts
@@ -240,8 +240,14 @@ function validateIanaNoon(
   const candidateTimestamp = wallTimestamp - sampledOffsetHours * 3600000;
   const candidate = getIanaWallClockParts(validator.formatter, candidateTimestamp);
   const previousOffsetHours = validator.previousOffsetHours;
+  const nearbyOffsets = [
+    getIanaOffsetHoursAt(validator.formatter, wallTimestamp - 36 * 3600000),
+    getIanaOffsetHoursAt(validator.formatter, wallTimestamp + 36 * 3600000),
+  ];
   const offsetChanged =
-    previousOffsetHours !== undefined && Math.abs(previousOffsetHours - sampledOffsetHours) > 1e-6;
+    (previousOffsetHours !== undefined &&
+      Math.abs(previousOffsetHours - sampledOffsetHours) > 1e-6) ||
+    nearbyOffsets.some((offsetHours) => Math.abs(offsetHours - sampledOffsetHours) > 1e-6);
   if (!sameIanaWallClockParts(candidate, target) || offsetChanged) {
     const resolved = resolveCivilTime(
       { ...target, timeZoneId },

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -1494,6 +1494,7 @@ async function fetchReadingData(
         response.ok
           ? '补充资料服务返回的内容格式不完整，请稍后重试。'
           : `补充资料服务暂不可用（HTTP ${response.status}），请稍后重试。`,
+        { cause: error },
       );
     }
     if (!response.ok || !record(body) || body.success === false) {

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -1485,7 +1485,17 @@ async function fetchReadingData(
         : {}),
       signal: timeout.signal,
     });
-    const body: unknown = await response.json();
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      if (timeout.signal.aborted) throw error;
+      throw new Error(
+        response.ok
+          ? '补充资料服务返回的内容格式不完整，请稍后重试。'
+          : `补充资料服务暂不可用（HTTP ${response.status}），请稍后重试。`,
+      );
+    }
     if (!response.ok || !record(body) || body.success === false) {
       const error =
         record(body) && record(body.error) && typeof body.error.message === 'string'

--- a/tests/ai-reading-workflow.test.ts
+++ b/tests/ai-reading-workflow.test.ts
@@ -541,6 +541,21 @@ test('皇极真实规划先列古籍时仍优先补算目标时点并保留纠�
   assert.match(h.sent.at(-1)![0].content, /2027/);
 });
 
+test('补算服务返回非JSON错误页时保留HTTP状态并给出可读错误', async (t) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response('<!DOCTYPE html><title>Worker exceeded resource limits</title>', {
+      status: 503,
+    })) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  await assert.rejects(
+    executeReadingAction({ kind: 'schema', method: 'bazi' }, undefined, baziSubject),
+    /补充资料服务暂不可用（HTTP 503）/,
+  );
+});
+
 test('没有主体快照时跳过自动补算并明确提示', async () => {
   const h = harness([
     '{"actions":[{"kind":"calculate","method":"bazi","input":{"year":1990}}]}',

--- a/tests/qimen-lifetime-performance.test.ts
+++ b/tests/qimen-lifetime-performance.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { calculateQimenLifetime, scanLifetimeDynamicEvents } from 'mingyu-core/divination/qimen';
+import { getDivinationTime, resolveCivilTime } from 'mingyu-core/calendar';
+
+test('奇门终身局日级扫描保留 IANA 当地日干支', () => {
+  const localNoon = resolveCivilTime({
+    year: 2024,
+    month: 3,
+    day: 10,
+    hour: 12,
+    minute: 0,
+    second: 0,
+    timeZoneId: 'America/New_York',
+  });
+  const expected = getDivinationTime(new Date(localNoon.utcTimestamp), -240).ganzhi.day;
+  const lifetime = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00+08:00',
+    timezone: 8,
+    timeStandard: 'civil',
+  });
+  const baseChart = { ...lifetime.baseChart, voidBranches: [expected.charAt(1)] };
+  const clusters = scanLifetimeDynamicEvents(
+    baseChart,
+    lifetime.stages,
+    { startDate: '2024-03-10', endDate: '2024-03-10' },
+    'zhuanpan',
+    'chaibu',
+    { timeZoneId: 'America/New_York' },
+  );
+  const fact = clusters
+    .flatMap((cluster) => cluster.triggerDates ?? [])
+    .find((item) => item.date === '2024-03-10' && item.ganzhi);
+  assert.equal(fact?.ganzhi, expected);
+});
+
+test('奇门终身局日级扫描保留 IANA 时区跳过日期的错误', () => {
+  const lifetime = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00+08:00',
+    timezone: 8,
+    timeStandard: 'civil',
+  });
+
+  assert.throws(
+    () =>
+      scanLifetimeDynamicEvents(
+        lifetime.baseChart,
+        lifetime.stages,
+        { startDate: '2011-12-30', endDate: '2011-12-30' },
+        'zhuanpan',
+        'chaibu',
+        { timeZoneId: 'Pacific/Apia' },
+      ),
+    /Pacific\/Apia.*不存在/u,
+  );
+});

--- a/tests/qimen-lifetime-performance.test.ts
+++ b/tests/qimen-lifetime-performance.test.ts
@@ -54,3 +54,24 @@ test('奇门终身局日级扫描保留 IANA 时区跳过日期的错误', () =>
     /Pacific\/Apia.*不存在/u,
   );
 });
+
+test('奇门终身局日级扫描保留 IANA 正午重复时刻的错误', () => {
+  const lifetime = calculateQimenLifetime({
+    birthDateTime: '1990-05-15T14:30:00+08:00',
+    timezone: 8,
+    timeStandard: 'civil',
+  });
+
+  assert.throws(
+    () =>
+      scanLifetimeDynamicEvents(
+        lifetime.baseChart,
+        lifetime.stages,
+        { startDate: '1969-09-30', endDate: '1969-09-30' },
+        'zhuanpan',
+        'chaibu',
+        { timeZoneId: 'Pacific/Kwajalein' },
+      ),
+    /Pacific\/Kwajalein.*回拨歧义.*timezone/u,
+  );
+});


### PR DESCRIPTION
31 年奇门终身局补算在 Cloudflare 触发资源限制，无法进入后续分阶段解读。现在日级扫描直接计算当地日干支，并复用时区校验器，减少重复构造完整排盘；保留全部事件日期、阶段归属和异常边界。补算服务返回 HTML 错误页时，界面保留可读 HTTP 状态及原始异常。

NAS 验证：70 项相关回归、类型、ESLint、格式检查通过；2026—2056 年仍有 161 个事件簇和 3806 条日期事实，固定偏移与上海 IANA 计算分别约 825/858 毫秒，提示词约 10.6 万字。历史时区额外复查发现 Kwajalein 1969 年回拨歧义，已补前后 36 小时偏移探查与回归；新边界等待门禁。完整发布包门禁执行中。实际新预览仍返回 Cloudflare 503/1102，因此本 PR 只确认计算提速，尚未解决预览服务的长范围资源限制；浏览器后台补算另行实施。

本 PR 基于 #291，未合并。真实模型额外 3 次额度已用完，本轮浏览器验证使用模拟模型响应与真实补算接口。