### PR TITLE
在浏览器后台补齐奇门完整目标时限

### DIFF
--- a/scripts/verify-docker-runtime.mjs
+++ b/scripts/verify-docker-runtime.mjs
@@ -52,6 +52,18 @@ try {
   assert.equal(mcpJson.status, 'ok');
   assert.equal(mcpJson.endpoint, '/mcp');
 
+  const lifetimeInput = {
+    birthDateTime: '1994-06-15T12:00:00',
+    timeZoneId: 'Asia/Shanghai',
+    timeStandard: 'civil',
+    periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
+    question: '分析完整目标时段的事业变化。',
+  };  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', lifetimeInput);
+  assert.ok(lifetime.prompt.length > 100_000);
+  assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
+  assert.equal(lifetime.result.eventClusters.length, 161);
+  assert.equal(lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length, 3806);
+
   const yilin = await postJson('/api/v1/classics/yilin', {
     baseHexagram: '乾',
     targetHexagram: '需',

--- a/scripts/verify-docker-runtime.mjs
+++ b/scripts/verify-docker-runtime.mjs
@@ -59,17 +59,19 @@ try {
     periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
     question: '分析完整目标时段的事业变化。',
   };
-  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', {
-    ...lifetimeInput,
-    responseMode: 'full',
-  });
+  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', lifetimeInput);
   assert.ok(lifetime.prompt.length > 100_000);
-  assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
-  assert.equal(lifetime.result.eventClusters.length, 161);
-  assert.equal(
-    lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length,
-    3806,
-  );
+  for (let year = 2026; year <= 2056; year += 1) {
+    assert.ok(lifetime.prompt.includes(`${year}年`));
+  }
+  assert.match(lifetime.prompt, /可复核日期/u);
+  const oversizedLifetime = await fetch(`${origin}/api/v1/divination/qimen/lifetime/prompt`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...lifetimeInput, responseMode: 'full' }),
+  });
+  assert.equal(oversizedLifetime.status, 413);
+  assert.equal((await oversizedLifetime.json()).error.code, 'RESPONSE_TOO_LARGE');
 
   const yilin = await postJson('/api/v1/classics/yilin', {
     baseHexagram: '乾',

--- a/scripts/verify-docker-runtime.mjs
+++ b/scripts/verify-docker-runtime.mjs
@@ -59,7 +59,10 @@ try {
     periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
     question: '分析完整目标时段的事业变化。',
   };
-  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', lifetimeInput);
+  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', {
+    ...lifetimeInput,
+    responseMode: 'full',
+  });
   assert.ok(lifetime.prompt.length > 100_000);
   assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
   assert.equal(lifetime.result.eventClusters.length, 161);

--- a/scripts/verify-docker-runtime.mjs
+++ b/scripts/verify-docker-runtime.mjs
@@ -58,11 +58,15 @@ try {
     timeStandard: 'civil',
     periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
     question: '分析完整目标时段的事业变化。',
-  };  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', lifetimeInput);
+  };
+  const lifetime = await postJson('/api/v1/divination/qimen/lifetime/prompt', lifetimeInput);
   assert.ok(lifetime.prompt.length > 100_000);
   assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
   assert.equal(lifetime.result.eventClusters.length, 161);
-  assert.equal(lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length, 3806);
+  assert.equal(
+    lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length,
+    3806,
+  );
 
   const yilin = await postJson('/api/v1/classics/yilin', {
     baseHexagram: '乾',

--- a/scripts/verify-mcp-package-runtime.mjs
+++ b/scripts/verify-mcp-package-runtime.mjs
@@ -113,7 +113,8 @@ try {
     timeStandard: 'civil',
     periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
     question: '分析完整目标时段的事业变化。',
-  };  const lifetimeResponse = await client.callTool({
+  };
+  const lifetimeResponse = await client.callTool({
     name: 'qimen_lifetime_prompt',
     arguments: lifetimeInput,
   });
@@ -122,7 +123,10 @@ try {
   assert.ok(lifetime.prompt.length > 100_000);
   assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
   assert.equal(lifetime.result.eventClusters.length, 161);
-  assert.equal(lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length, 3806);
+  assert.equal(
+    lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length,
+    3806,
+  );
 
   const soundReference = await callTool(client, 'huangji_reference_tables', {
     table: 'sound-rhythm',

--- a/scripts/verify-mcp-package-runtime.mjs
+++ b/scripts/verify-mcp-package-runtime.mjs
@@ -107,6 +107,23 @@ try {
   assert.equal(xuankong.replacement.mountain.referenceMountain, '子');
   assert.equal(xuankong.replacement.facing.referenceMountain, '巽');
 
+  const lifetimeInput = {
+    birthDateTime: '1994-06-15T12:00:00',
+    timeZoneId: 'Asia/Shanghai',
+    timeStandard: 'civil',
+    periodRange: { startDate: '2026-01-01', endDate: '2056-12-31' },
+    question: '分析完整目标时段的事业变化。',
+  };  const lifetimeResponse = await client.callTool({
+    name: 'qimen_lifetime_prompt',
+    arguments: lifetimeInput,
+  });
+  assert.notEqual(lifetimeResponse.isError, true);
+  const lifetime = lifetimeResponse.structuredContent;
+  assert.ok(lifetime.prompt.length > 100_000);
+  assert.deepEqual(lifetime.result.input.periodRange, lifetimeInput.periodRange);
+  assert.equal(lifetime.result.eventClusters.length, 161);
+  assert.equal(lifetime.result.eventClusters.flatMap((item) => item.triggerDates ?? []).length, 3806);
+
   const soundReference = await callTool(client, 'huangji_reference_tables', {
     table: 'sound-rhythm',
     detailMode: 'full',

--- a/src/lib/ai/qimen-lifetime-worker.ts
+++ b/src/lib/ai/qimen-lifetime-worker.ts
@@ -1,0 +1,97 @@
+import type { QimenLifetimeData, QimenLifetimeInput } from 'mingyu-core/types';
+
+export type QimenLifetimeWorkerResult = {
+  prompt: string;
+  result: QimenLifetimeData;
+};
+
+type WorkerResponse =
+  | ({ id: string; ok: true } & QimenLifetimeWorkerResult)
+  | { id: string; ok: false; error?: string };
+
+let requestCounter = 0;
+
+function createAbortError() {
+  return new DOMException('已停止解读', 'AbortError');
+}
+
+function createWorkerId() {
+  requestCounter += 1;
+  return `qimen-lifetime-${requestCounter}`;
+}
+
+export function executeQimenLifetimeWorker(
+  input: QimenLifetimeInput,
+  question: string | undefined,
+  signal?: AbortSignal,
+): Promise<QimenLifetimeWorkerResult> {
+  if (signal?.aborted) return Promise.reject(createAbortError());
+
+  let worker: Worker;
+  try {
+    worker = new Worker(new URL('../../workers/qimen-lifetime.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+  } catch (error) {
+    return Promise.reject(error);
+  }
+
+  const requestId = createWorkerId();
+  return new Promise<QimenLifetimeWorkerResult>((resolve, reject) => {
+    let settled = false;
+    const timer = globalThis.setTimeout(() => {
+      finishWithError(new Error('奇门终身局计算超时，请稍后重试。'));
+    }, 45_000);
+
+    const cleanup = () => {
+      globalThis.clearTimeout(timer);
+      signal?.removeEventListener('abort', handleAbort);
+      try {
+        worker.terminate();
+      } catch {
+        // worker 已结束时无需重复处理终止错误。
+      }
+    };
+
+    const finishWithError = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error instanceof Error ? error : new Error('奇门终身局排盘失败。'));
+    };
+
+    const handleAbort = () => finishWithError(createAbortError());
+
+    if (signal?.aborted) {
+      finishWithError(createAbortError());
+      return;
+    }
+    signal?.addEventListener('abort', handleAbort, { once: true });
+
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      if (settled || event.data.id !== requestId) return;
+      if (event.data.ok) {
+        settled = true;
+        cleanup();
+        resolve({
+          prompt: event.data.prompt,
+          result: event.data.result,
+        });
+      } else {
+        finishWithError(new Error(event.data.error || '奇门终身局排盘失败。'));
+      }
+    };
+    worker.onerror = (event) => {
+      finishWithError(new Error(event.message || '奇门终身局排盘失败。'));
+    };
+    worker.onmessageerror = () => {
+      finishWithError(new Error('奇门终身局结果解析失败。'));
+    };
+
+    try {
+      worker.postMessage({ id: requestId, input, question });
+    } catch (error) {
+      finishWithError(error);
+    }
+  });
+}

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -4,6 +4,8 @@ import {
 } from './reading-capabilities';
 import type { ReadingAction, ReadingResource, ReadingTarget } from './reading-workflow';
 import type { ReadingSubjectSnapshot } from './reading-subject';
+import type { QimenLifetimeInput } from 'mingyu-core/types';
+import { executeQimenLifetimeWorker } from './qimen-lifetime-worker';
 import { getDefaultAstrolabeScopeDate } from '../astrolabe-scope';
 import { getAiApiEndpoint } from './stream-client';
 import {
@@ -1743,7 +1745,21 @@ export async function executeReadingAction(
   ) {
     delete calculationRequest.timeIndex;
   }
-  const data = await fetchReadingData(path, signal, calculationRequest);
+  let data: Record<string, unknown>;
+  if (action.method === 'qimen-lifetime' && typeof Worker !== 'undefined') {
+    const question =
+      typeof calculationRequest.question === 'string' ? calculationRequest.question.trim() : '';
+    if (!question) throw new Error('缺少必填字段：question。');
+    const { question: _question, responseMode: _responseMode, ...qimenInput } = calculationRequest;
+    const workerResult = await executeQimenLifetimeWorker(
+      qimenInput as QimenLifetimeInput,
+      question,
+      signal,
+    );
+    data = workerResult as unknown as Record<string, unknown>;
+  } else {
+    data = await fetchReadingData(path, signal, calculationRequest);
+  }
   if (
     locked ||
     action.method === 'taiyi' ||

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -4,7 +4,6 @@ import {
 } from './reading-capabilities';
 import type { ReadingAction, ReadingResource, ReadingTarget } from './reading-workflow';
 import type { ReadingSubjectSnapshot } from './reading-subject';
-import type { QimenLifetimeInput } from 'mingyu-core/types';
 import { executeQimenLifetimeWorker } from './qimen-lifetime-worker';
 import { getDefaultAstrolabeScopeDate } from '../astrolabe-scope';
 import { getAiApiEndpoint } from './stream-client';
@@ -1751,8 +1750,12 @@ export async function executeReadingAction(
       typeof calculationRequest.question === 'string' ? calculationRequest.question.trim() : '';
     if (!question) throw new Error('缺少必填字段：question。');
     const { question: _question, responseMode: _responseMode, ...qimenInput } = calculationRequest;
+    const birthDateTime = qimenInput.birthDateTime;
+    if (typeof birthDateTime !== 'string' || !birthDateTime.trim()) {
+      throw new Error('奇门终身局排盘必须提供出生时间 birthDateTime。');
+    }
     const workerResult = await executeQimenLifetimeWorker(
-      qimenInput as QimenLifetimeInput,
+      { ...qimenInput, birthDateTime },
       question,
       signal,
     );

--- a/src/workers/qimen-lifetime.worker.ts
+++ b/src/workers/qimen-lifetime.worker.ts
@@ -1,0 +1,27 @@
+import { generateQimenLifetimePrompt } from 'mingyu-core/divination/qimen';
+import type { QimenLifetimeInput } from 'mingyu-core/types';
+
+type QimenLifetimeWorkerRequest = {
+  id: string;
+  input: QimenLifetimeInput;
+  question?: string;
+};
+
+self.onmessage = (event: MessageEvent<QimenLifetimeWorkerRequest>) => {
+  const { id, input, question } = event.data;
+  try {
+    const { data, prompt } = generateQimenLifetimePrompt(input, question);
+    self.postMessage({
+      id,
+      ok: true,
+      prompt,
+      result: data,
+    });
+  } catch (error) {
+    self.postMessage({
+      id,
+      ok: false,
+      error: error instanceof Error ? error.message : '奇门终身局排盘失败。',
+    });
+  }
+};

--- a/tests/ai-reading-qimen-lifetime.test.ts
+++ b/tests/ai-reading-qimen-lifetime.test.ts
@@ -8,7 +8,8 @@ import {
 import { executeReadingAction, type ReadingAction } from '../src/lib/ai/reading-resources';
 import type { QueryInputState, QueryPromptState } from '../src/lib/query-state';
 import { handlePublicApiRequest } from '../src/lib/public-api/handler';
-import { calculateQimenLifetime } from 'mingyu-core/divination/qimen';
+import { buildLifetimePrompt, calculateQimenLifetime } from 'mingyu-core/divination/qimen';
+import type { QimenLifetimeInput } from 'mingyu-core/types';
 
 const input: QueryInputState = {
   analysisMode: 'single',
@@ -212,6 +213,144 @@ test('终身奇门补算经真实公共 API 返回实际阶段和目标区间动
     assert.match(resource.title, /奇门终身局.*2026-01-01至2027-12-31/u);
     assert.match(resource.text, /2026年/u);
   });
+});
+
+test('浏览器奇门终身补算通过 Worker 返回同形 prompt/result 并继续主体校验', async () => {
+  const originalWorker = Object.getOwnPropertyDescriptor(globalThis, 'Worker');
+  const originalFetch = globalThis.fetch;
+  class FakeWorker {
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: ErrorEvent) => void) | null = null;
+    onmessageerror: (() => void) | null = null;
+
+    postMessage(message: { id: string; input: QimenLifetimeInput; question?: string }) {
+      queueMicrotask(() => {
+        try {
+          const result = calculateQimenLifetime(message.input);
+          const response = {
+            id: message.id,
+            ok: true,
+            prompt: buildLifetimePrompt(result, message.question),
+            result,
+          };
+          this.onmessage?.({ data: response } as MessageEvent);
+        } catch (error) {
+          this.onerror?.({ message: String(error) } as ErrorEvent);
+        }
+      });
+    }
+
+    terminate() {}
+  }
+
+  Object.defineProperty(globalThis, 'Worker', {
+    configurable: true,
+    writable: true,
+    value: FakeWorker,
+  });
+  globalThis.fetch = (async () => {
+    throw new Error('浏览器 Worker 补算不应访问公开接口。');
+  }) as typeof fetch;
+  try {
+    const resource = await executeReadingAction(action, undefined, subject);
+    const result = resource.structured as Record<string, unknown>;
+    const actualInput = result.input as Record<string, unknown>;
+    assert.deepEqual(actualInput.periodRange, periodRange);
+    assert.deepEqual(actualInput.topics, ['career']);
+    assert.match(resource.text, /未来两年的事业变化/u);
+    assert.match(resource.title, /2026-01-01至2027-12-31/u);
+    await assert.rejects(
+      executeReadingAction(
+        { ...action, input: { periodRange, topics: ['career'] } },
+        undefined,
+        subject,
+      ),
+      /缺少必填字段：question/u,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalWorker) {
+      Object.defineProperty(globalThis, 'Worker', originalWorker);
+    } else {
+      Reflect.deleteProperty(globalThis, 'Worker');
+    }
+  }
+});
+
+test('浏览器奇门终身 Worker 取消会终止且可忽略迟到结果，失败后可重试', async () => {
+  const originalWorker = Object.getOwnPropertyDescriptor(globalThis, 'Worker');
+  const originalFetch = globalThis.fetch;
+  let attempts = 0;
+  let terminatedWorkers = 0;
+  let lateResponses = 0;
+  class RetryWorker {
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: ErrorEvent) => void) | null = null;
+    onmessageerror: (() => void) | null = null;
+
+    postMessage(message: { id: string; input: QimenLifetimeInput; question?: string }) {
+      const attempt = ++attempts;
+      queueMicrotask(() => {
+        if (attempt === 1) {
+          lateResponses += 1;
+          this.onmessage?.({
+            data: { id: message.id, ok: true, prompt: '迟到结果', result: {} },
+          } as MessageEvent);
+          return;
+        }
+        if (attempt === 2) {
+          this.onerror?.({ message: '本次 Worker 计算失败。' } as ErrorEvent);
+          return;
+        }
+        const result = calculateQimenLifetime(message.input);
+        this.onmessage?.({
+          data: {
+            id: message.id,
+            ok: true,
+            prompt: buildLifetimePrompt(result, message.question),
+            result,
+          },
+        } as MessageEvent);
+      });
+    }
+
+    terminate() {
+      terminatedWorkers += 1;
+    }
+  }
+
+  Object.defineProperty(globalThis, 'Worker', {
+    configurable: true,
+    writable: true,
+    value: RetryWorker,
+  });
+  globalThis.fetch = (async () => {
+    throw new Error('浏览器 Worker 补算不应访问公开接口。');
+  }) as typeof fetch;
+  try {
+    const controller = new AbortController();
+    const cancelled = executeReadingAction(action, controller.signal, subject);
+    controller.abort();
+    await assert.rejects(cancelled, (error: unknown) => {
+      return error instanceof DOMException && error.name === 'AbortError';
+    });
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    assert.equal(lateResponses, 1);
+    assert.equal(terminatedWorkers, 1);
+
+    await assert.rejects(executeReadingAction(action, undefined, subject), /本次 Worker 计算失败/u);
+    const resource = await executeReadingAction(action, undefined, subject);
+    assert.ok(resource.structured);
+    assert.equal(attempts, 3);
+    assert.equal(terminatedWorkers, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalWorker) {
+      Object.defineProperty(globalThis, 'Worker', originalWorker);
+    } else {
+      Reflect.deleteProperty(globalThis, 'Worker');
+    }
+  }
 });
 
 test('终身局主体拒绝普通即时奇门和篡改后的出生主体', async () => {


### PR DESCRIPTION
浏览器中的奇门终身局 AI 追问现在使用后台 Worker 计算完整目标时段，避免长范围请求受 Pages 计算资源限制而失败。结果继续经过原有主体、时段和主题校验，并进入分阶段解读；取消会终止计算，失败后可重试。

Node/MCP 保留现有路径，另补实际 Node HTTP 与隔离 MCP 发布包的31年时限资料验证。本改动没有改变默认范围，也没有裁切或抽样日期。

NAS 81项相关回归、类型、ESLint、格式及生产构建通过。实际Node HTTP的31年完整提示词及1MiB结构化响应边界、隔离MCP发布包的161个事件簇/3806条日期事实、Pages构建均通过。真实237ae978预览使用浏览器Worker完成31年补算：4阶段最大48637字，汇总与刷新恢复成功，320像素无横向溢出；模型回答为模拟，排盘与资料真实。截图保存在本地验收目录。最新提交d951d73c的GitHub/Cloudflare 5项检查全部通过。本 PR 基于 #292，尚未合并。公网 Pages API 的31年503仍单独记录，不能由浏览器成功推断为已修复。