### PR TITLE
同步长时限返回模式与托管运行边界

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@
 
 参数选择建议：
 
-- `responseMode` 默认用 `summary`；只转交提示词给 AI 时用 `prompt-only`；确实需要完整结构化排盘时再用 `full`。
+- `responseMode` 默认为 `prompt-only`；需要提示词及轻量盘面摘要时用 `summary`；需要完整结构化排盘时用 `full`。
 - 八字紫微合参、八字、紫微、星盘要做完整长期分析时，优先选择完整输出版：八字用 `baziFortuneScope: "full"`，紫微和合参用 `promptScope: "full"`，星盘用 `astrolabeScope: "full"` 并以 `astrolabeScopeDate: "YYYY-MM-DD"` 明确行运基准日。
 - 只问某一年、某月、某日时，优先选择对应范围，避免把短期问题做成泛泛终身解读。
 - `promptMode` 默认用 `framework`，这样返回的提示词结构更完整；只有用户明确要自由问答或自己已经写好完整问题时，才用 `custom`。
@@ -173,6 +173,8 @@
 `/calculate` 和 `/divination/{method}` 接口只返回排盘、卦盘、牌阵或灵签数据。需要可直接发送给 AI 的提示词时，使用对应的 `/prompt` 一站式接口。
 
 为降低大排盘、长提示词和代理转发失败风险，`/prompt` 默认使用 `responseMode: "prompt-only"`，只返回 `data.prompt`。需要结构化展示时显式传 `responseMode: "summary"` 获取轻量摘要；确实需要同一次响应带完整排盘时才传 `responseMode: "full"`。所有命理、占卜和风水计算接口默认使用 `detailMode: "compact"`，保留盘面与解读所需字段，省略提示词、证据链和重复计算过程；其中八字仍保留逐柱神煞命中。审计或研究场景可显式传 `detailMode: "full"`。
+
+公开 HTTP 成功响应的上限为 1 MiB，超过时返回 `HTTP 413` 与 `RESPONSE_TOO_LARGE`。长时限查询只需交给 AI 解读时，可使用 `responseMode: "prompt-only"` 获取完整提示词；需要全部结构化时限资料时可使用独立 MCP 的对应工具。奇门终身局最多31年是计算范围上限，实际 HTTP 返回还受响应大小和部署资源限制；分页或分段获取资料时应保留原目标范围并核对覆盖。
 
 真太阳时换算：
 

--- a/docs/development-and-deployment.md
+++ b/docs/development-and-deployment.md
@@ -87,6 +87,8 @@ npx tsc --project mcp/tsconfig.json --noEmit
 
 静态页面由 Pages 托管，`/api/v1/*` 由 Pages Functions 处理。
 
+Pages Functions 使用 Workers 的运行额度。免费计划的 CPU 时间上限为每次10毫秒，长时限排盘可能触发1102资源超限；HTTP的1MiB成功响应上限则由应用自身执行。浏览器奇门终身局AI补算使用后台Worker，独立MCP在客户端运行；需要托管长时限API时，应选择有足够计算资源的Node/Docker部署或评估Workers额度。具体平台限制见 [Cloudflare官方文档](https://developers.cloudflare.com/workers/platform/limits/)。
+
 | 配置项                 | 值           |
 | ---------------------- | ------------ |
 | Build command          | `pnpm build` |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -274,6 +274,8 @@ pnpm mcp
 
 奇门终身局工具必须提供 `birthDateTime`；出生时间按 `timeZoneId` 或固定 `timezone` 解析，`timeStandard: "trueSolar"` 时还必须提供 `location.longitude`。`periodRange` 使用有效的 `startDate`、`endDate`（`YYYY-MM-DD`）指定动态流年区间，最多连续31个年份；`topics` 可限定事业、财运、婚姻、健康、学业、迁居、家庭、子女或合作主题；终身局工具返回出生主体、阶段卡和该区间实际生成的动态事件簇。
 
+独立 MCP 的 stdio 工具在本机运行，奇门31年时限可返回完整 `result` 和 `prompt`。HTTP部署另受应用1MiB成功响应上限与托管运行额度限制：`RESPONSE_TOO_LARGE` 表示响应过大，Pages的1102表示运行资源超限。仅需完整解读文本时可选HTTP的 `responseMode: "prompt-only"`；切换入口或分段获取时仍应保留原主体、主题与目标时间范围。
+
 ### 解读口径与合参
 
 只对规划内确有合理差异的提示词工具提供 `schools`，可传一至三个值。传一个值时按该流派、断法或侧重解读；传两个或三个值时，提示词会要求分别判断，再归纳共同结论、分歧及各自盘面依据，最后形成综合判断。同属流派时称“多派合参”，同属断法时称“多法合参”，混合类型时称“多口径合参”。八字、紫微、住宅风水属于真实流派选择；塔罗、黄历择日、星盘和七政四余同时包含流派与断法；其余登记项属于不同断法，不称作不同派系。八字和紫微原有 `school` 参数继续兼容；同时传入时以 `schools` 为准。八字紫微合参分别使用 `baziSchools`、`ziweiSchools`。

--- a/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
+++ b/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
@@ -229,5 +229,6 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
    - `compact`：在八字、紫微、奇门和黄历排盘中，过滤冗长计算步骤，仅保留核心盘面；八字仍保留逐柱神煞命中；
    - `full`：返回全量证据节点。
 3. **服务异常与降级**：
+   - HTTP成功响应上限为1MiB；`413 / RESPONSE_TOO_LARGE` 时，纯解读任务可使用 `responseMode: "prompt-only"`，需要完整结构化时限资料时可切换独立MCP。Pages的1102属于运行资源限制。保留原主体、主题与目标范围，分段获取后核对完整覆盖；
    - 当 API 返回 5xx、超时或网络中断时，保留用户输入并转由上层 Skill 执行人工盘面核验或基于已知柱位做保守分析；
    - 严禁将 HTTP 错误代码解释为命理吉凶。

--- a/public/skills/mingyu/references/providers/aov-mingyu.md
+++ b/public/skills/mingyu/references/providers/aov-mingyu.md
@@ -229,5 +229,6 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
    - `compact`：在八字、紫微、奇门和黄历排盘中，过滤冗长计算步骤，仅保留核心盘面；八字仍保留逐柱神煞命中；
    - `full`：返回全量证据节点。
 3. **服务异常与降级**：
+   - HTTP成功响应上限为1MiB；`413 / RESPONSE_TOO_LARGE` 时，纯解读任务可使用 `responseMode: "prompt-only"`，需要完整结构化时限资料时可切换独立MCP。Pages的1102属于运行资源限制。保留原主体、主题与目标范围，分段获取后核对完整覆盖；
    - 当 API 返回 5xx、超时或网络中断时，保留用户输入并转由上层 Skill 执行人工盘面核验或基于已知柱位做保守分析；
    - 严禁将 HTTP 错误代码解释为命理吉凶。

--- a/skills/mingyu/references/providers/aov-mingyu.md
+++ b/skills/mingyu/references/providers/aov-mingyu.md
@@ -229,5 +229,6 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
    - `compact`：在八字、紫微、奇门和黄历排盘中，过滤冗长计算步骤，仅保留核心盘面；八字仍保留逐柱神煞命中；
    - `full`：返回全量证据节点。
 3. **服务异常与降级**：
+   - HTTP成功响应上限为1MiB；`413 / RESPONSE_TOO_LARGE` 时，纯解读任务可使用 `responseMode: "prompt-only"`，需要完整结构化时限资料时可切换独立MCP。Pages的1102属于运行资源限制。保留原主体、主题与目标范围，分段获取后核对完整覆盖；
    - 当 API 返回 5xx、超时或网络中断时，保留用户输入并转由上层 Skill 执行人工盘面核验或基于已知柱位做保守分析；
    - 严禁将 HTTP 错误代码解释为命理吉凶。


### PR DESCRIPTION
公开API文档有一处把默认responseMode写成summary，与代码的prompt-only不一致，已修正。同步说明HTTP的1MiB成功响应限制、Pages运行额度和独立MCP的长时限返回能力，帮助调用方保留目标范围并选择完整资料入口。

仅修改现有API、部署、MCP与Provider说明；Skill单一源同步到两份发布镜像。NAS上15项文档、链接和契约检查全部通过。平台限制引用Cloudflare官方文档；31年运行证据沿用#293的实际Node、MCP和浏览器验证。

本PR基于#293，尚未合并。