### PR TITLE
消除奇门终身局重算依赖警告

### DIFF
--- a/src/pages/ResultPage/index.tsx
+++ b/src/pages/ResultPage/index.tsx
@@ -1149,6 +1149,7 @@ export function ResultPage({ assistantOnly = false }: ResultPageProps) {
     data: import('@/types/divination').QimenLifetimeData | null;
     error: string;
   }>(() => {
+    void qimenLifetimeCalculationRevision;
     if (!shouldCalculateQimenLifetime) return { data: null, error: '' };
     const year = Number(inputState.year);
     const month = Number(inputState.month);


### PR DESCRIPTION
奇门终身局的重算版本是 `useMemo` 的显式失效信号，但回调没有读取它，React Hooks lint 将其误判为多余依赖。直接删除依赖会让手动重试无法重新计算。

本次在计算回调内显式读取该版本值，保留原有重算行为并消除警告，不改变计算输入或输出。

验证：

- `eslint src/pages/ResultPage/index.tsx --max-warnings 0`：通过
- `pnpm typecheck:app`：通过
- Prettier 与 `git diff --check`：通过
