### PR TITLE
接入皇极冬至岁周现代换算

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@
 4. 用户要从一段日期里挑日子，优先用 `POST /divination/almanac/prompt`；日期超过 31 天或参与人很多时分页调用。
 5. 用户提供一人的西方占星出生资料时，用 `POST /divination/astrolabe/prompt`；提供双方完整出生资料并询问关系时，用 `POST /divination/astrolabe/synastry/prompt`。
 6. 用户只想要轻量灵感、心理牌面或不提供出生信息时，可用塔罗、灵签等提示词接口。
-7. 用户问住宅、搬家、坐向、命宅或风水时，优先用 `POST /metaphysics/residential/prompt`（产品统一入口）；明确只要八宅或只要玄空时再用对应底层接口；太乙、五运六气、皇极经世和七政四余仍用各自 `/metaphysics/{method}/prompt`。皇极经世年月日时即时占断使用 `customDate`，六日逐爻公历占断使用显式历元参数，年度研究使用 `year`，研究其他纪元时再额外提供 `epochYear`；查声音律吕、动植物数或固定卷三历史纪年时使用 `/metaphysics/huangji-jingshi/references`。
+7. 用户问住宅、搬家、坐向、命宅或风水时，优先用 `POST /metaphysics/residential/prompt`（产品统一入口）；明确只要八宅或只要玄空时再用对应底层接口；太乙、五运六气、皇极经世和七政四余仍用各自 `/metaphysics/{method}/prompt`。皇极经世年月日时即时占断使用 `customDate`，六日逐爻公历占断可选 `calendarModel=six-day-seven-part`（现代冬至与岁周比例定位，不传显式历元）或 `calendarModel=six-day-explicit-epoch`（必须传显式历元），年度研究使用 `year`，研究其他纪元时再额外提供 `epochYear`；查声音律吕、动植物数或固定卷三历史纪年时使用 `/metaphysics/huangji-jingshi/references`。
 
 常见问题到推荐接口：
 
@@ -155,7 +155,7 @@
 | 生肖犯太岁、流年贵人               | `POST /metaphysics/zodiac/prompt`            | `zodiac`、`year` 或 `yearGanZhi`                                                                                                                            | 生肖可传“鼠”或“子”                                               |
 | 太乙神数                           | `POST /metaphysics/taiyi/prompt`             | `scope` 支持 `year`、`month`、`day`、`hour`；年计传 `year`，其余计式传对应年月日时分                                                                        | 返回四计七十二局式盘与 `evidenceAnalysis` 结构化证据             |
 | 五运六气年度结构                   | `POST /metaphysics/wuyun-liuqi/prompt`       | `year` 或 `yearGanZhi`；同时提供时会校验一致性，可选 `question`                                                                                             | 返回五步主客运、五类符会与六步主客气；不替代实际气象或医疗资料   |
-| 皇极经世年月日时与六日逐爻占断     | `POST /metaphysics/huangji-jingshi/prompt`   | 既有年月日时传 `customDate`；六日逐爻同时传 `sixDayDateTime`、经校定的 `sixDayEpochDateTime` 与 `calendarModel=six-day-explicit-epoch`，未带偏移时再传 `timezone`/`timeZoneId`；年度研究传 `year`；自定义纪元传 `epochYear`，再从 `year` 与 `elapsedYears` 中选一个 | 返回元会运世、值年卦、六日逐爻或年月日时层级资料               |
+| 皇极经世年月日时与六日逐爻占断     | `POST /metaphysics/huangji-jingshi/prompt`   | 既有年月日时传 `customDate`；六日逐爻传 `sixDayDateTime` 与 `calendarModel=six-day-seven-part`，或传 `sixDayDateTime`、经校定的 `sixDayEpochDateTime` 与 `calendarModel=six-day-explicit-epoch`；未带偏移时再传 `timezone`/`timeZoneId`；年度研究传 `year`；自定义纪元传 `epochYear`，再从 `year` 与 `elapsedYears` 中选一个 | 返回元会运世、值年卦、六日逐爻或年月日时层级资料，并说明现代冬至岁周比例模型的适用边界 |
 | 皇极声音律吕、动植物数与历史纪年资料 | `POST /metaphysics/huangji-jingshi/references` | `table: "sound-rhythm"`、`"animal-plant"` 或 `"historical-era"`；查询历史表时另传 `shiIndex: 2149-2208` | 返回固定版本中的声音分类与数目、动植物数，或经辰三十年干支及原表标注名称 |
 | 七政四余                           | `POST /metaphysics/qizheng/prompt`           | 精准出生年月日时、经纬度，并提供 `timezone` 或 `timeZoneId`；可选 `useTrueSolarTime`、`gender`、`flowYear`/`flowMonth`/`flowDay`                            | 返回十一星、真实距星宿界、命身十二宫、庙旺吊照；有流年时另给行限与流曜 |
 | 玄空飞星                           | `POST /metaphysics/xuankong/prompt`          | `year`、`sitMountain`/`facingMountain` 或度数；可选 `guaType: 下卦/替卦`、测量误差、`flowYear`/`flowMonth`/`flowDay` 目标流运日期                                                               | 返回下卦或显式替卦的三盘飞星、局型与组合；有目标日期时叠紫白流年流月飞星 |
@@ -462,7 +462,7 @@ curl -X POST https://aov.cc/api/v1/ai/models \
 - 五运六气使用 `year` 或 `yearGanZhi`；同时提供时会校验两者一致。`year` 支持 1—9999 年，按该公历年年中所属年柱换算。公历交司日期支持 1900—2199 年；其他年份和仅提供干支时仍返回完整年度结构，以节气及传统序日表示边界，`calendarDateStatus` 为“节令边界”；已换算日期时为“公历日期已换算”。结果包含固定木火土金水的五步主运、从中运起按相生轮转的五步客运、五音太少、传统交司日期、司天与中运的同气、顺化、天刑、小逆、不和关系，天符、岁会、太乙天符、同天符、同岁会逐项核验，以及从大寒起每四个节气一组的六步主客气。交司日期保留《运气要诀》的“节气后第几日”口径，不包装成精确到时分秒的现代时刻。
 - 吴谦《运气要诀》列出的五类符会逐年名单按六十甲子去重为 26 年，与原文“二十八年”汇总不一致；接口保留 `sourceReconciliation` 校勘说明，并以逐项定义和逐年名单为计算依据。
 - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦。月日层按二十四节气分配的三百六十日历法坐标推演，结果会明确返回该传统历法口径，不把它包装为现代公历自然月日。
-- 皇极经世六日逐爻入口同时传 `sixDayDateTime`、`sixDayEpochDateTime` 与 `calendarModel=six-day-explicit-epoch`。`sixDayEpochDateTime` 必须是经校定的当地子半（00:00:00），表示三百六十日正数坐标的起点；两个时间字符串可自带同一固定 UTC 偏移，或均未带偏移并同时提供固定 `timezone` 或 IANA `timeZoneId`。公历适配直接使用显式历元至目标当地日期的整数日差作为六日坐标，并保留真实 UTC 瞬时和每四小时一爻资料；原典没有现代公历唯一历元，三百六十日坐标之外的六日余分不在该入口换算。
+- 皇极经世六日逐爻入口支持两种公历模型。`calendarModel=six-day-seven-part` 只需传 `sixDayDateTime`，按现代冬至起点与实际岁周长度的比例定位六日七分坐标；目标时间仍须带固定 UTC 偏移，或在未带偏移时同时提供 `timezone`/`timeZoneId`。响应会返回该现代比例定位的依据和适用边界，不能把它解释为原典已经指定的现代公历唯一历元，也不能超出核心声明的公历与坐标范围。`calendarModel=six-day-explicit-epoch` 则必须同时传经校定的 `sixDayEpochDateTime`，且该时间为当地子半（00:00:00）；两个时间字符串可自带同一固定 UTC 偏移，或均未带偏移并同时提供固定 `timezone` 或 IANA `timeZoneId`，按显式历元至目标当地日期的整数日差适配三百六十日正数。显式历元之外的六日余分不在该模型自动换算。
 - 只提供公元 `year` 时仍返回年度盘，默认采用公元前 67017 年为本元起点、1984 年鼎卦为甲子值年锚点的通行排法，包含会内统卦、运卦、六十年统卦、十年卦、值年卦及互卦、错卦、综卦。
 - 研究自定义纪元时提供 `epochYear`，并从 `year` 与 `elapsedYears` 中选择一项；该模式保留纯元会运世坐标换算，不附通行值年卦。
 - `progress` 分别给出当前元、会、运、世内已过年数、当前年之后剩余的完整年数，以及下一元、会、运、世开始年；所有层级序号均从 1 开始。

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -77,8 +77,8 @@
 | `taiyi_prompt` | 太乙神数提示词 | 生成太乙主客胜负定性与宏观时势自包含提示词；支持统一主题、主题细项和分析范围选择 |
 | `metaphysics_wuyun_liuqi` | 五运六气排盘 | 年度五步主客运、司天在泉与天符岁会五类符会病机 |
 | `wuyun_liuqi_prompt` | 五运六气提示词 | 生成年度气候节律与病机平气自包含提示词；支持统一主题、主题细项和分析范围选择 |
-| `metaphysics_huangji_jingshi` | 皇极经世宏观周期 | 邵雍皇极经世元会运世、值年卦与运世消息推进 |
-| `huangji_jingshi_prompt` | 皇极经世提示词 | 生成皇极经世时代坐标与值年卦演变自包含提示词；支持统一主题、主题细项和分析范围选择 |
+| `metaphysics_huangji_jingshi` | 皇极经世宏观周期 | 邵雍皇极经世元会运世、值年卦与运世消息推进；六日七分支持现代冬至岁周比例模型和显式历元模型 |
+| `huangji_jingshi_prompt` | 皇极经世提示词 | 生成皇极经世时代坐标与值年卦演变自包含提示词；支持六日七分两种公历模型、统一主题、主题细项和分析范围选择 |
 | `huangji_reference_tables` | 皇极经世扩展资料表 | 查询固定版本的声音律吕、动植物数与经辰历史纪年原表；历史表按经辰序号查询 |
 | `metaphysics_qizheng` | 七政四余排盘 | 果老星宗七政十一星、二十八宿界、昼夜分金恩难与行限流曜 |
 | `qizheng_prompt` | 七政四余提示词 | 生成七政四余天星恩难自包含解读任务书；支持统一主题、主题细项和分析范围选择 |
@@ -128,7 +128,7 @@
 | 雷诺曼关系或选择牌阵             | `lenormand_prompt`             | `spreadType`、`question`                                                 |
 | 求签                             | `ssgw_prompt`                  | `question`                                                               |
 | 年度气候节律、司天在泉           | `wuyun_liuqi_prompt`           | `year` 或 `yearGanZhi`、`question`                                      |
-| 皇极经世宏观周期、值年卦          | `huangji_jingshi_prompt`       | `customDate` 或 `year` / `epochYear` / `elapsedYears`、`question`        |
+| 皇极经世宏观周期、值年卦          | `huangji_jingshi_prompt`       | `customDate`、`sixDayDateTime` + `calendarModel`，或 `year` / `epochYear` / `elapsedYears`、`question` |
 
 出生时辰未知时，不要自行补时辰。八字可以保守分析；紫微和八字紫微合参需要时辰，优先请用户补足后再调用。
 
@@ -259,7 +259,7 @@ pnpm mcp
 
 ### 起卦与排盘时间参数
 
-六爻、梅花易数、小六壬、金口诀、奇门遁甲、大六壬以及太乙月、日、时计默认使用当前时间。需要复盘历史时刻、按用户指定时间起卦，或让本地 MCP 与网页端自定时间保持一致时，传入 `customDate`。皇极经世可用 `customDate` 固定年月日时，五运六气应明确目标 `year` 或 `yearGanZhi`；这些资料按目标时点或年度解读，不作为出生本命。金口诀还可用 `jinkoujueMethod: "branch"` 与 `jinkoujueBranch` 直接指定地分。
+六爻、梅花易数、小六壬、金口诀、奇门遁甲、大六壬以及太乙月、日、时计默认使用当前时间。需要复盘历史时刻、按用户指定时间起卦，或让本地 MCP 与网页端自定时间保持一致时，传入 `customDate`。皇极经世可用 `customDate` 固定年月日时；六日逐爻公历占断传 `sixDayDateTime` 并选择 `calendarModel=six-day-seven-part`（以现代冬至与岁周比例定位，不传 `sixDayEpochDateTime`）或 `calendarModel=six-day-explicit-epoch`（必须同时传经校定当地子半 `sixDayEpochDateTime`）。两种模型在未带时区偏移时都需 `timezone` 或 `timeZoneId`，响应会保留相应模型的适用边界；五运六气应明确目标 `year` 或 `yearGanZhi`，这些资料按目标时点或年度解读，不作为出生本命。金口诀还可用 `jinkoujueMethod: "branch"` 与 `jinkoujueBranch` 直接指定地分。
 
 `customDate` 必须是带时区的 ISO 8601 时间字符串，例如 `2025-01-01T08:30:00+08:00`。适用工具包括 `divine_liuyao`、`liuyao_prompt`、`divine_meihua`、`meihua_prompt`、`divine_xiaoliuren`、`xiaoliuren_prompt`、`divine_jinkoujue`、`jinkoujue_prompt`、`divine_qimen`、`qimen_prompt`、`divine_liuren`、`liuren_prompt`、`metaphysics_taiyi`、`taiyi_prompt`、`metaphysics_huangji_jingshi` 和 `huangji_jingshi_prompt`。
 

--- a/mcp/src/tools/huangji-jingshi.ts
+++ b/mcp/src/tools/huangji-jingshi.ts
@@ -25,32 +25,34 @@ const huangjiJingshiSchema = z
       .min(1)
       .optional()
       .describe(
-        '六日逐爻目标当地公历时间（ISO 8601 格式）；必须同时提供 calendarModel 与 sixDayEpochDateTime，并与其他起法字段互斥；可与历元一起带同一固定 UTC 偏移，或均不带偏移并配合 timezone 或 timeZoneId',
+        '六日逐爻目标当地公历时间（ISO 8601 格式）；calendarModel=six-day-seven-part 以现代冬至与岁周比例定位且不需要 sixDayEpochDateTime，calendarModel=six-day-explicit-epoch 必须同时提供显式历元；与其他起法字段互斥',
       ),
     sixDayEpochDateTime: z
       .string()
       .min(1)
       .optional()
       .describe(
-        '六日逐爻经校定的当地子半历元（ISO 8601 格式）；必须与 sixDayDateTime、calendarModel 同时提供；该时刻对应已过日数0',
+        '六日逐爻经校定的当地子半历元（ISO 8601 格式）；仅 calendarModel=six-day-explicit-epoch 使用，须与 sixDayDateTime、calendarModel 同时提供；该时刻对应已过日数0，six-day-seven-part 不得提供',
       ),
     calendarModel: z
-      .literal('six-day-explicit-epoch')
+      .enum(['six-day-explicit-epoch', 'six-day-seven-part'])
       .optional()
       .describe(
-        '六日逐爻公历换算模型；仅可与 sixDayDateTime、sixDayEpochDateTime 同时提供，并须取 six-day-explicit-epoch',
+        '六日逐爻公历换算模型；six-day-seven-part 使用现代冬至与岁周比例定位并保留核心定义范围，six-day-explicit-epoch 使用经校定公历子半历元且必须同时提供 sixDayEpochDateTime',
       ),
     timezone: z
       .number()
       .min(-12)
       .max(14)
       .optional()
-      .describe('sixDayDateTime 与 sixDayEpochDateTime 未带偏移时的固定 UTC 时区'),
+      .describe(
+        'sixDayDateTime 未带偏移时的固定 UTC 时区；显式历元模型中也用于核验 sixDayEpochDateTime',
+      ),
     timeZoneId: z
       .string()
       .optional()
       .describe(
-        'sixDayDateTime 与 sixDayEpochDateTime 对应的 IANA 历史时区，例如 America/New_York',
+        'sixDayDateTime 对应的 IANA 历史时区，例如 America/New_York；显式历元模型中目标与历元共用该时区',
       ),
     epochYear: safeInteger
       .optional()
@@ -72,7 +74,7 @@ const huangjiJingshiSchema = z
     scope: z.string().optional().describe('统一分析范围 ID'),
   })
   .describe(
-    '皇极经世起盘输入模式互斥：customDate、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 四类只能选一类',
+    '皇极经世起盘输入模式互斥：customDate、六日逐爻六日七分模型、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 五类只能选一类',
   );
 
 const huangjiReferenceSchema = z.object({
@@ -106,8 +108,22 @@ const huangjiModeContract = {
     },
     {
       required: ['sixDayDateTime', 'sixDayEpochDateTime', 'calendarModel'],
+      properties: { calendarModel: { const: 'six-day-explicit-epoch' } },
       not: {
         anyOf: [
+          { required: ['customDate'] },
+          { required: ['epochYear'] },
+          { required: ['year'] },
+          { required: ['elapsedYears'] },
+        ],
+      },
+    },
+    {
+      required: ['sixDayDateTime', 'calendarModel'],
+      properties: { calendarModel: { const: 'six-day-seven-part' } },
+      not: {
+        anyOf: [
+          { required: ['sixDayEpochDateTime'] },
           { required: ['customDate'] },
           { required: ['epochYear'] },
           { required: ['year'] },
@@ -159,14 +175,14 @@ const huangjiCalculationSchema = huangjiJingshiSchema
   .omit({ question: true })
   .extend(calculationDetailShape)
   .describe(
-    '皇极经世输入模式互斥：customDate、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 四类只能选一类',
+    '皇极经世输入模式互斥：customDate、六日逐爻六日七分模型、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 五类只能选一类',
   )
   .meta(huangjiModeContract);
 
 const huangjiPromptSchema = huangjiJingshiSchema
   .extend(createPromptSchoolsShape('huangji-jingshi'))
   .describe(
-    '皇极经世输入模式互斥：customDate、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 四类只能选一类',
+    '皇极经世输入模式互斥：customDate、六日逐爻六日七分模型、六日逐爻显式历元、通行公元 year、自定义 epochYear 配 year 或 elapsedYears 五类只能选一类',
   )
   .meta(huangjiModeContract);
 
@@ -195,11 +211,18 @@ function calculateHuangjiJingshi(args: z.infer<typeof huangjiJingshiSchema>) {
   const sixDayEpochDateTime = args.sixDayEpochDateTime;
   let sixDayDate: ReturnType<typeof huangjiJingshi.parseHuangjiSixDayDateTime> | undefined;
   if (args.sixDayDateTime !== undefined) {
-    if (calendarModel !== 'six-day-explicit-epoch') {
-      throw new Error('六日逐爻公历时间必须明确提供 calendarModel=six-day-explicit-epoch。');
+    if (calendarModel !== 'six-day-explicit-epoch' && calendarModel !== 'six-day-seven-part') {
+      throw new Error(
+        '六日逐爻公历时间必须明确提供 calendarModel=six-day-seven-part 或 six-day-explicit-epoch。',
+      );
     }
-    if (sixDayEpochDateTime === undefined) {
+    if (calendarModel === 'six-day-explicit-epoch' && sixDayEpochDateTime === undefined) {
       throw new Error('六日逐爻公历时间必须同时提供经校定的 sixDayEpochDateTime。');
+    }
+    if (calendarModel === 'six-day-seven-part' && sixDayEpochDateTime !== undefined) {
+      throw new Error(
+        'calendarModel=six-day-seven-part 不得提供 sixDayEpochDateTime；该模型以现代冬至与岁周比例定位。',
+      );
     }
     if (
       args.customDate !== undefined ||
@@ -261,7 +284,7 @@ export function registerHuangjiJingshiTool(server: McpServer) {
     'metaphysics_huangji_jingshi',
     {
       description:
-        '皇极经世排盘：customDate 返回既有年月日时盘；sixDayDateTime 配合 sixDayEpochDateTime 与 calendarModel=six-day-explicit-epoch 返回显式历元六日逐爻盘；year 兼容值年盘，也支持自定义纪元换算',
+        '皇极经世排盘：customDate 返回既有年月日时盘；sixDayDateTime 可选 calendarModel=six-day-seven-part（现代冬至与岁周比例定位，返回适用边界）或 calendarModel=six-day-explicit-epoch（必须配合 sixDayEpochDateTime）；year 兼容值年盘，也支持自定义纪元换算',
       inputSchema: huangjiCalculationSchema,
       outputSchema: resultOutputSchema,
     },

--- a/packages/core/src/huangji-jingshi/datetime.ts
+++ b/packages/core/src/huangji-jingshi/datetime.ts
@@ -11,10 +11,13 @@ import {
   createUtcTimestamp,
   formatCivilDateTime,
   formatFixedTimezoneOffset,
+  getCivilDateTimeAtFixedOffset,
+  getHistoricalTimezoneOffsetAt,
   resolveCivilTime,
   type CivilDateTimeParts,
   type CivilTimeZoneInput,
 } from '../calendar';
+import { getSixtyCycleIndex } from '../ganzhi';
 import {
   HUANGJI_CIRCLE_HEXAGRAMS,
   calculateStandardHuangjiForecast,
@@ -68,7 +71,11 @@ export interface HuangjiSixDayCycleInput {
 }
 
 export interface HuangjiSixDayCycleResult {
-  model: '书绪言六日逐爻' | '书绪言六日逐爻·显式历元';
+  model:
+    | '书绪言六日逐爻'
+    | '书绪言六日逐爻·显式历元'
+    | '书绪言六日逐爻·公历定位'
+    | '书绪言六日逐爻·现代冬至岁周换算';
   elapsedDays: number;
   hour: number;
   dayOfCycle: number;
@@ -84,19 +91,34 @@ export interface HuangjiSixDayCycleResult {
 }
 
 export const HUANGJI_SIX_DAY_CALENDAR_MODEL = 'six-day-explicit-epoch' as const;
-export type HuangjiSixDayCalendarModel = typeof HUANGJI_SIX_DAY_CALENDAR_MODEL;
+/** 以冬至岁周实测跨度按三百六十逻辑日等分的现代比例换算模型。 */
+export const HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL = 'six-day-seven-part' as const;
+export type HuangjiSixDayCalendarModel =
+  | typeof HUANGJI_SIX_DAY_CALENDAR_MODEL
+  | typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
 
-export interface HuangjiSixDayDateInput extends CivilDateTimeParts, CivilTimeZoneInput {
-  /** 明确选择以校定公历历元直接适配六日逐爻坐标的模型。 */
-  calendarModel: HuangjiSixDayCalendarModel;
-  /** 经校定的当地公历子半；该时刻对应 elapsedDays=0、hour=0。 */
-  epochDateTime: string;
+interface HuangjiSixDayDateInputBase extends CivilDateTimeParts, CivilTimeZoneInput {
   /** 可选毫秒；六日逐爻以秒作为传统时段的最小公开精度。 */
   millisecond?: number;
 }
 
-export interface HuangjiSixDayDateResult extends HuangjiSixDayCycleResult {
-  model: '书绪言六日逐爻·显式历元';
+export interface HuangjiSixDayExplicitDateInput extends HuangjiSixDayDateInputBase {
+  calendarModel: typeof HUANGJI_SIX_DAY_CALENDAR_MODEL;
+  /** 经校定的当地公历子半；该时刻对应 elapsedDays=0、hour=0。 */
+  epochDateTime: string;
+}
+
+export interface HuangjiSixDayProportionalDateInput extends HuangjiSixDayDateInputBase {
+  calendarModel: typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
+  /** 现代比例模型由冬至岁周自动确定起点，不接受显式历元。 */
+  epochDateTime?: never;
+}
+
+export type HuangjiSixDayDateInput =
+  | HuangjiSixDayExplicitDateInput
+  | HuangjiSixDayProportionalDateInput;
+
+interface HuangjiSixDayDateResultBase extends HuangjiSixDayCycleResult {
   civilTime: {
     dateTime: string;
     utcDateTime: string;
@@ -110,6 +132,13 @@ export interface HuangjiSixDayDateResult extends HuangjiSixDayCycleResult {
     second: number;
     millisecond: number;
   };
+  calculationChain: string[];
+  sources: Array<{ title: string; scope: string }>;
+  limitations: string[];
+}
+
+export interface HuangjiSixDayExplicitDateResult extends HuangjiSixDayDateResultBase {
+  model: '书绪言六日逐爻·显式历元';
   anchor: {
     kind: 'explicit-epoch';
     dateTime: string;
@@ -119,21 +148,68 @@ export interface HuangjiSixDayDateResult extends HuangjiSixDayCycleResult {
     dayBoundary: '当地子半';
   };
   calendar: {
-    model: HuangjiSixDayCalendarModel;
+    model: typeof HUANGJI_SIX_DAY_CALENDAR_MODEL;
     mapping: 'explicit-epoch-civil-days';
     targetYear: number;
     actualElapsedDays: number;
     actualElapsedSeconds: number;
     logicalElapsedDays: number;
-    logicalDayFraction: 0;
+    logicalDayFraction: number;
     coordinateSpanDays: 360;
     cycleDay: number;
   };
-  calculationChain: string[];
-  sources: Array<{ title: string; scope: string }>;
-  limitations: string[];
 }
 
+export interface HuangjiSixDayProportionalDateResult extends HuangjiSixDayDateResultBase {
+  model: '书绪言六日逐爻·现代冬至岁周换算';
+  anchor: {
+    kind: 'winter-solstice-civil-midnight';
+    term: '冬至';
+    /** tyme4ts 的冬至年标识；例如 2026 指向公历 2025 年冬至。 */
+    winterSolsticeYear: number;
+    /** 节气真实瞬时按现有节气口径以 UTC+8 回显。 */
+    dateTime: string;
+    utcDateTime: string;
+    timezone: 8;
+    /** 同一节气瞬时在目标地点的当地钟表表示。 */
+    localDateTime: string;
+    localTimezone: number;
+    /** 冬至所在当地公历日的子半，用作比例岁周起点。 */
+    dayStartDateTime: string;
+    dayStartUtcDateTime: string;
+    dayStartTimezone: number;
+    dayGanZhi: string;
+    dayIndex: number;
+    dayBoundary: '当地子半';
+  };
+  calendar: {
+    model: typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
+    mapping: 'winter-solstice-proportional-360';
+    winterSolsticeYear: number;
+    actualElapsedDays: number;
+    actualElapsedMilliseconds: number;
+    actualElapsedSeconds: number;
+    logicalPosition: number;
+    logicalElapsedDays: number;
+    logicalDayFraction: number;
+    /** 节气前尾段落在下一冬至当地日子半之后时，逻辑位置是否封顶于上一岁周末端。 */
+    endpointClamped: boolean;
+    coordinateSpanDays: 360;
+    yearLengthDays: number;
+    yearLengthMilliseconds: number;
+    yearLengthSeconds: number;
+    logicalDayLengthSeconds: number;
+    cycleDay: number;
+    cardinalSeason: '冬' | '春' | '夏' | '秋';
+    cardinalDay: number;
+  };
+}
+
+export type HuangjiSixDayDateResult =
+  | HuangjiSixDayExplicitDateResult
+  | HuangjiSixDayProportionalDateResult;
+
+const HUANGJI_SOLAR_TERM_TIMEZONE = 8;
 const HUANGJI_LOGICAL_DAYS = 360;
 const MILLISECONDS_PER_DAY = 86400000;
 
@@ -144,15 +220,15 @@ const HUANGJI_SIX_DAY_SOURCES = [
   },
   {
     title: '《皇极经世书绪言》卷八上',
-    scope: '以三百六十为正数、另列六日余分；公历入口只适配已给出的正数坐标。',
+    scope: '以三百六十为正数、另列六日余分；现代公历入口按所选模型表达正数与岁余关系。',
   },
   {
     title: '《皇极经世书解》卷十二',
-    scope: '说明余分六藏于六甲；公历入口不把未校定的余分暗化为整日坐标。',
+    scope: '说明余分六藏于六甲；现代比例入口不把余分暗化为固定整日闰位。',
   },
   {
     title: '《皇极经世观物外篇衍义》卷一',
-    scope: '三百六十正数与六日余分、六日七分的卦气换算说明；未据此推定现代公历历元。',
+    scope: '三百六十正数与六日余分、六日七分的卦气换算说明。',
   },
 ] as const;
 
@@ -269,12 +345,37 @@ function assertSixDayDateTimeZones(
   return inferredTimezone;
 }
 
+function assertSixDayTargetTimezone(
+  target: ParsedSixDayDateTime,
+  timezone: number | undefined,
+  timeZoneId: string | undefined,
+): number | undefined {
+  if (timezone !== undefined) assertFixedTimezoneHours(timezone, '六日逐爻公历时间的 timezone');
+  if (timeZoneId !== undefined && timezone === undefined) {
+    if (target.embeddedTimezone !== undefined) {
+      throw new Error('使用 timeZoneId 时，sixDayDateTime 不得内嵌固定时区偏移。');
+    }
+    return undefined;
+  }
+  const inferredTimezone = timezone ?? target.embeddedTimezone;
+  if (inferredTimezone === undefined) {
+    throw new Error('timezone 与 timeZoneId 至少需要提供一项。');
+  }
+  if (
+    target.embeddedTimezone !== undefined &&
+    target.embeddedTimezone !== inferredTimezone
+  ) {
+    throw new Error('六日逐爻公历时间内的时区偏移与 timezone 不一致。');
+  }
+  return inferredTimezone;
+}
+
 /**
  * 解析六日逐爻专用的当地公历时间。
  *
  * 这个入口不改变既有 customDate 的年月日时算法。时间字符串可以自带 ISO 偏移；
- * 未带偏移时必须同时提供 timezone 或 timeZoneId，避免按宿主机时区猜测。历元必须
- * 由调用者明确提供，并表示当地子半对应的 elapsedDays=0。
+ * 未带偏移时必须同时提供 timezone 或 timeZoneId，避免按宿主机时区猜测。显式历元模型
+ * 还需提供当地子半历元；现代比例模型以冬至岁周自动确定换算区间。
  */
 export function parseHuangjiSixDayDateTime(
   value: string,
@@ -283,13 +384,38 @@ export function parseHuangjiSixDayDateTime(
   calendarModel?: HuangjiSixDayCalendarModel,
   epochDateTime?: string,
 ): HuangjiSixDayDateInput {
-  if (calendarModel !== HUANGJI_SIX_DAY_CALENDAR_MODEL) {
-    throw new Error(`六日逐爻公历换算暂只支持${HUANGJI_SIX_DAY_CALENDAR_MODEL}模型。`);
+  if (
+    calendarModel !== HUANGJI_SIX_DAY_CALENDAR_MODEL &&
+    calendarModel !== HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL
+  ) {
+    throw new Error(
+      `六日逐爻公历换算暂只支持${HUANGJI_SIX_DAY_CALENDAR_MODEL}或${HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL}模型。`,
+    );
+  }
+  const target = parseSixDayDateTimeParts(value, '六日逐爻公历时间');
+  if (calendarModel === HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL) {
+    if (epochDateTime !== undefined) {
+      throw new Error(
+        'six-day-seven-part 现代比例模型不使用 sixDayEpochDateTime；需要显式历元时应选择 six-day-explicit-epoch。',
+      );
+    }
+    const inferredTimezone = assertSixDayTargetTimezone(target, timezone, timeZoneId);
+    return {
+      year: target.year,
+      month: target.month,
+      day: target.day,
+      hour: target.hour,
+      minute: target.minute,
+      second: target.second,
+      millisecond: target.millisecond,
+      ...(inferredTimezone !== undefined ? { timezone: inferredTimezone } : {}),
+      ...(timeZoneId !== undefined ? { timeZoneId } : {}),
+      calendarModel,
+    };
   }
   if (typeof epochDateTime !== 'string' || !epochDateTime.trim()) {
     throw new Error('六日逐爻公历时间必须同时提供经校定的 sixDayEpochDateTime。');
   }
-  const target = parseSixDayDateTimeParts(value, '六日逐爻公历时间');
   const epoch = parseSixDayDateTimeParts(epochDateTime, '六日逐爻显式历元');
   const inferredTimezone = assertSixDayDateTimeZones(target, epoch, timezone, timeZoneId);
   if (epoch.hour !== 0 || epoch.minute !== 0 || epoch.second !== 0 || epoch.millisecond !== 0) {
@@ -318,6 +444,119 @@ function formatLocalDateTime(
   return `${formatCivilDateTime(value)}${millisecond ? `.${String(millisecond).padStart(3, '0')}` : ''}${formatFixedTimezoneOffset(timezone)}`;
 }
 
+function getSolarTimeParts(solarTime: SolarTime): CivilDateTimeParts {
+  return {
+    year: solarTime.getYear(),
+    month: solarTime.getMonth(),
+    day: solarTime.getDay(),
+    hour: solarTime.getHour(),
+    minute: solarTime.getMinute(),
+    second: solarTime.getSecond(),
+  };
+}
+
+function resolveWinterSolstice(termYear: number) {
+  const term = SolarTerm.fromName(termYear, '冬至');
+  const solarTime = term.getJulianDay().getSolarTime();
+  const civilTime = getSolarTimeParts(solarTime);
+  const resolved = resolveCivilTime({ ...civilTime, timezone: HUANGJI_SOLAR_TERM_TIMEZONE });
+  return {
+    termYear,
+    civilTime,
+    utcTimestamp: resolved.utcTimestamp,
+    utcDateTime: resolved.utcDateTime,
+  };
+}
+
+function resolveWinterSolsticeDayStart(
+  term: ReturnType<typeof resolveWinterSolstice>,
+  target: ReturnType<typeof resolveCivilTime>,
+) {
+  const dayStartTimezone = target.timeZoneId
+    ? getHistoricalTimezoneOffsetAt(new Date(term.utcTimestamp), target.timeZoneId)
+    : target.timezone;
+  const localTermTime = getCivilDateTimeAtFixedOffset(
+    new Date(term.utcTimestamp),
+    dayStartTimezone,
+  );
+  const dayStart = resolveCivilTime({
+    year: localTermTime.year,
+    month: localTermTime.month,
+    day: localTermTime.day,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    ...(target.timeZoneId ? { timeZoneId: target.timeZoneId } : { timezone: dayStartTimezone }),
+  });
+  const dayGanZhi = SolarTime.fromYmdHms(
+    localTermTime.year,
+    localTermTime.month,
+    localTermTime.day,
+    0,
+    0,
+    0,
+  )
+    .getLunarHour()
+    .getEightChar()
+    .getDay()
+    .getName();
+  return {
+    ...term,
+    localTermTime,
+    localTermTimezone: dayStartTimezone,
+    dayStartCivilTime: dayStart.localTime,
+    dayStartUtcTimestamp: dayStart.utcTimestamp,
+    dayStartUtcDateTime: dayStart.utcDateTime,
+    dayStartTimezone: dayStart.timezone,
+    dayGanZhi,
+    dayIndex: getSixtyCycleIndex(dayGanZhi),
+  };
+}
+
+function resolveWinterSolsticeAnchor(
+  target: ReturnType<typeof resolveCivilTime>,
+  targetTimestamp: number,
+) {
+  const targetYear = target.localTime.year;
+  const candidates = [targetYear - 1, targetYear, targetYear + 1]
+    .map(resolveWinterSolstice)
+    .map((term) => resolveWinterSolsticeDayStart(term, target));
+  const anchor = candidates
+    .filter((candidate) => candidate.utcTimestamp <= targetTimestamp)
+    .sort((left, right) => right.utcTimestamp - left.utcTimestamp)[0];
+  if (!anchor) throw new Error('无法定位六日逐爻公历时间所属的冬至锚点。');
+  return anchor;
+}
+
+function mapSolarYearToLogicalDay(
+  actualElapsedMilliseconds: number,
+  yearLengthMilliseconds: number,
+) {
+  if (
+    !Number.isFinite(actualElapsedMilliseconds) ||
+    actualElapsedMilliseconds < 0 ||
+    !Number.isFinite(yearLengthMilliseconds) ||
+    yearLengthMilliseconds <= 0
+  ) {
+    throw new Error('六日逐爻公历时间不在冬至子半至下一冬至子半的单年范围内。');
+  }
+  // 冬至发生在当地日子半之后时，冬至当地日期的子半会先于真实节气。
+  // 该日期的节气前尾段仍归上一冬至岁周，逻辑位置在上一岁周末端封顶。
+  const boundedElapsedMilliseconds = Math.min(
+    actualElapsedMilliseconds,
+    yearLengthMilliseconds - 1,
+  );
+  const logicalPosition =
+    (boundedElapsedMilliseconds / yearLengthMilliseconds) * HUANGJI_LOGICAL_DAYS;
+  const logicalElapsedDays = Math.min(HUANGJI_LOGICAL_DAYS - 1, Math.floor(logicalPosition));
+  return {
+    logicalPosition,
+    logicalElapsedDays,
+    logicalDayFraction: logicalPosition - logicalElapsedDays,
+    endpointClamped: actualElapsedMilliseconds >= yearLengthMilliseconds,
+  };
+}
+
 function civilDayNumber(value: CivilDateTimeParts): number {
   return createUtcTimestamp(value.year, value.month - 1, value.day) / MILLISECONDS_PER_DAY;
 }
@@ -326,7 +565,10 @@ function calculateCivilDateDifference(start: CivilDateTimeParts, end: CivilDateT
   return civilDayNumber(end) - civilDayNumber(start);
 }
 
-function resolveExplicitEpoch(input: HuangjiSixDayDateInput, targetMillisecond: number) {
+function resolveExplicitEpoch(
+  input: HuangjiSixDayExplicitDateInput,
+  targetMillisecond: number,
+) {
   const epochParts = parseSixDayDateTimeParts(input.epochDateTime, '六日逐爻显式历元');
   if (
     input.timeZoneId !== undefined &&
@@ -388,16 +630,9 @@ function resolveExplicitEpoch(input: HuangjiSixDayDateInput, targetMillisecond: 
 }
 
 /** 从经校定历元与当地公历时间直接适配书绪言六日逐爻坐标。 */
-export function calculateHuangjiSixDayCycleFromDate(
-  input: HuangjiSixDayDateInput,
-): HuangjiSixDayDateResult {
-  if (!input || typeof input !== 'object') throw new Error('六日逐爻公历输入不能为空。');
-  if (input.calendarModel !== HUANGJI_SIX_DAY_CALENDAR_MODEL) {
-    throw new Error(`六日逐爻公历换算暂只支持${HUANGJI_SIX_DAY_CALENDAR_MODEL}模型。`);
-  }
-  if (typeof input.epochDateTime !== 'string' || !input.epochDateTime.trim()) {
-    throw new Error('六日逐爻公历时间必须同时提供经校定的 sixDayEpochDateTime。');
-  }
+function calculateHuangjiSixDayCycleFromExplicitDate(
+  input: HuangjiSixDayExplicitDateInput,
+): HuangjiSixDayExplicitDateResult {
   const millisecond = assertSixDayMillisecond(input.millisecond);
   const resolved = resolveExplicitEpoch(input, millisecond);
   const { target, epoch, targetTimestamp, epochTimestamp, actualElapsedDays } = resolved;
@@ -413,7 +648,7 @@ export function calculateHuangjiSixDayCycleFromDate(
     resolved.epochMillisecond,
     epoch.timezone,
   );
-  const calendar = {
+  const calendar: HuangjiSixDayExplicitDateResult['calendar'] = {
     model: HUANGJI_SIX_DAY_CALENDAR_MODEL,
     mapping: 'explicit-epoch-civil-days',
     targetYear: target.localTime.year,
@@ -423,7 +658,7 @@ export function calculateHuangjiSixDayCycleFromDate(
     logicalDayFraction: 0,
     coordinateSpanDays: HUANGJI_LOGICAL_DAYS,
     cycleDay: cycleElapsedDays + 1,
-  } as HuangjiSixDayDateResult['calendar'];
+  };
   return {
     ...cycle,
     model: '书绪言六日逐爻·显式历元',
@@ -458,6 +693,140 @@ export function calculateHuangjiSixDayCycleFromDate(
       '小时爻沿用当地子半起的四小时段；分钟、秒和毫秒保留在真实时刻资料中，不改变四小时段。',
     ],
   };
+}
+
+/**
+ * 以实际冬至岁周承载“六日七分”的现代公历比例换算。
+ *
+ * 节气瞬时用于决定所属冬至岁周；该冬至所在地点的当地公历日子半作为
+ * 现代换算起点，至下一冬至当地公历日子半的真实 UTC 间隔等分为360个逻辑日。
+ */
+function calculateHuangjiSixDayCycleFromProportionalDate(
+  input: HuangjiSixDayProportionalDateInput,
+): HuangjiSixDayProportionalDateResult {
+  const millisecond = assertSixDayMillisecond(input.millisecond);
+  const target = resolveCivilTime({
+    year: input.year,
+    month: input.month,
+    day: input.day,
+    hour: input.hour,
+    minute: input.minute,
+    second: input.second,
+    ...(input.timezone !== undefined ? { timezone: input.timezone } : {}),
+    ...(input.timeZoneId !== undefined ? { timeZoneId: input.timeZoneId } : {}),
+  });
+  const targetTimestamp = target.utcTimestamp + millisecond;
+  const anchor = resolveWinterSolsticeAnchor(target, targetTimestamp);
+  const nextAnchor = resolveWinterSolsticeDayStart(
+    resolveWinterSolstice(anchor.termYear + 1),
+    target,
+  );
+  const yearLengthMilliseconds = nextAnchor.dayStartUtcTimestamp - anchor.dayStartUtcTimestamp;
+  const actualElapsedMilliseconds = targetTimestamp - anchor.dayStartUtcTimestamp;
+  const actualElapsedDays = Math.floor(actualElapsedMilliseconds / MILLISECONDS_PER_DAY);
+  const actualElapsedSeconds = Math.floor(actualElapsedMilliseconds / 1000);
+  const mapped = mapSolarYearToLogicalDay(actualElapsedMilliseconds, yearLengthMilliseconds);
+  const cycleElapsedDays =
+    (anchor.dayIndex + mapped.logicalElapsedDays) % HUANGJI_LOGICAL_DAYS;
+  const cycle = calculateHuangjiSixDayCycle({
+    elapsedDays: cycleElapsedDays,
+    hour: target.localTime.hour,
+  });
+  const cardinalSeasons: Array<'冬' | '春' | '夏' | '秋'> = ['冬', '春', '夏', '秋'];
+  const cardinalIndex = Math.floor(mapped.logicalElapsedDays / 90);
+  const targetDateTime = formatLocalDateTime(target.localTime, millisecond, target.timezone);
+  const anchorDateTime = `${formatCivilDateTime(anchor.civilTime)}${formatFixedTimezoneOffset(HUANGJI_SOLAR_TERM_TIMEZONE)}`;
+  const anchorLocalDateTime = formatLocalDateTime(
+    anchor.localTermTime,
+    0,
+    anchor.localTermTimezone,
+  );
+  const anchorDayStartDateTime = formatLocalDateTime(
+    anchor.dayStartCivilTime,
+    0,
+    anchor.dayStartTimezone,
+  );
+  const calendar: HuangjiSixDayProportionalDateResult['calendar'] = {
+    model: HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL,
+    mapping: 'winter-solstice-proportional-360',
+    winterSolsticeYear: anchor.termYear,
+    actualElapsedDays,
+    actualElapsedMilliseconds,
+    actualElapsedSeconds,
+    logicalPosition: mapped.logicalPosition,
+    logicalElapsedDays: mapped.logicalElapsedDays,
+    logicalDayFraction: mapped.logicalDayFraction,
+    endpointClamped: mapped.endpointClamped,
+    coordinateSpanDays: HUANGJI_LOGICAL_DAYS,
+    yearLengthDays: yearLengthMilliseconds / MILLISECONDS_PER_DAY,
+    yearLengthMilliseconds,
+    yearLengthSeconds: yearLengthMilliseconds / 1000,
+    logicalDayLengthSeconds: yearLengthMilliseconds / 1000 / HUANGJI_LOGICAL_DAYS,
+    cycleDay: cycleElapsedDays + 1,
+    cardinalSeason: cardinalSeasons[Math.min(cardinalIndex, cardinalSeasons.length - 1)],
+    cardinalDay: (mapped.logicalElapsedDays % 90) + 1,
+  };
+  return {
+    ...cycle,
+    model: '书绪言六日逐爻·现代冬至岁周换算',
+    civilTime: {
+      dateTime: targetDateTime,
+      utcDateTime: new Date(targetTimestamp).toISOString(),
+      timezone: target.timezone,
+      ...(target.timeZoneId ? { timeZoneId: target.timeZoneId } : {}),
+      ...target.localTime,
+      millisecond,
+    },
+    anchor: {
+      kind: 'winter-solstice-civil-midnight',
+      term: '冬至',
+      winterSolsticeYear: anchor.termYear,
+      dateTime: anchorDateTime,
+      utcDateTime: anchor.utcDateTime,
+      timezone: HUANGJI_SOLAR_TERM_TIMEZONE,
+      localDateTime: anchorLocalDateTime,
+      localTimezone: anchor.localTermTimezone,
+      dayStartDateTime: anchorDayStartDateTime,
+      dayStartUtcDateTime: anchor.dayStartUtcDateTime,
+      dayStartTimezone: anchor.dayStartTimezone,
+      dayGanZhi: anchor.dayGanZhi,
+      dayIndex: anchor.dayIndex,
+      dayBoundary: '当地子半',
+    },
+    calendar,
+    calculationChain: [
+      `${targetDateTime}解析为 UTC${target.timezone >= 0 ? '+' : ''}${target.timezone} 的当地公历时刻，保留真实 UTC 瞬时点。`,
+      `以${anchorDateTime}的冬至天文时刻确定所属${anchor.termYear}冬至岁周；该瞬时在目标地点为${anchorLocalDateTime}。`,
+      `以冬至所在当地公历日${anchorDayStartDateTime}子半为起点，至下一冬至当地公历日子半的实际跨度为${(yearLengthMilliseconds / MILLISECONDS_PER_DAY).toFixed(6)}日（${yearLengthMilliseconds}毫秒），按三百六十逻辑日比例映射。`,
+      `目标距当地子半起点实际经过${actualElapsedSeconds}秒（${actualElapsedDays}个完整UTC日），逻辑位置为${mapped.logicalPosition.toFixed(9)}日，即第${mapped.logicalElapsedDays + 1}个逻辑日的${mapped.logicalDayFraction.toFixed(9)}。`,
+      `以冬至日子半的${anchor.dayGanZhi}（六十甲子序号${anchor.dayIndex}）接续六日逐爻周期，得到周期第${cycleElapsedDays + 1}日；每四小时取一爻，当前为${cycle.hourRange}。`,
+    ],
+    sources: HUANGJI_SIX_DAY_SOURCES.map((source) => ({ ...source })),
+    limitations: [
+      '原典给出冬至甲子日子半、六日逐爻和六日七分的传统条件，没有给出现代公历唯一对应的甲子历元；本结果是明确标注的现代比例换算，不宣称古籍唯一算法。',
+      '本模型以实际冬至瞬时确定所属冬至岁周，以该冬至所在当地公历日子半至下一冬至当地公历日子半的实测 UTC 间隔等分三百六十逻辑日；不同地点的民用日界和历史时区规则会改变子半锚点。',
+      '六日七分的传统余分有不同传承；本模型不把六个余分硬插为六个公历整日，也不以该比例换算替代既有年月日时十五日节气链。',
+      '若下一冬至发生在其当地公历日子半之后，该日期子半至真实节气前仍属上一岁周；因下一岁周的子半端点已先到，逻辑位置封顶在上一岁周最后一个逻辑日，并保留实际跨度字段。',
+      '小时爻沿用目标地点当地钟表从子半开始的四小时段；分钟、秒和毫秒保留在真实时刻资料中，不改变已取的四小时段。',
+      '节气时刻采用 tyme4ts 历表的 UTC+8 表达，实际精度受所用历表与 IANA 时区数据库版本边界影响。',
+    ],
+  };
+}
+
+/** 从带时区的真实公历时间定位六日逐爻坐标；两种模型共用此入口。 */
+export function calculateHuangjiSixDayCycleFromDate(
+  input: HuangjiSixDayDateInput,
+): HuangjiSixDayDateResult {
+  if (!input || typeof input !== 'object') throw new Error('六日逐爻公历输入不能为空。');
+  if (input.calendarModel === HUANGJI_SIX_DAY_CALENDAR_MODEL) {
+    return calculateHuangjiSixDayCycleFromExplicitDate(input);
+  }
+  if (input.calendarModel === HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL) {
+    return calculateHuangjiSixDayCycleFromProportionalDate(input);
+  }
+  throw new Error(
+    `六日逐爻公历换算暂只支持${HUANGJI_SIX_DAY_CALENDAR_MODEL}或${HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL}模型。`,
+  );
 }
 
 export interface HuangjiDateTimeForecast {

--- a/packages/core/src/huangji-jingshi/datetime.ts
+++ b/packages/core/src/huangji-jingshi/datetime.ts
@@ -94,8 +94,7 @@ export const HUANGJI_SIX_DAY_CALENDAR_MODEL = 'six-day-explicit-epoch' as const;
 /** 以冬至岁周实测跨度按三百六十逻辑日等分的现代比例换算模型。 */
 export const HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL = 'six-day-seven-part' as const;
 export type HuangjiSixDayCalendarModel =
-  | typeof HUANGJI_SIX_DAY_CALENDAR_MODEL
-  | typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
+  typeof HUANGJI_SIX_DAY_CALENDAR_MODEL | typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
 
 interface HuangjiSixDayDateInputBase extends CivilDateTimeParts, CivilTimeZoneInput {
   /** 可选毫秒；六日逐爻以秒作为传统时段的最小公开精度。 */
@@ -115,8 +114,7 @@ export interface HuangjiSixDayProportionalDateInput extends HuangjiSixDayDateInp
 }
 
 export type HuangjiSixDayDateInput =
-  | HuangjiSixDayExplicitDateInput
-  | HuangjiSixDayProportionalDateInput;
+  HuangjiSixDayExplicitDateInput | HuangjiSixDayProportionalDateInput;
 
 interface HuangjiSixDayDateResultBase extends HuangjiSixDayCycleResult {
   civilTime: {
@@ -165,8 +163,8 @@ export interface HuangjiSixDayProportionalDateResult extends HuangjiSixDayDateRe
   anchor: {
     kind: 'winter-solstice-civil-midnight';
     term: '冬至';
-    /** tyme4ts 的冬至年标识；例如 2026 指向公历 2025 年冬至。 */
-    winterSolsticeYear: number;
+    /** 冬至节气落在当地公历中的年份；所属皇极岁周见 calendar.targetYear。 */
+    winterSolsticeGregorianYear: number;
     /** 节气真实瞬时按现有节气口径以 UTC+8 回显。 */
     dateTime: string;
     utcDateTime: string;
@@ -185,7 +183,8 @@ export interface HuangjiSixDayProportionalDateResult extends HuangjiSixDayDateRe
   calendar: {
     model: typeof HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL;
     mapping: 'winter-solstice-proportional-360';
-    winterSolsticeYear: number;
+    /** 所属皇极岁周，沿用 tyme4ts 的冬至 termYear 语义；例如公历2025冬至为2026。 */
+    targetYear: number;
     actualElapsedDays: number;
     actualElapsedMilliseconds: number;
     actualElapsedSeconds: number;
@@ -206,8 +205,7 @@ export interface HuangjiSixDayProportionalDateResult extends HuangjiSixDayDateRe
 }
 
 export type HuangjiSixDayDateResult =
-  | HuangjiSixDayExplicitDateResult
-  | HuangjiSixDayProportionalDateResult;
+  HuangjiSixDayExplicitDateResult | HuangjiSixDayProportionalDateResult;
 
 const HUANGJI_SOLAR_TERM_TIMEZONE = 8;
 const HUANGJI_LOGICAL_DAYS = 360;
@@ -361,10 +359,7 @@ function assertSixDayTargetTimezone(
   if (inferredTimezone === undefined) {
     throw new Error('timezone 与 timeZoneId 至少需要提供一项。');
   }
-  if (
-    target.embeddedTimezone !== undefined &&
-    target.embeddedTimezone !== inferredTimezone
-  ) {
+  if (target.embeddedTimezone !== undefined && target.embeddedTimezone !== inferredTimezone) {
     throw new Error('六日逐爻公历时间内的时区偏移与 timezone 不一致。');
   }
   return inferredTimezone;
@@ -444,7 +439,7 @@ function formatLocalDateTime(
   return `${formatCivilDateTime(value)}${millisecond ? `.${String(millisecond).padStart(3, '0')}` : ''}${formatFixedTimezoneOffset(timezone)}`;
 }
 
-function getSolarTimeParts(solarTime: SolarTime): CivilDateTimeParts {
+function getSolarTimeParts(solarTime: ReturnType<typeof SolarTime.fromYmdHms>): CivilDateTimeParts {
   return {
     year: solarTime.getYear(),
     month: solarTime.getMonth(),
@@ -565,10 +560,7 @@ function calculateCivilDateDifference(start: CivilDateTimeParts, end: CivilDateT
   return civilDayNumber(end) - civilDayNumber(start);
 }
 
-function resolveExplicitEpoch(
-  input: HuangjiSixDayExplicitDateInput,
-  targetMillisecond: number,
-) {
+function resolveExplicitEpoch(input: HuangjiSixDayExplicitDateInput, targetMillisecond: number) {
   const epochParts = parseSixDayDateTimeParts(input.epochDateTime, '六日逐爻显式历元');
   if (
     input.timeZoneId !== undefined &&
@@ -726,8 +718,7 @@ function calculateHuangjiSixDayCycleFromProportionalDate(
   const actualElapsedDays = Math.floor(actualElapsedMilliseconds / MILLISECONDS_PER_DAY);
   const actualElapsedSeconds = Math.floor(actualElapsedMilliseconds / 1000);
   const mapped = mapSolarYearToLogicalDay(actualElapsedMilliseconds, yearLengthMilliseconds);
-  const cycleElapsedDays =
-    (anchor.dayIndex + mapped.logicalElapsedDays) % HUANGJI_LOGICAL_DAYS;
+  const cycleElapsedDays = (anchor.dayIndex + mapped.logicalElapsedDays) % HUANGJI_LOGICAL_DAYS;
   const cycle = calculateHuangjiSixDayCycle({
     elapsedDays: cycleElapsedDays,
     hour: target.localTime.hour,
@@ -749,7 +740,7 @@ function calculateHuangjiSixDayCycleFromProportionalDate(
   const calendar: HuangjiSixDayProportionalDateResult['calendar'] = {
     model: HUANGJI_SIX_DAY_PROPORTIONAL_CALENDAR_MODEL,
     mapping: 'winter-solstice-proportional-360',
-    winterSolsticeYear: anchor.termYear,
+    targetYear: anchor.termYear,
     actualElapsedDays,
     actualElapsedMilliseconds,
     actualElapsedSeconds,
@@ -780,7 +771,7 @@ function calculateHuangjiSixDayCycleFromProportionalDate(
     anchor: {
       kind: 'winter-solstice-civil-midnight',
       term: '冬至',
-      winterSolsticeYear: anchor.termYear,
+      winterSolsticeGregorianYear: anchor.civilTime.year,
       dateTime: anchorDateTime,
       utcDateTime: anchor.utcDateTime,
       timezone: HUANGJI_SOLAR_TERM_TIMEZONE,
@@ -803,7 +794,7 @@ function calculateHuangjiSixDayCycleFromProportionalDate(
     ],
     sources: HUANGJI_SIX_DAY_SOURCES.map((source) => ({ ...source })),
     limitations: [
-      '原典给出冬至甲子日子半、六日逐爻和六日七分的传统条件，没有给出现代公历唯一对应的甲子历元；本结果是明确标注的现代比例换算，不宣称古籍唯一算法。',
+      '原典给出冬至甲子日子半、六日逐爻和六日七分的传统条件，没有给出现代公历唯一对应的甲子历元；本结果是明确标注的现代比例换算，不宣称是古籍唯一算法。',
       '本模型以实际冬至瞬时确定所属冬至岁周，以该冬至所在当地公历日子半至下一冬至当地公历日子半的实测 UTC 间隔等分三百六十逻辑日；不同地点的民用日界和历史时区规则会改变子半锚点。',
       '六日七分的传统余分有不同传承；本模型不把六个余分硬插为六个公历整日，也不以该比例换算替代既有年月日时十五日节气链。',
       '若下一冬至发生在其当地公历日子半之后，该日期子半至真实节气前仍属上一岁周；因下一岁周的子半端点已先到，逻辑位置封顶在上一岁周最后一个逻辑日，并保留实际跨度字段。',

--- a/packages/core/src/huangji-jingshi/index.ts
+++ b/packages/core/src/huangji-jingshi/index.ts
@@ -301,6 +301,23 @@ export function buildHuangjiJingshiPrompt(
         : sixDayCycle
           ? `请解读${sixDayCycle.civilTime.dateTime}这一时点的六日逐爻时势与主要变化。`
           : `请解读${input.year}年的整体趋势与主要变化。`);
+    const sixDayDateTimeLines = sixDayCycle
+      ? sixDayCycle.model === '书绪言六日逐爻·显式历元'
+        ? [
+            `六日逐爻公历时间：${sixDayCycle.civilTime.dateTime}（UTC${sixDayCycle.civilTime.timezone >= 0 ? '+' : ''}${sixDayCycle.civilTime.timezone}${sixDayCycle.civilTime.timeZoneId ? `，${sixDayCycle.civilTime.timeZoneId}` : ''}）`,
+            `显式历元：${sixDayCycle.anchor.dateTime}（UTC${sixDayCycle.anchor.timezone >= 0 ? '+' : ''}${sixDayCycle.anchor.timezone}，真实瞬时${sixDayCycle.anchor.utcDateTime}）为经校定的当地子半起点，对应六日逐爻已过日数0、子半时刻。`,
+            `六日逐爻坐标：从显式历元至目标当地日期经过${sixDayCycle.calendar.actualElapsedDays}个完整公历日，直接取得三百六十日正数中的第${sixDayCycle.dayOfCycle}日；实际 UTC 瞬时相隔${sixDayCycle.calendar.actualElapsedSeconds}秒。`,
+            `经卦${sixDayCycle.hexagrams.jing.name}第${sixDayCycle.dayLine}爻当日，日变卦${sixDayCycle.hexagrams.daily.name}，${sixDayCycle.hourRange}时变卦${sixDayCycle.hexagrams.hourly.name}。`,
+            `时段依据：当地公历子半起，钟表${sixDayCycle.civilTime.hour}时处于${sixDayCycle.hourRange}，每四小时一爻。`,
+          ]
+        : [
+            `六日逐爻公历时间：${sixDayCycle.civilTime.dateTime}（UTC${sixDayCycle.civilTime.timezone >= 0 ? '+' : ''}${sixDayCycle.civilTime.timezone}${sixDayCycle.civilTime.timeZoneId ? `，${sixDayCycle.civilTime.timeZoneId}` : ''}）`,
+            `现代冬至岁周换算模型：以${sixDayCycle.anchor.dateTime}的冬至真实瞬时确定${sixDayCycle.anchor.winterSolsticeYear}岁周；该瞬时在目标地点为${sixDayCycle.anchor.localDateTime}。`,
+            `当地子半锚点：${sixDayCycle.anchor.dayStartDateTime}（真实瞬时${sixDayCycle.anchor.dayStartUtcDateTime}），以冬至子半至下一冬至子半的实际跨度按三百六十逻辑日比例映射。`,
+            `实际跨度：已经过${sixDayCycle.calendar.actualElapsedSeconds}秒（${sixDayCycle.calendar.actualElapsedDays}个完整日），逻辑位置${sixDayCycle.calendar.logicalPosition.toFixed(9)}日，即第${sixDayCycle.calendar.logicalElapsedDays + 1}个逻辑日的${sixDayCycle.calendar.logicalDayFraction.toFixed(9)}。`,
+            `冬至日子半干支：${sixDayCycle.anchor.dayGanZhi}（六十甲子序号${sixDayCycle.anchor.dayIndex}）；经卦${sixDayCycle.hexagrams.jing.name}第${sixDayCycle.dayLine}爻当日，${sixDayCycle.hourRange}时变卦${sixDayCycle.hexagrams.hourly.name}，每四小时一爻。`,
+          ]
+      : [];
     const dateTimeLines = dateTimeForecast
       ? [
           `起盘时间：${dateTimeForecast.civilTime.dateTime}（${dateTimeForecast.civilTime.timezone}）`,
@@ -318,16 +335,12 @@ export function buildHuangjiJingshiPrompt(
           `时经卦卦辞：${dateTimeForecast.hexagrams.hourJing.judgment}`,
         ]
       : sixDayCycle
-        ? [
-            `六日逐爻公历时间：${sixDayCycle.civilTime.dateTime}（UTC${sixDayCycle.civilTime.timezone >= 0 ? '+' : ''}${sixDayCycle.civilTime.timezone}${sixDayCycle.civilTime.timeZoneId ? `，${sixDayCycle.civilTime.timeZoneId}` : ''}）`,
-            `显式历元：${sixDayCycle.anchor.dateTime}（UTC${sixDayCycle.anchor.timezone >= 0 ? '+' : ''}${sixDayCycle.anchor.timezone}，真实瞬时${sixDayCycle.anchor.utcDateTime}）为经校定的当地子半起点，对应六日逐爻已过日数0、子半时刻。`,
-            `六日逐爻坐标：从显式历元至目标当地日期经过${sixDayCycle.calendar.actualElapsedDays}个完整公历日，直接取得三百六十日正数中的第${sixDayCycle.dayOfCycle}日；实际 UTC 瞬时相隔${sixDayCycle.calendar.actualElapsedSeconds}秒。`,
-            `经卦${sixDayCycle.hexagrams.jing.name}第${sixDayCycle.dayLine}爻当日，日变卦${sixDayCycle.hexagrams.daily.name}，${sixDayCycle.hourRange}时变卦${sixDayCycle.hexagrams.hourly.name}。`,
-            `时段依据：当地公历子半起，钟表${sixDayCycle.civilTime.hour}时处于${sixDayCycle.hourRange}，每四小时一爻。`,
-          ]
+        ? sixDayDateTimeLines
         : [];
     const dateTimeBasis = sixDayCycle
-      ? '具体时点以真实带时区公历时间与经校定的当地子半历元适配六日逐爻坐标；传统依据为每卦六日七分与每四小时一爻，公历日期差直接对应三百六十日正数中的已过日数，再依每六日一经卦、每日一爻、每四小时一爻取象。'
+      ? sixDayCycle.model === '书绪言六日逐爻·显式历元'
+        ? '具体时点以真实带时区公历时间与经校定的当地子半历元适配六日逐爻坐标；传统依据为每卦六日七分与每四小时一爻，公历日期差直接对应三百六十日正数中的已过日数，再依每六日一经卦、每日一爻、每四小时一爻取象。'
+        : '具体时点采用明确标注的现代冬至岁周比例换算：以实际冬至瞬时确定所属岁周，以冬至所在当地公历日子半至下一冬至当地公历日子半的实际跨度映射三百六十逻辑日；传统取象仍沿用每六日一经卦、每日一爻、每四小时一爻。该现代比例口径不宣称是古籍唯一算法。'
       : dateTimeForecast
         ? '具体时点以冬至换年，每个节气按十五个皇极日定位，超过十五日的尾段归第十五日；值年卦每六十日变一爻得月经卦，月经卦每十日变一爻得旬纬卦，日卦从月经卦依六十卦序逐日顺行，日卦自子半起每四小时变一爻得时经卦。'
         : '';
@@ -482,7 +495,13 @@ export function calculateHuangjiJingshi(input: HuangjiJingshiInput): HuangjiJing
     dateTimeForecast
       ? { year: dateTimeForecast.calendar.forecastYear, question: input.question }
       : sixDayCycle
-        ? { year: sixDayCycle.calendar.targetYear, question: input.question }
+        ? {
+            year:
+              sixDayCycle.model === '书绪言六日逐爻·显式历元'
+                ? sixDayCycle.calendar.targetYear
+                : sixDayCycle.calendar.winterSolsticeYear,
+            question: input.question,
+          }
         : input,
   );
   const elapsed = normalized.elapsedYears;

--- a/packages/core/src/huangji-jingshi/index.ts
+++ b/packages/core/src/huangji-jingshi/index.ts
@@ -312,7 +312,7 @@ export function buildHuangjiJingshiPrompt(
           ]
         : [
             `六日逐爻公历时间：${sixDayCycle.civilTime.dateTime}（UTC${sixDayCycle.civilTime.timezone >= 0 ? '+' : ''}${sixDayCycle.civilTime.timezone}${sixDayCycle.civilTime.timeZoneId ? `，${sixDayCycle.civilTime.timeZoneId}` : ''}）`,
-            `现代冬至岁周换算模型：以${sixDayCycle.anchor.dateTime}的冬至真实瞬时确定${sixDayCycle.anchor.winterSolsticeYear}岁周；该瞬时在目标地点为${sixDayCycle.anchor.localDateTime}。`,
+            `现代冬至岁周换算模型：以${sixDayCycle.anchor.dateTime}的冬至真实瞬时确定${sixDayCycle.calendar.targetYear}岁周；该冬至落在公历${sixDayCycle.anchor.winterSolsticeGregorianYear}年，该瞬时在目标地点为${sixDayCycle.anchor.localDateTime}。`,
             `当地子半锚点：${sixDayCycle.anchor.dayStartDateTime}（真实瞬时${sixDayCycle.anchor.dayStartUtcDateTime}），以冬至子半至下一冬至子半的实际跨度按三百六十逻辑日比例映射。`,
             `实际跨度：已经过${sixDayCycle.calendar.actualElapsedSeconds}秒（${sixDayCycle.calendar.actualElapsedDays}个完整日），逻辑位置${sixDayCycle.calendar.logicalPosition.toFixed(9)}日，即第${sixDayCycle.calendar.logicalElapsedDays + 1}个逻辑日的${sixDayCycle.calendar.logicalDayFraction.toFixed(9)}。`,
             `冬至日子半干支：${sixDayCycle.anchor.dayGanZhi}（六十甲子序号${sixDayCycle.anchor.dayIndex}）；经卦${sixDayCycle.hexagrams.jing.name}第${sixDayCycle.dayLine}爻当日，${sixDayCycle.hourRange}时变卦${sixDayCycle.hexagrams.hourly.name}，每四小时一爻。`,
@@ -499,7 +499,7 @@ export function calculateHuangjiJingshi(input: HuangjiJingshiInput): HuangjiJing
             year:
               sixDayCycle.model === '书绪言六日逐爻·显式历元'
                 ? sixDayCycle.calendar.targetYear
-                : sixDayCycle.calendar.winterSolsticeYear,
+                : sixDayCycle.calendar.targetYear,
             question: input.question,
           }
         : input,

--- a/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
+++ b/public/skills/aov-mingyu-api/references/providers/aov-mingyu.md
@@ -182,7 +182,7 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
   `jinkoujueMethod` 支持 `time`（时间）、`branch`（直接指定地分）、`number`（数字）、`random`（随机）。采用 `branch` 方式必须传 `jinkoujueBranch`，取子至亥之一；指定地分后仍按起课时间计算月将与日干。
 - **五运六气与皇极经世输入口径规范**：
   - 五运六气使用 `year` 或 `yearGanZhi`；同时提供时会校验两者一致。`year` 按该公历年年中所属年柱换算。结果包含天符、岁会、太乙天符、同天符、同岁会逐项核验；吴谦《运气要诀》列出的五类符会逐年名单按六十甲子去重为 26 年，与原文“二十八年”汇总不一致；接口保留 `sourceReconciliation` 校勘说明，并以逐项定义为准。
-  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘；六日逐爻公历入口另须提供经校定的 `sixDayEpochDateTime`（当地子半）与 `calendarModel=six-day-explicit-epoch`，按显式历元至目标当地日期的整数日差适配三百六十日正数，余分不自动换算。
+  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘。六日逐爻公历入口支持两种模型：`calendarModel=six-day-seven-part` 只需 `sixDayDateTime`，以现代冬至起点和实际岁周长度的比例定位六日七分；`calendarModel=six-day-explicit-epoch` 则必须另传经校定的 `sixDayEpochDateTime`（当地子半），按显式历元至目标当地日期的整数日差适配三百六十日正数。两种模型均须由时间字符串自带固定 UTC 偏移，或在未带偏移时提供 `timezone`/`timeZoneId`；响应保留模型来源、适用边界和传统六日七分依据，不能把现代比例定位解释为原典指定的唯一公历历元。
   - 年度研究提供公元 `year`，默认采用公元前 67017 年为本元起点、1984 年鼎卦为甲子值年锚点的通行排法，包含值年卦及互卦错卦综卦。
   - 研究自定义纪元时提供 `epochYear`，并从公元 `year` 与 `elapsedYears` 中选择一项；该模式保留纯元会运世坐标换算。
 

--- a/public/skills/mingyu/references/providers/aov-mingyu.md
+++ b/public/skills/mingyu/references/providers/aov-mingyu.md
@@ -182,7 +182,7 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
   `jinkoujueMethod` 支持 `time`（时间）、`branch`（直接指定地分）、`number`（数字）、`random`（随机）。采用 `branch` 方式必须传 `jinkoujueBranch`，取子至亥之一；指定地分后仍按起课时间计算月将与日干。
 - **五运六气与皇极经世输入口径规范**：
   - 五运六气使用 `year` 或 `yearGanZhi`；同时提供时会校验两者一致。`year` 按该公历年年中所属年柱换算。结果包含天符、岁会、太乙天符、同天符、同岁会逐项核验；吴谦《运气要诀》列出的五类符会逐年名单按六十甲子去重为 26 年，与原文“二十八年”汇总不一致；接口保留 `sourceReconciliation` 校勘说明，并以逐项定义为准。
-  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘；六日逐爻公历入口另须提供经校定的 `sixDayEpochDateTime`（当地子半）与 `calendarModel=six-day-explicit-epoch`，按显式历元至目标当地日期的整数日差适配三百六十日正数，余分不自动换算。
+  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘。六日逐爻公历入口支持两种模型：`calendarModel=six-day-seven-part` 只需 `sixDayDateTime`，以现代冬至起点和实际岁周长度的比例定位六日七分；`calendarModel=six-day-explicit-epoch` 则必须另传经校定的 `sixDayEpochDateTime`（当地子半），按显式历元至目标当地日期的整数日差适配三百六十日正数。两种模型均须由时间字符串自带固定 UTC 偏移，或在未带偏移时提供 `timezone`/`timeZoneId`；响应保留模型来源、适用边界和传统六日七分依据，不能把现代比例定位解释为原典指定的唯一公历历元。
   - 年度研究提供公元 `year`，默认采用公元前 67017 年为本元起点、1984 年鼎卦为甲子值年锚点的通行排法，包含值年卦及互卦错卦综卦。
   - 研究自定义纪元时提供 `epochYear`，并从公元 `year` 与 `elapsedYears` 中选择一项；该模式保留纯元会运世坐标换算。
 

--- a/skills/mingyu/references/providers/aov-mingyu.md
+++ b/skills/mingyu/references/providers/aov-mingyu.md
@@ -182,7 +182,7 @@ curl -X POST https://aov.cc/api/v1/calendar/true-solar-birth \
   `jinkoujueMethod` 支持 `time`（时间）、`branch`（直接指定地分）、`number`（数字）、`random`（随机）。采用 `branch` 方式必须传 `jinkoujueBranch`，取子至亥之一；指定地分后仍按起课时间计算月将与日干。
 - **五运六气与皇极经世输入口径规范**：
   - 五运六气使用 `year` 或 `yearGanZhi`；同时提供时会校验两者一致。`year` 按该公历年年中所属年柱换算。结果包含天符、岁会、太乙天符、同天符、同岁会逐项核验；吴谦《运气要诀》列出的五类符会逐年名单按六十甲子去重为 26 年，与原文“二十八年”汇总不一致；接口保留 `sourceReconciliation` 校勘说明，并以逐项定义为准。
-  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘；六日逐爻公历入口另须提供经校定的 `sixDayEpochDateTime`（当地子半）与 `calendarModel=six-day-explicit-epoch`，按显式历元至目标当地日期的整数日差适配三百六十日正数，余分不自动换算。
+  - 皇极经世提供 `customDate` 时，以北京时间和冬至换年定位皇极年，并在元会运世和值年卦之下继续推演月经卦、旬纬卦、日卦及时经卦，即 `customDate` 对应年月日时完整排盘。六日逐爻公历入口支持两种模型：`calendarModel=six-day-seven-part` 只需 `sixDayDateTime`，以现代冬至起点和实际岁周长度的比例定位六日七分；`calendarModel=six-day-explicit-epoch` 则必须另传经校定的 `sixDayEpochDateTime`（当地子半），按显式历元至目标当地日期的整数日差适配三百六十日正数。两种模型均须由时间字符串自带固定 UTC 偏移，或在未带偏移时提供 `timezone`/`timeZoneId`；响应保留模型来源、适用边界和传统六日七分依据，不能把现代比例定位解释为原典指定的唯一公历历元。
   - 年度研究提供公元 `year`，默认采用公元前 67017 年为本元起点、1984 年鼎卦为甲子值年锚点的通行排法，包含值年卦及互卦错卦综卦。
   - 研究自定义纪元时提供 `epochYear`，并从公元 `year` 与 `elapsedYears` 中选择一项；该模式保留纯元会运世坐标换算。
 

--- a/src/components/DivinationPanel/DivinationForm.tsx
+++ b/src/components/DivinationPanel/DivinationForm.tsx
@@ -50,7 +50,20 @@ const DIVINATION_TIME_STANDARD_OPTIONS = [
 
 const HUANGJI_METHOD_OPTIONS = [
   { value: 'standard', label: '年月日时' },
-  { value: 'six-day', label: '六日逐爻（校定历元）' },
+  { value: 'six-day', label: '六日逐爻' },
+] as const;
+
+const HUANGJI_SIX_DAY_MODEL_OPTIONS = [
+  {
+    value: 'six-day-seven-part',
+    label: '冬至岁周换算（现代）',
+    triggerLabel: '现代换算',
+  },
+  {
+    value: 'six-day-explicit-epoch',
+    label: '显式校定历元',
+    triggerLabel: '显式历元',
+  },
 ] as const;
 
 const JINKOUJUE_BRANCH_OPTIONS = [
@@ -318,6 +331,9 @@ export function DivinationForm({
   const isTimeBasedDivination = isTimeBasedDivinationDraft(draft);
   const huangjiMethod = draft.huangjiMethod ?? 'standard';
   const isHuangjiSixDay = draft.method === 'huangji' && huangjiMethod === 'six-day';
+  const huangjiSixDayCalendarModel = draft.huangjiSixDayCalendarModel ?? 'six-day-seven-part';
+  const isHuangjiSixDayExplicitEpoch =
+    isHuangjiSixDay && huangjiSixDayCalendarModel === 'six-day-explicit-epoch';
   const supportsTrueSolarTime =
     isTimeBasedDivination &&
     !isHuangjiSixDay &&
@@ -473,6 +489,12 @@ export function DivinationForm({
   function updateHuangjiMethod(value: NonNullable<DivinationDraft['huangjiMethod']>) {
     updateDraft('huangjiMethod', value);
     if (value === 'six-day') updateDraft('divinationTimeMode', 'custom');
+  }
+
+  function updateHuangjiSixDayCalendarModel(
+    value: NonNullable<DivinationDraft['huangjiSixDayCalendarModel']>,
+  ) {
+    updateDraft('huangjiSixDayCalendarModel', value);
   }
 
   if (isAlmanac) {
@@ -641,6 +663,25 @@ export function DivinationForm({
                             onChange={(value) =>
                               updateHuangjiMethod(
                                 value as NonNullable<DivinationDraft['huangjiMethod']>,
+                              )
+                            }
+                          />
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {isHuangjiSixDay ? (
+                      <div className="form-item divination-inline-field divination-huangji-model-field">
+                        <label htmlFor="huangji-six-day-model-select">换算模型</label>
+                        <div className="divination-select-shell divination-desktop-select-shell">
+                          <DropdownSelect
+                            id="huangji-six-day-model-select"
+                            value={huangjiSixDayCalendarModel}
+                            options={HUANGJI_SIX_DAY_MODEL_OPTIONS}
+                            ariaLabel="六日逐爻换算模型"
+                            onChange={(value) =>
+                              updateHuangjiSixDayCalendarModel(
+                                value as NonNullable<DivinationDraft['huangjiSixDayCalendarModel']>,
                               )
                             }
                           />
@@ -1069,6 +1110,21 @@ export function DivinationForm({
                       ariaLabel="皇极起盘方式"
                       onChange={(value) =>
                         updateHuangjiMethod(value as NonNullable<DivinationDraft['huangjiMethod']>)
+                      }
+                    />
+                  </div>
+                ) : null}
+
+                {isHuangjiSixDay ? (
+                  <div className="divination-mobile-secondary-picker divination-huangji-model-picker">
+                    <DropdownSelect
+                      value={huangjiSixDayCalendarModel}
+                      options={HUANGJI_SIX_DAY_MODEL_OPTIONS}
+                      ariaLabel="六日逐爻换算模型"
+                      onChange={(value) =>
+                        updateHuangjiSixDayCalendarModel(
+                          value as NonNullable<DivinationDraft['huangjiSixDayCalendarModel']>,
+                        )
                       }
                     />
                   </div>
@@ -1742,7 +1798,7 @@ export function DivinationForm({
               </div>
             ) : (
               <div className="divination-extra-panel divination-time-panel">
-                <div className="form-row-flex">
+                <div className={`form-row-flex ${isHuangjiSixDay ? 'has-third-item' : ''}`}>
                   <div className="form-item">
                     <label htmlFor="custom-divination-date-input">
                       {isHuangjiSixDay ? '目标日期' : `${timeActionLabel}日期`}
@@ -1769,8 +1825,26 @@ export function DivinationForm({
                       onChange={(event) => updateDraft('customDivinationTime', event.target.value)}
                     />
                   </div>
+                  {isHuangjiSixDay ? (
+                    <div className="form-item">
+                      <label htmlFor="huangji-six-day-timezone-input">时区（UTC偏移）</label>
+                      <input
+                        id="huangji-six-day-timezone-input"
+                        type="number"
+                        min="-12"
+                        max="14"
+                        step="any"
+                        inputMode="decimal"
+                        className="form-input"
+                        value={draft.huangjiSixDayTimezone ?? ''}
+                        onChange={(event) =>
+                          updateDraft('huangjiSixDayTimezone', event.target.value)
+                        }
+                      />
+                    </div>
+                  ) : null}
                 </div>
-                {isHuangjiSixDay ? (
+                {isHuangjiSixDayExplicitEpoch ? (
                   <>
                     <div className="form-row-flex">
                       <div className="form-item">
@@ -1787,27 +1861,15 @@ export function DivinationForm({
                           }
                         />
                       </div>
-                      <div className="form-item">
-                        <label htmlFor="huangji-six-day-timezone-input">时区（UTC偏移）</label>
-                        <input
-                          id="huangji-six-day-timezone-input"
-                          type="number"
-                          min="-12"
-                          max="14"
-                          step="any"
-                          inputMode="decimal"
-                          className="form-input"
-                          value={draft.huangjiSixDayTimezone ?? ''}
-                          onChange={(event) =>
-                            updateDraft('huangjiSixDayTimezone', event.target.value)
-                          }
-                        />
-                      </div>
                     </div>
                     <small className="workspace-ui-field-hint">
-                      填写已校定的历元日期，其当地00:00作为六日逐爻起点。目标时间和历元使用同一时区。
+                      填写当地子半作为第1日，目标时间和历元使用同一时区。
                     </small>
                   </>
+                ) : isHuangjiSixDay ? (
+                  <small className="workspace-ui-field-hint">
+                    默认按现代冬至和实际岁周比例换算；结果会标明“现代换算”。
+                  </small>
                 ) : null}
               </div>
             )

--- a/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
+++ b/src/components/DivinationPanel/TraditionalDivinationBoard.tsx
@@ -3138,6 +3138,8 @@ function HuangjiTraditionalBoard({
   if (!forecast) return null;
   const dateTimeForecast = data.dateTimeForecast;
   const sixDayCycle = data.sixDayCycle;
+  const sixDayUsesExplicitEpoch = sixDayCycle?.calendar.model === 'six-day-explicit-epoch';
+  const sixDayModelLabel = sixDayUsesExplicitEpoch ? '显式校定历元' : '冬至岁周换算（现代）';
 
   const { governing, yun, sixtyYear, decade, annual } = forecast.hexagrams;
   const related = [
@@ -3240,7 +3242,8 @@ function HuangjiTraditionalBoard({
           <TraditionalMeta
             items={[
               ['六日目标时间', sixDayCycle.civilTime.dateTime],
-              ['校定历元', sixDayCycle.anchor.dateTime],
+              [sixDayUsesExplicitEpoch ? '校定历元' : '现代冬至定位', sixDayCycle.anchor.dateTime],
+              ['换算模型', sixDayModelLabel],
               [
                 '时区',
                 `UTC${sixDayCycle.civilTime.timezone >= 0 ? '+' : ''}${sixDayCycle.civilTime.timezone}`,
@@ -3253,11 +3256,22 @@ function HuangjiTraditionalBoard({
                 '六日坐标',
                 `第${sixDayCycle.dayOfCycle}日（已过${sixDayCycle.calendar.actualElapsedDays}日）`,
               ],
+              [
+                '换算说明',
+                sixDayUsesExplicitEpoch
+                  ? '按校定历元后的当地公历日定位'
+                  : '按现代冬至与实际岁周比例定位',
+              ],
               ['经卦', `${sixDayCycle.hexagrams.jing.name} · 第${sixDayCycle.dayLine}爻`],
               ['当日变卦', sixDayCycle.hexagrams.daily.name],
               ['时变卦', `${sixDayCycle.hexagrams.hourly.name}（${sixDayCycle.hourRange}）`],
               ['实际时刻相隔', `${sixDayCycle.calendar.actualElapsedSeconds}秒`],
-              ['有效坐标范围', '显式历元后第0至359个当地公历日'],
+              [
+                '有效坐标范围',
+                sixDayUsesExplicitEpoch
+                  ? '显式历元后第0至359个当地公历日'
+                  : '现代冬至至下一冬至映射360个逻辑日',
+              ],
             ]}
           />
           <div

--- a/src/components/DivinationPanel/constants.ts
+++ b/src/components/DivinationPanel/constants.ts
@@ -29,6 +29,7 @@ export const defaultDraft: DivinationDraft = {
   customDivinationTime: '',
   divinationTimeStandard: 'beijing',
   huangjiMethod: 'standard',
+  huangjiSixDayCalendarModel: 'six-day-seven-part',
   huangjiSixDayEpochDate: '',
   huangjiSixDayTimezone: '8',
   birthPlace: '',

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -1234,22 +1234,33 @@ function assertHuangjiResult(
     const expectedTimezone = locked.timezone ?? calculationInput.timezone;
     if (
       typeof calculationInput.sixDayDateTime !== 'string' ||
-      typeof expectedEpoch !== 'string' ||
       typeof expectedModel !== 'string' ||
       typeof expectedTimezone !== 'number'
     ) {
-      throw new Error('皇极六日逐爻补算缺少目标、历元、模型或业务时区。');
+      throw new Error('皇极六日逐爻补算缺少目标、模型或业务时区。');
     }
     assertStructuredField(
       'huangji.sixDayCycle.civilTime.dateTime',
       normalizeDateTimeKey(calculationInput.sixDayDateTime),
       normalizeDateTimeKey(cycle.civilTime.dateTime),
     );
-    assertStructuredField(
-      'huangji.sixDayCycle.anchor.dateTime',
-      normalizeDateTimeKey(expectedEpoch),
-      normalizeDateTimeKey(cycle.anchor.dateTime),
-    );
+    if (expectedModel === 'six-day-explicit-epoch') {
+      if (typeof expectedEpoch !== 'string') {
+        throw new Error('皇极六日逐爻显式历元补算缺少历元。');
+      }
+      assertStructuredField(
+        'huangji.sixDayCycle.anchor.dateTime',
+        normalizeDateTimeKey(expectedEpoch),
+        normalizeDateTimeKey(cycle.anchor.dateTime),
+      );
+      assertStructuredField('huangji.sixDayCycle.anchor.kind', 'explicit-epoch', cycle.anchor.kind);
+    } else if (expectedModel === 'six-day-seven-part') {
+      assertStructuredField(
+        'huangji.sixDayCycle.anchor.kind',
+        'winter-solstice-civil-midnight',
+        cycle.anchor.kind,
+      );
+    }
     assertStructuredField(
       'huangji.sixDayCycle.calendar.model',
       expectedModel,

--- a/src/lib/ai/reading-resources.ts
+++ b/src/lib/ai/reading-resources.ts
@@ -497,9 +497,16 @@ function filterCalculationSchema(method: string, value: unknown): Record<string,
 
 function filterCalculationSchemaCondition(value: unknown, mutable: Set<string>): unknown {
   if (Array.isArray(value)) {
+    const seen = new Set<string>();
     const conditions = value
       .map((item) => filterCalculationSchemaCondition(item, mutable))
-      .filter((item) => item !== undefined);
+      .filter((item) => {
+        if (item === undefined) return false;
+        const key = JSON.stringify(item);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
     return conditions.length ? conditions : undefined;
   }
   if (!record(value)) return value;
@@ -509,6 +516,12 @@ function filterCalculationSchemaCondition(value: unknown, mutable: Set<string>):
         (field): field is string => typeof field === 'string' && mutable.has(field),
       );
       return required.length ? [[key, required]] : [];
+    }
+    if (key === 'properties' && record(item)) {
+      const properties = Object.fromEntries(
+        Object.entries(item).filter(([field]) => mutable.has(field)),
+      );
+      return Object.keys(properties).length ? [[key, properties]] : [];
     }
     const condition = filterCalculationSchemaCondition(item, mutable);
     return condition === undefined ? [] : [[key, condition]];

--- a/src/lib/ai/reading-subject.ts
+++ b/src/lib/ai/reading-subject.ts
@@ -345,15 +345,17 @@ export function buildDivinationReadingSubject(
     range.huangjiInput = result.input;
     if (result.sixDayCycle) {
       const cycle = result.sixDayCycle;
+      const usesExplicitEpoch = cycle.calendar.model === 'six-day-explicit-epoch';
       lockedInputs.huangji = {
         _mode: mode,
-        sixDayEpochDateTime: cycle.anchor.dateTime,
+        ...(usesExplicitEpoch ? { sixDayEpochDateTime: cycle.anchor.dateTime } : {}),
         calendarModel: cycle.calendar.model,
         timezone: cycle.civilTime.timezone,
         ...(cycle.civilTime.timeZoneId ? { timeZoneId: cycle.civilTime.timeZoneId } : {}),
       };
       range.huangjiSixDayDateTime = cycle.civilTime.dateTime;
-      range.huangjiSixDayEpochDateTime = cycle.anchor.dateTime;
+      range.huangjiSixDayAnchorDateTime = cycle.anchor.dateTime;
+      if (usesExplicitEpoch) range.huangjiSixDayEpochDateTime = cycle.anchor.dateTime;
       range.huangjiSixDayTimezone = cycle.civilTime.timezone;
       range.huangjiCalendarModel = cycle.calendar.model;
       range.huangjiDateTime = cycle.civilTime.dateTime;

--- a/src/lib/divination/engine/index.ts
+++ b/src/lib/divination/engine/index.ts
@@ -21,7 +21,7 @@ import type {
   MeihuaDivinationMethod,
 } from '../../../types/divination';
 import type { DivinationMethodId } from 'mingyu-core/divination/config';
-import type { HuangjiJingshiResult } from 'mingyu-core/huangji-jingshi';
+import type { HuangjiJingshiResult, HuangjiSixDayCalendarModel } from 'mingyu-core/huangji-jingshi';
 import type { WuyunLiuqiResult } from 'mingyu-core/wuyun-liuqi';
 import { convertTrueSolarTime, formatSolarDateTimeParts, TimeManager } from 'mingyu-core/calendar';
 import { daysInSolarMonth } from '../../date-validation';
@@ -104,6 +104,7 @@ export type DivinationDraft = {
   customDivinationTime?: string;
   divinationTimeStandard?: 'beijing' | 'true-solar';
   huangjiMethod?: 'standard' | 'six-day';
+  huangjiSixDayCalendarModel?: HuangjiSixDayCalendarModel;
   huangjiSixDayEpochDate?: string;
   huangjiSixDayTimezone?: string;
   birthPlace?: string;
@@ -421,11 +422,17 @@ function validateDraft(draft: DivinationDraft) {
 
   if (draft.method === 'huangji' && draft.huangjiMethod === 'six-day') {
     readCustomDivinationDate(draft);
-    const epochDate = draft.huangjiSixDayEpochDate?.trim() ?? '';
-    if (!epochDate) {
-      throw new Error('六日逐爻需要填写经校定的历元日期');
+    const calendarModel = draft.huangjiSixDayCalendarModel ?? 'six-day-seven-part';
+    if (calendarModel !== 'six-day-seven-part' && calendarModel !== 'six-day-explicit-epoch') {
+      throw new Error('六日逐爻换算模型无效');
     }
-    readDateText(epochDate, '六日逐爻校定历元日期');
+    if (calendarModel === 'six-day-explicit-epoch') {
+      const epochDate = draft.huangjiSixDayEpochDate?.trim() ?? '';
+      if (!epochDate) {
+        throw new Error('六日逐爻显式历元需要填写校定日期');
+      }
+      readDateText(epochDate, '六日逐爻校定历元日期');
+    }
     const timezone = readNumberText(draft.huangjiSixDayTimezone?.trim() ?? '', '六日逐爻业务时区');
     assertNumberRange(timezone, '六日逐爻业务时区', -12, 14);
   }
@@ -871,13 +878,16 @@ function resolveCustomDivinationDate(
 function buildHuangjiSixDayDateInput(draft: DivinationDraft) {
   const targetDate = draft.customDivinationDate?.trim() ?? '';
   const targetTime = draft.customDivinationTime?.trim() ?? '';
-  const epochDate = draft.huangjiSixDayEpochDate?.trim() ?? '';
+  const calendarModel = draft.huangjiSixDayCalendarModel ?? 'six-day-seven-part';
   const timezone = readNumberText(draft.huangjiSixDayTimezone?.trim() ?? '', '六日逐爻业务时区');
   assertNumberRange(timezone, '六日逐爻业务时区', -12, 14);
   return {
     targetDateTime: `${targetDate}T${targetTime}:00`,
-    epochDateTime: `${epochDate}T00:00:00`,
     timezone,
+    calendarModel,
+    ...(calendarModel === 'six-day-explicit-epoch'
+      ? { epochDateTime: `${draft.huangjiSixDayEpochDate?.trim() ?? ''}T00:00:00` }
+      : {}),
   };
 }
 
@@ -1038,8 +1048,8 @@ export async function generateDivinationSession(
           sixDay.targetDateTime,
           sixDay.timezone,
           undefined,
-          module.HUANGJI_SIX_DAY_CALENDAR_MODEL,
-          sixDay.epochDateTime,
+          sixDay.calendarModel,
+          sixDay.calendarModel === 'six-day-explicit-epoch' ? sixDay.epochDateTime : undefined,
         );
         data = module.calculateHuangjiJingshi({
           sixDayDate,

--- a/src/lib/public-api/handler.ts
+++ b/src/lib/public-api/handler.ts
@@ -1086,7 +1086,12 @@ export function getPublicApiOpenApiDocument(
         post: {
           summary: '皇极经世六日逐爻、公历年月日时盘与元会运世周期换算',
           requestBody: openApiJsonRequestBody('#/components/schemas/HuangjiJingshiRequest'),
-          responses: { '200': { description: '六日逐爻或年月日时卦、值年卦与元会运世层级' } },
+          responses: {
+            '200': {
+              description:
+                '六日逐爻或年月日时卦、值年卦与元会运世层级；六日七分模型以现代冬至与岁周比例定位，并返回适用边界。',
+            },
+          },
         },
       },
       '/metaphysics/huangji-jingshi/prompt': {
@@ -1094,7 +1099,10 @@ export function getPublicApiOpenApiDocument(
           summary: '皇极经世六日逐爻、公历年月日时盘并生成完整解读提示词',
           requestBody: openApiJsonRequestBody('#/components/schemas/HuangjiJingshiRequest'),
           responses: {
-            '200': { description: '六日逐爻或年月日时盘、元会运世结果与自包含提示词' },
+            '200': {
+              description:
+                '六日逐爻或年月日时盘、元会运世结果与自包含提示词；六日七分模型以现代冬至与岁周比例定位，并返回适用边界。',
+            },
           },
         },
       },
@@ -2007,7 +2015,7 @@ export function getPublicApiOpenApiDocument(
         HuangjiJingshiRequest: {
           type: 'object',
           description:
-            '提供 customDate 可获得既有年月日时盘；提供 sixDayDateTime、sixDayEpochDateTime 与 calendarModel=six-day-explicit-epoch 可按显式历元定位六日逐爻；只提供公元 year 可获得值年盘；研究自定义纪元时提供 epochYear，并从 year 与 elapsedYears 中选择一项。',
+            '提供 customDate 可获得既有年月日时盘；六日逐爻可选择 calendarModel=six-day-seven-part（以现代冬至与岁周比例定位，不传 sixDayEpochDateTime）或 calendarModel=six-day-explicit-epoch（必须同时传经校定的 sixDayEpochDateTime）；只提供公元 year 可获得值年盘；研究自定义纪元时提供 epochYear，并从 year 与 elapsedYears 中选择一项。',
           oneOf: [
             {
               required: ['customDate'],
@@ -2024,8 +2032,22 @@ export function getPublicApiOpenApiDocument(
             },
             {
               required: ['sixDayDateTime', 'sixDayEpochDateTime', 'calendarModel'],
+              properties: { calendarModel: { const: 'six-day-explicit-epoch' } },
               not: {
                 anyOf: [
+                  { required: ['customDate'] },
+                  { required: ['epochYear'] },
+                  { required: ['year'] },
+                  { required: ['elapsedYears'] },
+                ],
+              },
+            },
+            {
+              required: ['sixDayDateTime', 'calendarModel'],
+              properties: { calendarModel: { const: 'six-day-seven-part' } },
+              not: {
+                anyOf: [
+                  { required: ['sixDayEpochDateTime'] },
                   { required: ['customDate'] },
                   { required: ['epochYear'] },
                   { required: ['year'] },
@@ -2067,30 +2089,30 @@ export function getPublicApiOpenApiDocument(
             sixDayDateTime: {
               type: 'string',
               description:
-                '六日逐爻目标当地公历时间，ISO 8601 格式；可与历元一起带同一固定 UTC 偏移，或均不带偏移并配合 timezone 或 timeZoneId。',
+                '六日逐爻目标当地公历时间，ISO 8601 格式；six-day-seven-part 以现代冬至与岁周比例定位，不需要 sixDayEpochDateTime；six-day-explicit-epoch 须与历元一起带同一固定 UTC 偏移，或均不带偏移并配合 timezone 或 timeZoneId。',
             },
             sixDayEpochDateTime: {
               type: 'string',
               description:
-                '六日逐爻经校定的当地子半历元，ISO 8601 格式；该时刻对应已过日数0，须与 sixDayDateTime 使用同一时区口径。',
+                '显式历元模型使用的经校定当地子半，ISO 8601 格式；该时刻对应已过日数0，须与 sixDayDateTime 使用同一时区口径；calendarModel=six-day-seven-part 时不得提供。',
             },
             calendarModel: {
               type: 'string',
-              enum: ['six-day-explicit-epoch'],
+              enum: ['six-day-explicit-epoch', 'six-day-seven-part'],
               description:
-                '六日逐爻公历换算模型；须明确传 six-day-explicit-epoch，表示使用已校定公历子半历元直接适配三百六十日正数坐标。',
+                '六日逐爻公历换算模型。six-day-seven-part 使用现代冬至与岁周比例定位，不需要 sixDayEpochDateTime，并仅适用于核心返回的定义范围；six-day-explicit-epoch 使用已校定公历子半历元直接适配三百六十日正数坐标，必须同时提供 sixDayEpochDateTime。',
             },
             timezone: {
               type: 'number',
               minimum: -12,
               maximum: 14,
               description:
-                'sixDayDateTime 与 sixDayEpochDateTime 未带偏移时的固定 UTC 时区；有 IANA 时区时用于消歧与核验。',
+                'sixDayDateTime 未带偏移时的固定 UTC 时区；显式历元模型中也用于核验 sixDayEpochDateTime，有 IANA 时区时用于消歧与核验。',
             },
             timeZoneId: {
               type: 'string',
               description:
-                'sixDayDateTime 与 sixDayEpochDateTime 对应的 IANA 历史时区，例如 America/New_York。',
+                'sixDayDateTime 对应的 IANA 历史时区，例如 America/New_York；显式历元模型中目标与历元共用该时区。',
             },
             epochYear: {
               type: 'integer',
@@ -3809,18 +3831,25 @@ function calculateHuangjiJingshiApi(input: JsonRecord) {
   const question = readString(input, 'question', '').trim();
   let sixDayDate: ReturnType<typeof huangjiJingshi.parseHuangjiSixDayDateTime> | undefined;
   if (sixDayDateTime !== undefined) {
-    if (calendarModel !== 'six-day-explicit-epoch') {
+    if (calendarModel !== 'six-day-explicit-epoch' && calendarModel !== 'six-day-seven-part') {
       throw new ApiError(
         400,
         'BAD_REQUEST',
-        '六日逐爻公历时间必须明确提供 calendarModel=six-day-explicit-epoch。',
+        '六日逐爻公历时间必须明确提供 calendarModel=six-day-seven-part 或 six-day-explicit-epoch。',
       );
     }
-    if (sixDayEpochDateTime === undefined) {
+    if (calendarModel === 'six-day-explicit-epoch' && sixDayEpochDateTime === undefined) {
       throw new ApiError(
         400,
         'BAD_REQUEST',
         '六日逐爻公历时间必须同时提供经校定的 sixDayEpochDateTime。',
+      );
+    }
+    if (calendarModel === 'six-day-seven-part' && sixDayEpochDateTime !== undefined) {
+      throw new ApiError(
+        400,
+        'BAD_REQUEST',
+        'calendarModel=six-day-seven-part 不得提供 sixDayEpochDateTime；该模型以现代冬至与岁周比例定位。',
       );
     }
     if (customDate || epochYear !== undefined || year !== undefined || elapsedYears !== undefined) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4037,6 +4037,10 @@ select {
   flex: 0 1 200px;
 }
 
+.divination-huangji-model-field {
+  flex-basis: 190px;
+}
+
 .divination-inline-number-field {
   flex-basis: 148px;
 }
@@ -7941,6 +7945,11 @@ select {
     min-height: 44px;
     overflow: hidden;
     border-radius: 8px;
+  }
+
+  .divination-huangji-model-picker {
+    flex: 1 1 132px;
+    min-width: 132px;
   }
 
   .divination-mobile-control-row {

--- a/src/traditional-charts.css
+++ b/src/traditional-charts.css
@@ -2184,6 +2184,10 @@
     font-weight: 600;
   }
 
+  .traditional-huangji-board .traditional-fact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .traditional-facts-row,
   .traditional-note-row {
     padding: 6px 8px;

--- a/tests/api/huangji-six-day.test.ts
+++ b/tests/api/huangji-six-day.test.ts
@@ -14,7 +14,7 @@ type HuangjiResponse = {
   sixDayCycle?: {
     civilTime?: { timezone?: number };
     anchor?: { kind?: string };
-    calendar?: { actualElapsedDays?: number };
+    calendar?: { model?: string; mapping?: string; actualElapsedDays?: number };
   };
   result?: HuangjiResponse;
   prompt?: string;
@@ -47,6 +47,40 @@ async function callHttp(tool: string, input: Record<string, unknown>) {
   };
 }
 
+test('皇极六日逐爻 OpenAPI 以 oneOf 固定两种模型的历元要求', async () => {
+  const response = await handlePublicApiRequest(
+    new Request('https://aov.cc/api/v1/openapi.json', { method: 'GET' }),
+  );
+  assert.equal(response.status, 200);
+  const document = (await response.json()) as {
+    components?: {
+      schemas?: {
+        HuangjiJingshiRequest?: {
+          oneOf?: Array<{
+            required?: string[];
+            properties?: { calendarModel?: { const?: string } };
+            not?: { anyOf?: Array<{ required?: string[] }> };
+          }>;
+        };
+      };
+    };
+  };
+  const modes = document.components?.schemas?.HuangjiJingshiRequest?.oneOf ?? [];
+  const explicit = modes.find(
+    (mode) => mode.properties?.calendarModel?.const === 'six-day-explicit-epoch',
+  );
+  const proportional = modes.find(
+    (mode) => mode.properties?.calendarModel?.const === 'six-day-seven-part',
+  );
+  assert.deepEqual(explicit?.required, ['sixDayDateTime', 'sixDayEpochDateTime', 'calendarModel']);
+  assert.deepEqual(proportional?.required, ['sixDayDateTime', 'calendarModel']);
+  assert.ok(
+    proportional?.not?.anyOf?.some((condition) =>
+      condition.required?.includes('sixDayEpochDateTime'),
+    ),
+  );
+});
+
 test('皇极六日逐爻 HTTP 与 MCP 入口返回同一带时区公历结果', async () => {
   const args = {
     sixDayDateTime: '2025-12-22T05:03:05+14:00',
@@ -64,6 +98,34 @@ test('皇极六日逐爻 HTTP 与 MCP 入口返回同一带时区公历结果', 
   assert.equal(http.body.data?.sixDayCycle?.civilTime?.timezone, 14);
   assert.equal(http.body.data?.sixDayCycle?.anchor?.kind, 'explicit-epoch');
   assert.equal(http.body.data?.sixDayCycle?.calendar?.actualElapsedDays, 1);
+});
+
+test('皇极六日七分模型无需显式历元且 HTTP 与 MCP 均保留现代定位说明', async () => {
+  const args = {
+    sixDayDateTime: '2025-12-22T05:03:05+08:00',
+    calendarModel: 'six-day-seven-part',
+    detailMode: 'full',
+  };
+  const http = await callHttp('metaphysics_huangji_jingshi', args);
+  assert.equal(http.response.status, 200, JSON.stringify(http.body));
+  assert.equal(http.body.data?.input?.mode, '六日逐爻公历');
+  assert.equal(http.body.data?.sixDayCycle?.calendar?.model, 'six-day-seven-part');
+  assert.equal(http.body.data?.sixDayCycle?.calendar?.mapping, 'winter-solstice-proportional-360');
+  assert.equal(http.body.data?.sixDayCycle?.anchor?.kind, 'winter-solstice-civil-midnight');
+  assert.match(JSON.stringify(http.body.data), /冬至|岁周|适用/);
+
+  const mcp = await client.callTool({ name: 'metaphysics_huangji_jingshi', arguments: args });
+  assert.notEqual(mcp.isError, true, JSON.stringify(mcp));
+  const mcpResult = (mcp.structuredContent as { result: HuangjiResponse }).result;
+  assert.deepEqual(mcpResult, http.body.data);
+  assert.equal(mcpResult.sixDayCycle?.calendar?.model, 'six-day-seven-part');
+
+  const rejectedEpoch = await callHttp('metaphysics_huangji_jingshi', {
+    ...args,
+    sixDayEpochDateTime: '2025-12-21T00:00:00+08:00',
+  });
+  assert.equal(rejectedEpoch.response.status, 400);
+  assert.match(JSON.stringify(rejectedEpoch.body), /six-day-seven-part.*sixDayEpochDateTime/);
 });
 
 test('皇极六日逐爻 prompt 入口保留显式历元资料并拒绝无时区时间', async () => {

--- a/tests/api/huangji-six-day.test.ts
+++ b/tests/api/huangji-six-day.test.ts
@@ -52,7 +52,10 @@ test('皇极六日逐爻 OpenAPI 以 oneOf 固定两种模型的历元要求', a
     new Request('https://aov.cc/api/v1/openapi.json', { method: 'GET' }),
   );
   assert.equal(response.status, 200);
-  const document = (await response.json()) as {
+  const payload = (await response.json()) as {
+    data?: unknown;
+  };
+  const document = (payload.data ?? payload) as {
     components?: {
       schemas?: {
         HuangjiJingshiRequest?: {
@@ -165,7 +168,7 @@ test('皇极六日逐爻 prompt 入口保留显式历元资料并拒绝无时区
   assert.equal(missingModel.response.status, 400);
   assert.match(
     JSON.stringify(missingModel.body),
-    /必须明确提供 calendarModel=six-day-explicit-epoch/,
+    /必须明确提供 calendarModel=six-day-seven-part 或 six-day-explicit-epoch/,
   );
 
   const missingEpoch = await callHttp('metaphysics_huangji_jingshi', {

--- a/tests/api/public-api.test.ts
+++ b/tests/api/public-api.test.ts
@@ -557,8 +557,22 @@ test('公开 API OpenAPI 文档应标明占卜提示词接口返回摘要', asyn
     },
     {
       required: ['sixDayDateTime', 'sixDayEpochDateTime', 'calendarModel'],
+      properties: { calendarModel: { const: 'six-day-explicit-epoch' } },
       not: {
         anyOf: [
+          { required: ['customDate'] },
+          { required: ['epochYear'] },
+          { required: ['year'] },
+          { required: ['elapsedYears'] },
+        ],
+      },
+    },
+    {
+      required: ['sixDayDateTime', 'calendarModel'],
+      properties: { calendarModel: { const: 'six-day-seven-part' } },
+      not: {
+        anyOf: [
+          { required: ['sixDayEpochDateTime'] },
           { required: ['customDate'] },
           { required: ['epochYear'] },
           { required: ['year'] },
@@ -591,9 +605,9 @@ test('公开 API OpenAPI 文档应标明占卜提示词接口返回摘要', asyn
       },
     },
   ]);
-  assert.equal(
-    body.data.components.schemas.HuangjiJingshiRequest.properties.calendarModel.enum[0],
-    'six-day-explicit-epoch',
+  assert.deepEqual(
+    body.data.components.schemas.HuangjiJingshiRequest.properties.calendarModel.enum,
+    ['six-day-explicit-epoch', 'six-day-seven-part'],
   );
   assert.match(
     body.data.components.schemas.HuangjiJingshiRequest.properties.sixDayEpochDateTime.description,

--- a/tests/huangji-six-day-gregorian.test.ts
+++ b/tests/huangji-six-day-gregorian.test.ts
@@ -139,9 +139,11 @@ test('现代比例模型以实际冬至瞬时确定岁周并以当地冬至日�
 
   assert.equal(beforeTerm.model, '书绪言六日逐爻·现代冬至岁周换算');
   assert.equal(beforeTerm.anchor.kind, 'winter-solstice-civil-midnight');
-  assert.equal(beforeTerm.anchor.winterSolsticeYear, 2025);
+  assert.equal(beforeTerm.anchor.winterSolsticeGregorianYear, 2024);
+  assert.equal(beforeTerm.calendar.targetYear, 2025);
   assert.equal(beforeTerm.anchor.dayStartDateTime, '2024-12-21T00:00:00+08:00');
-  assert.equal(atTerm.anchor.winterSolsticeYear, 2026);
+  assert.equal(atTerm.anchor.winterSolsticeGregorianYear, 2025);
+  assert.equal(atTerm.calendar.targetYear, 2026);
   assert.equal(atTerm.anchor.dateTime, '2025-12-21T23:03:05+08:00');
   assert.equal(atTerm.anchor.utcDateTime, '2025-12-21T15:03:05.000Z');
   assert.equal(atTerm.anchor.dayStartDateTime, '2025-12-21T00:00:00+08:00');
@@ -170,7 +172,7 @@ test('现代比例模型按冬至子半至下一冬至子半的实际跨度映�
   assert.equal(result.hourLine, 6);
   assert.equal(result.hourRange, '20:00—24:00');
   assert.match(result.limitations.join('；'), /现代比例换算/);
-  assert.match(result.limitations.join('；'), /不宣称古籍唯一算法/);
+  assert.match(result.limitations.join('；'), /不宣称是古籍唯一算法/);
 });
 
 test('现代比例模型支持固定时区与 IANA，并分别保留真实瞬时和当地子半', () => {

--- a/tests/huangji-six-day-gregorian.test.ts
+++ b/tests/huangji-six-day-gregorian.test.ts
@@ -7,9 +7,14 @@ import {
 } from '@core/huangji-jingshi';
 
 const MODEL = 'six-day-explicit-epoch' as const;
+const PROPORTIONAL_MODEL = 'six-day-seven-part' as const;
 
 function parseSixDay(target: string, epoch: string, timezone?: number, timeZoneId?: string) {
   return parseHuangjiSixDayDateTime(target, timezone, timeZoneId, MODEL, epoch);
+}
+
+function parseProportionalSixDay(target: string, timezone?: number, timeZoneId?: string) {
+  return parseHuangjiSixDayDateTime(target, timezone, timeZoneId, PROPORTIONAL_MODEL);
 }
 
 test('六日逐爻使用显式子半历元直接进入三百六十日坐标', () => {
@@ -73,10 +78,10 @@ test('六日逐爻公历入口拒绝未经校定的模型、历元和坐标范�
         '2025-01-01T00:00:00+08:00',
         undefined,
         undefined,
-        'six-day-seven-part' as never,
+        'unknown-model' as never,
         '2025-01-01T00:00:00+08:00',
       ),
-    /six-day-explicit-epoch/,
+    /six-day-explicit-epoch.*six-day-seven-part/,
   );
   assert.throws(
     () => parseHuangjiSixDayDateTime('2025-01-01T00:00:00+08:00', undefined, undefined, MODEL),
@@ -121,5 +126,82 @@ test('六日逐爻公历结果与提示词保留显式历元事实', () => {
   assert.match(result.prompt, /显式历元：2025-01-01T00:00:00\+14:00/);
   assert.match(result.prompt, /每六日一经卦、每日一爻、每四小时一爻/);
   assert.doesNotMatch(result.prompt, /冬至定位依据|太阳年|日干支/);
+  assert.match(result.prompt, /【问题】\n此时的主要变化是什么？/);
+});
+
+test('现代比例模型以实际冬至瞬时确定岁周并以当地冬至日子半为锚点', () => {
+  const beforeTerm = calculateHuangjiSixDayCycleFromDate(
+    parseProportionalSixDay('2025-12-21T12:00:00+08:00'),
+  );
+  const atTerm = calculateHuangjiSixDayCycleFromDate(
+    parseProportionalSixDay('2025-12-21T23:03:05+08:00'),
+  );
+
+  assert.equal(beforeTerm.model, '书绪言六日逐爻·现代冬至岁周换算');
+  assert.equal(beforeTerm.anchor.kind, 'winter-solstice-civil-midnight');
+  assert.equal(beforeTerm.anchor.winterSolsticeYear, 2025);
+  assert.equal(beforeTerm.anchor.dayStartDateTime, '2024-12-21T00:00:00+08:00');
+  assert.equal(atTerm.anchor.winterSolsticeYear, 2026);
+  assert.equal(atTerm.anchor.dateTime, '2025-12-21T23:03:05+08:00');
+  assert.equal(atTerm.anchor.utcDateTime, '2025-12-21T15:03:05.000Z');
+  assert.equal(atTerm.anchor.dayStartDateTime, '2025-12-21T00:00:00+08:00');
+  assert.equal(atTerm.anchor.dayBoundary, '当地子半');
+  assert.equal(atTerm.calendar.model, PROPORTIONAL_MODEL);
+  assert.equal(atTerm.calendar.mapping, 'winter-solstice-proportional-360');
+  assert.equal(atTerm.calendar.actualElapsedDays, 0);
+  assert.equal(atTerm.calendar.coordinateSpanDays, 360);
+  assert.equal(atTerm.elapsedDays, atTerm.anchor.dayIndex);
+});
+
+test('现代比例模型按冬至子半至下一冬至子半的实际跨度映射逻辑日并保留四小时一爻', () => {
+  const result = calculateHuangjiSixDayCycleFromDate(
+    parseProportionalSixDay('2026-02-19T23:03:05+08:00'),
+  );
+  const { calendar } = result;
+
+  assert.equal(calendar.actualElapsedDays, 60);
+  assert.ok(calendar.yearLengthDays > 365 && calendar.yearLengthDays < 367);
+  assert.equal(
+    calendar.logicalPosition,
+    (calendar.actualElapsedMilliseconds / calendar.yearLengthMilliseconds) * 360,
+  );
+  assert.equal(calendar.logicalElapsedDays, Math.floor(calendar.logicalPosition));
+  assert.equal(calendar.logicalDayFraction, calendar.logicalPosition - calendar.logicalElapsedDays);
+  assert.equal(result.hourLine, 6);
+  assert.equal(result.hourRange, '20:00—24:00');
+  assert.match(result.limitations.join('；'), /现代比例换算/);
+  assert.match(result.limitations.join('；'), /不宣称古籍唯一算法/);
+});
+
+test('现代比例模型支持固定时区与 IANA，并分别保留真实瞬时和当地子半', () => {
+  const fixed = calculateHuangjiSixDayCycleFromDate(
+    parseProportionalSixDay('2026-07-01T16:00:00Z'),
+  );
+  const iana = calculateHuangjiSixDayCycleFromDate(
+    parseProportionalSixDay('2026-07-01T12:00:00', undefined, 'America/New_York'),
+  );
+
+  assert.equal(fixed.civilTime.utcDateTime, iana.civilTime.utcDateTime);
+  assert.equal(iana.civilTime.timezone, -4);
+  assert.equal(iana.civilTime.timeZoneId, 'America/New_York');
+  assert.equal(iana.anchor.kind, 'winter-solstice-civil-midnight');
+  assert.match(iana.anchor.dayStartDateTime, /-05:00$/u);
+  assert.equal(iana.calendar.model, PROPORTIONAL_MODEL);
+  assert.ok(iana.calendar.yearLengthSeconds > 364 * 86400);
+});
+
+test('现代比例模型提示词回显冬至锚点、实际岁周与限制说明', () => {
+  const result = calculateHuangjiJingshi({
+    sixDayDate: parseProportionalSixDay('2025-12-22T05:03:05+08:00'),
+    question: '此时的主要变化是什么？',
+  });
+
+  assert.equal(result.sixDayCycle?.calendar.model, PROPORTIONAL_MODEL);
+  assert.match(result.prompt, /现代冬至岁周换算/);
+  assert.match(result.prompt, /冬至真实瞬时/);
+  assert.match(result.prompt, /当地子半/);
+  assert.match(result.prompt, /实际跨度/);
+  assert.match(result.prompt, /逻辑位置/);
+  assert.match(result.prompt, /不宣称是古籍唯一算法/);
   assert.match(result.prompt, /【问题】\n此时的主要变化是什么？/);
 });

--- a/tests/huangji-six-day-web.test.ts
+++ b/tests/huangji-six-day-web.test.ts
@@ -128,4 +128,23 @@ test('网页皇极六日七分默认不要求历元并锁定现代换算模型',
   assert.equal(subject?.lockedInputs.huangji.sixDayEpochDateTime, undefined);
   assert.equal(subject?.range.huangjiSixDayEpochDateTime, undefined);
   assert.equal(subject?.range.huangjiSixDayAnchorDateTime, cycle?.anchor.dateTime);
+
+  await withRealApi(async () => {
+    const resource = await executeReadingAction(
+      {
+        kind: 'calculate',
+        method: 'huangji',
+        input: { sixDayDateTime: '2026-09-01T09:00:00+08:00' },
+      },
+      undefined,
+      subject,
+    );
+    const structured = resource.structured as Record<string, unknown>;
+    const restoredCycle = structured.sixDayCycle as Record<string, unknown>;
+    const restoredCalendar = restoredCycle.calendar as Record<string, unknown>;
+    const restoredAnchor = restoredCycle.anchor as Record<string, unknown>;
+    assert.equal(resource.usable, true);
+    assert.equal(restoredCalendar.model, 'six-day-seven-part');
+    assert.equal(restoredAnchor.kind, 'winter-solstice-civil-midnight');
+  });
 });

--- a/tests/huangji-six-day-web.test.ts
+++ b/tests/huangji-six-day-web.test.ts
@@ -13,6 +13,7 @@ function buildSixDayDraft(overrides: Partial<DivinationDraft> = {}): DivinationD
     method: 'huangji',
     question: '这个目标时点的六日时势如何？',
     huangjiMethod: 'six-day',
+    huangjiSixDayCalendarModel: 'six-day-seven-part',
     divinationTimeMode: 'custom',
     customDivinationDate: '2026-08-24',
     customDivinationTime: '15:30',
@@ -35,8 +36,8 @@ async function withRealApi(callback: () => Promise<void>) {
   }
 }
 
-test('网页皇极六日逐爻入口保留目标、历元和有效盘面资料', async () => {
-  const draft = buildSixDayDraft();
+test('网页皇极六日逐爻显式历元入口保留目标、历元和有效盘面资料', async () => {
+  const draft = buildSixDayDraft({ huangjiSixDayCalendarModel: 'six-day-explicit-epoch' });
   const session = await generateDivinationSession(draft);
   const data = session.data as HuangjiJingshiResult;
   const cycle = data.sixDayCycle;
@@ -97,9 +98,34 @@ test('网页皇极六日逐爻入口拒绝超出显式历元坐标范围的目�
   await assert.rejects(
     generateDivinationSession(
       buildSixDayDraft({
+        huangjiSixDayCalendarModel: 'six-day-explicit-epoch',
         customDivinationDate: '2027-08-24',
       }),
     ),
     /超出显式历元后0至359日的已定义坐标范围/u,
   );
+});
+
+test('网页皇极六日七分默认不要求历元并锁定现代换算模型', async () => {
+  assert.equal(defaultDraft.huangjiSixDayCalendarModel, 'six-day-seven-part');
+  const draft = buildSixDayDraft({
+    huangjiSixDayEpochDate: '',
+    huangjiSixDayCalendarModel: 'six-day-seven-part',
+  });
+  const session = await generateDivinationSession(draft);
+  const data = session.data as HuangjiJingshiResult;
+  const cycle = data.sixDayCycle;
+
+  assert.ok(cycle);
+  assert.equal(cycle?.calendar.model, 'six-day-seven-part');
+  assert.equal(cycle?.calendar.mapping, 'winter-solstice-proportional-360');
+  assert.equal(cycle?.anchor.kind, 'winter-solstice-civil-midnight');
+  assert.equal(cycle?.model, '书绪言六日逐爻·现代冬至岁周换算');
+  assert.equal(data.input.mode, '六日逐爻公历');
+
+  const subject = buildDivinationReadingSubject(draft, session);
+  assert.equal(subject?.lockedInputs.huangji.calendarModel, 'six-day-seven-part');
+  assert.equal(subject?.lockedInputs.huangji.sixDayEpochDateTime, undefined);
+  assert.equal(subject?.range.huangjiSixDayEpochDateTime, undefined);
+  assert.equal(subject?.range.huangjiSixDayAnchorDateTime, cycle?.anchor.dateTime);
 });

--- a/tests/mcp/structured-output.test.ts
+++ b/tests/mcp/structured-output.test.ts
@@ -606,8 +606,22 @@ test('MCP 工具列表应声明输出结构', async () => {
       },
       {
         required: ['sixDayDateTime', 'sixDayEpochDateTime', 'calendarModel'],
+        properties: { calendarModel: { const: 'six-day-explicit-epoch' } },
         not: {
           anyOf: [
+            { required: ['customDate'] },
+            { required: ['epochYear'] },
+            { required: ['year'] },
+            { required: ['elapsedYears'] },
+          ],
+        },
+      },
+      {
+        required: ['sixDayDateTime', 'calendarModel'],
+        properties: { calendarModel: { const: 'six-day-seven-part' } },
+        not: {
+          anyOf: [
+            { required: ['sixDayEpochDateTime'] },
             { required: ['customDate'] },
             { required: ['epochYear'] },
             { required: ['year'] },


### PR DESCRIPTION
皇极六日逐爻过去只能依赖人工填写校定历元，普通用户无法直接使用；AI 补算时也缺少可验证的现代时间锚点。本改动新增以实际冬至为边界、按岁周比例换算 360 日的现代模型，并将其设为页面默认，同时保留显式校定历元供研究用途。

主要修改：

- 核心包返回冬至时刻、民用日界、岁周长度、逻辑日与爻位等可复算资料，并明确现代换算的适用边界。
- 页面、公开 API、MCP、AI 解读和三份 Skill 数据提供方说明统一使用同一模型契约。
- 移动端模型选择器和结果资料在 320px、390px 宽度下保持紧凑排列。
- 修复 AI 补算过滤不可变字段后产生重复条件分支的问题。

验证：

- `pnpm format:check`
- `pnpm lint`（0 错误；保留目标分支已有的 1 条依赖数组警告）
- `pnpm test:ci`（单元 1916/1916、集成 49/49、API 162/162、MCP 66/66）
- `pnpm build`
- `pnpm prompt:check`
- `pnpm package:check`

兼容性：已有 `six-day-explicit-epoch` 请求继续要求 `sixDayEpochDateTime`；新增 `six-day-seven-part` 不需要显式历元。核心包压缩体积当前为预算的 94.7%，门禁通过但需要继续控制后续资料增长。
