### PR TITLE
前置展示QQ交流群入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **在线 Remote MCP（云端直连 · 零依赖）**：
   - **Claude Code**：`claude mcp add mingyu --transport sse https://aov.cc/mcp`
   - **Cursor / Windsurf / VS Code**：直接添加 SSE 类型的 Server URL：`https://aov.cc/mcp`
+  - **QQ 交流群**：命语 Mingyu 技术交流群（1080947018）
 
 ---
 
@@ -160,12 +161,6 @@ pnpm build
 - [MCP Server 配置指南](mcp/README.md)
 - [mingyu-core 算法包说明](packages/core/README.md)
 - [开发、部署与环境配置](docs/development-and-deployment.md)
-
----
-
-## 💬 交流
-
-QQ群：命语 Mingyu 技术交流群（1080947018）
 
 ---
 


### PR DESCRIPTION
将 QQ 技术交流群移动到 README 顶部“在线 Remote MCP”说明下方，删除页面末尾的独立交流板块，用户打开仓库即可看到群号。

验证：`git diff --check`
